### PR TITLE
fix(ci): pre-start E2E stack and free BDD In-Network disk

### DIFF
--- a/.github/actions/_free-disk/action.yml
+++ b/.github/actions/_free-disk/action.yml
@@ -1,0 +1,22 @@
+name: Free disk space
+description: >-
+  Reclaim ubuntu-latest headroom before heavy Docker/compose builds
+  (unused preinstalled toolchains + Docker builder cache).
+runs:
+  using: composite
+  steps:
+    - name: Free disk space
+      shell: bash
+      run: |
+        set -eux
+        df -h
+        sudo rm -rf \
+          /usr/share/dotnet \
+          /usr/local/lib/android \
+          /opt/ghc \
+          /opt/hostedtoolcache/CodeQL \
+          /usr/local/share/boost \
+          /usr/share/swift \
+          || true
+        docker builder prune -af 2>/dev/null || true
+        df -h

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -328,7 +328,7 @@ jobs:
           sudo chmod +x /usr/local/bin/docker-compose
       # Image build + compose layers need headroom on ubuntu-latest.
       - name: Free disk space
-        uses: ./.github/actions/_free-disk
+        uses: $/.github/actions/_free-disk
       - name: Clean up lingering containers
         run: |
           docker ps -q | xargs -r docker kill || true
@@ -404,7 +404,7 @@ jobs:
       # Image build + /opt/venv + second full tox env under tox_data
       # overflowed ubuntu-latest (~14GB free) → ENOSPC on uv sync into /app/.tox.
       - name: Free disk space
-        uses: ./.github/actions/_free-disk
+        uses: $/.github/actions/_free-disk
       - name: Clean up lingering containers
         run: |
           docker compose -f docker-compose.e2e.yml down -v 2>/dev/null || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,12 +286,26 @@ jobs:
         run: ./scripts/creative-agent-stack.sh down
 
   e2e-tests:
+    # CI owns build+up (with healthchecks); pytest only verifies.
+    # Do NOT clear ADCP_TESTING — empty forces docker_services_e2e into the
+    # standalone cold-build path under pytest --timeout=300 (setup ENOSPC/timeouts).
     name: E2E Tests
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: read # pull adcp-creative-agent from ghcr.io (publish runs on main via publish-creative-agent.yml)
-    timeout-minutes: 25
+    # 40m: pre-start compose --wait + migrations + pytest bodies; 25m too tight.
+    timeout-minutes: 40
+    env:
+      # Native compose multi-file (colon-separated). Overlay sites inherit this;
+      # cascading single-file downs keep an explicit -f (intentional scopes).
+      COMPOSE_FILE: docker-compose.e2e.yml:docker-compose.e2e.ports.yml
+      POSTGRES_PORT: 5435
+      ADCP_SALES_PORT: 8080
+      ADCP_TLS_PORT: 8443
+      WEBHOOK_CAPTURE_PORT: 8090
+      DOCKER_BUILDKIT: 1
+      COMPOSE_DOCKER_CLI_BUILD: 1
     steps:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
@@ -312,42 +326,56 @@ jobs:
           echo '#!/bin/bash' | sudo tee /usr/local/bin/docker-compose
           echo 'exec docker compose "$@"' | sudo tee -a /usr/local/bin/docker-compose
           sudo chmod +x /usr/local/bin/docker-compose
+      # Image build + compose layers need headroom on ubuntu-latest.
+      - name: Free disk space
+        uses: ./.github/actions/_free-disk
       - name: Clean up lingering containers
         run: |
           docker ps -q | xargs -r docker kill || true
-          docker compose -f docker-compose.e2e.yml down -v 2>/dev/null || true
           docker compose down -v 2>/dev/null || true
+          docker compose -f docker-compose.e2e.yml down -v 2>/dev/null || true
           docker container prune -f 2>/dev/null || true
           docker network prune -f 2>/dev/null || true
           docker volume prune -f 2>/dev/null || true
+      - name: Build and start E2E stack
+        env:
+          ADCP_TESTING: "true"
+          # Prefer pin-keyed GHCR pull in creative-agent-stack.sh build (CI owns
+          # the only cold-build path under ADCP_TESTING=true verify-only pytest).
+          CREATIVE_AGENT_GHCR_IMAGE: ghcr.io/${{ github.repository }}/adcp-creative-agent
+        run: |
+          set -eux
+          # tls-proxy bind-mounts .test-tls/; generate material before compose build/up.
+          ./scripts/dev/ensure-test-tls.sh
+          ./scripts/creative-agent-stack.sh build
+          # COMPOSE_FILE (job env) overlays e2e + e2e.ports for host curl/pytest.
+          docker compose build
+          # --wait gates postgres, creative-agent, adcp-server, proxy healthchecks
+          # (creative-agent hard gate for all E2E). Budget covers migrations.
+          docker compose \
+            up -d --wait --wait-timeout 600
+          curl -sf "http://127.0.0.1:${ADCP_SALES_PORT}/health"
+          docker compose ps
       # No coverage: the server under test runs inside Docker, so host-side
       # coverage would measure the client harness, not src/.
+      # --timeout=300 + timeout_func_only=true: bodies only. CI pre-start above
+      # owns creative-agent build + compose up --wait + migrations; with
+      # ADCP_TESTING=true the session fixture is verify-only (no cold build).
+      # Job timeout-minutes covers a hung pre-start; do not resurrect fixture
+      # cold-build narratives here. Pin ADCP_TESTING on this step — do not rely
+      # on workflow-env inheritance alone.
       - uses: ./.github/actions/_pytest
         with:
           paths: tests/e2e/
-          # timeout_func_only: the 300s budget applies to TEST BODIES only.
-          # Since the pinned creative agent was un-gated, the first
-          # stack-needing test's session fixture does agent build/pull +
-          # compose up + migrations — >300s on a 4-core runner when the pin's
-          # ghcr tag isn't published yet (source-build fallback). With
-          # func_only=false that killed the fixture at exactly 300s and
-          # error-cascaded the remaining 40 tests. A genuinely hung bring-up
-          # now surfaces as the job timeout instead.
           extra_args: --timeout=300 -o timeout_func_only=true
         env:
-          # Override workflow env — conftest starts docker-compose.e2e.yml (legacy test.yml parity).
-          ADCP_TESTING: ""
           DATABASE_URL: ""
-          ADCP_SALES_PORT: 8080
-          POSTGRES_PORT: 5435
-          DOCKER_BUILDKIT: 1
-          COMPOSE_DOCKER_CLI_BUILD: 1
-          # conftest builds the pinned creative agent host-side; prefer the
-          # pin-keyed ghcr pull (~5m faster) over building from source.
-          CREATIVE_AGENT_GHCR_IMAGE: ghcr.io/${{ github.repository }}/adcp-creative-agent
+          ADCP_TESTING: "true"
       - name: Cleanup Docker services
         if: always()
-        run: docker compose -f docker-compose.e2e.yml down -v 2>/dev/null || true
+        run: |
+          docker compose down -v 2>/dev/null || true
+          docker compose -f docker-compose.e2e.yml down -v 2>/dev/null || true
 
   bdd-in-network:
     # The 5th BDD transport (e2e_rest: real HTTP through nginx to the live
@@ -373,6 +401,10 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
+      # Image build + /opt/venv + second full tox env under tox_data
+      # overflowed ubuntu-latest (~14GB free) → ENOSPC on uv sync into /app/.tox.
+      - name: Free disk space
+        uses: ./.github/actions/_free-disk
       - name: Clean up lingering containers
         run: |
           docker compose -f docker-compose.e2e.yml down -v 2>/dev/null || true
@@ -396,6 +428,10 @@ jobs:
           # run_all_tests.sh builds the pinned creative agent host-side; prefer
           # the pin-keyed ghcr pull (~5m faster) over building from source.
           CREATIVE_AGENT_GHCR_IMAGE: ghcr.io/${{ github.repository }}/adcp-creative-agent
+          # Serial e2e_rest leg — no xdist fan-out; default 10g tmpfs wastes RAM
+          # on ubuntu-latest. Cap is a RAM ceiling (tmpfs size=), not host-disk
+          # headroom; ENOSPC on the runner is handled by _free-disk.
+          PGDATA_TMPFS_SIZE: 2g
           # No host uvx in this job (no _setup-env); the dedicated Security
           # Audit check owns the uv-secure scan.
           RUN_ALL_SKIP_AUDIT: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -328,7 +328,7 @@ jobs:
           sudo chmod +x /usr/local/bin/docker-compose
       # Image build + compose layers need headroom on ubuntu-latest.
       - name: Free disk space
-        uses: $/.github/actions/_free-disk
+        uses: ./.github/actions/_free-disk
       - name: Clean up lingering containers
         run: |
           docker ps -q | xargs -r docker kill || true
@@ -404,7 +404,7 @@ jobs:
       # Image build + /opt/venv + second full tox env under tox_data
       # overflowed ubuntu-latest (~14GB free) → ENOSPC on uv sync into /app/.tox.
       - name: Free disk space
-        uses: $/.github/actions/_free-disk
+        uses: ./.github/actions/_free-disk
       - name: Clean up lingering containers
         run: |
           docker compose -f docker-compose.e2e.yml down -v 2>/dev/null || true

--- a/docker-compose.e2e.ports.yml
+++ b/docker-compose.e2e.ports.yml
@@ -7,8 +7,9 @@
 #
 # The HOST test paths, however, run pytest ON THE HOST and must reach the stack
 # over localhost, so they DO need published ports. Those paths overlay this file:
-#   - tests/e2e/conftest.py  (standalone branch: builds + ups its own stack; this
-#                             is also the path GitHub CI uses for `pytest tests/e2e`)
+#   - .github/workflows/ci.yml e2e-tests  (pre-starts stack, then pytest with
+# ADCP_TESTING=true)
+#   - tests/e2e/conftest.py  (local standalone branch: builds + ups its own stack)
 #   - scripts/test-stack.sh  (host stack for run_all_tests.sh / make test-stack-up)
 #
 # Usage (host paths only):

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -181,7 +181,7 @@ services:
       # https, via the shared tls-proxy front below.
       CREATIVE_AGENT_URL: https://creative-agent.adcp.test:8443/api/creative-agent
       CREATE_DEMO_TENANT: "true"
-      DELIVERY_WEBHOOK_INTERVAL: ${DELIVERY_WEBHOOK_INTERVAL:-}
+      DELIVERY_WEBHOOK_INTERVAL: ${DELIVERY_WEBHOOK_INTERVAL:-5}
       # GH #1802: the breaker's RECOVERY timeout only. Reaching
       # HALF_OPEN honestly means waiting this out inside the server, and 60s per
       # scenario is wall clock the suite should not spend. This is a VALUE, not a
@@ -214,33 +214,37 @@ services:
       - single-request-reopen
     volumes:
       - .:/app
+    # Tighter probes + start_period so `compose up --wait` (CI) survives
+    # alembic + cold import without waiting a full 30s interval before first check.
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      # 60s, not creative-agent's 30s (below) -- adcp-server does more work
-      # at startup (DB migrations, etc.) and is the service that actually
-      # showed this bug live: marked genuinely UNHEALTHY (not just
-      # `starting`) under heavy concurrent test-suite load, because there
-      # was no grace period for Docker to report `starting` during
-
+      # Tighter probes for `compose up --wait` (CI #1667); start_period 60s
+      # (not creative-agent's 30s) — adcp-server does more startup work
+      # (DB migrations) and without grace Docker can mark UNHEALTHY under load.
+      interval: 5s
+      timeout: 5s
+      retries: 36
       start_period: 60s
 
   proxy:
     image: nginx:stable
     volumes:
       - ./config/nginx/nginx-development.conf:/etc/nginx/nginx.conf:ro
+    # Wait for adcp healthy before starting nginx — otherwise /health → 502 while
+    # adcp is still in its 60s start_period and `compose up --wait` can flake
+    # (proxy: 12×5s + start_period 15s after adcp is healthy; CI).
     depends_on:
-      - adcp-server
+      adcp-server:
+        condition: service_healthy
     # NO host port here either — see the postgres note above. Publishing for the
     # host paths is in docker-compose.e2e.ports.yml; the in-network runner reaches
     # the proxy by service name (proxy:8000).
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
-      interval: 10s
+      interval: 5s
       timeout: 5s
-      retries: 5
+      retries: 12
+      start_period: 15s
 
   # ─── TLS listener (GH #1291, collapsed onto one front — amht.2) ─────
   # ADDITIVE, never a migration: `proxy` above keeps its plaintext :8000 exactly

--- a/docs/development/ci-pipeline.md
+++ b/docs/development/ci-pipeline.md
@@ -97,11 +97,15 @@ Each shard runs against a GitHub Actions service container (Postgres 15).
 
 ## E2E Tests
 
-The workflow sets `ADCP_TESTING: true` at the top level for integration/BDD/smoke
-jobs. The **E2E job overrides this to empty** so `tests/e2e/conftest.py` starts
-`docker-compose.e2e.yml` itself (same as legacy `test.yml`). Do not set
-`ADCP_TESTING=true` on the E2E pytest step — that path assumes an already-running
-stack on `ADCP_SALES_PORT` and fails with "Server not ready after 60s".
+The workflow sets `ADCP_TESTING: true` at the top level. The **E2E job**
+pre-starts the stack (pinned `creative-agent` build + `compose up -d --wait`
+with healthchecks and the host-ports overlay), then runs pytest with
+`ADCP_TESTING: "true"` set explicitly on the pytest step so
+`docker_services_e2e` is verify-only. Do **not** clear or omit it on that
+step — an empty/false value forces the fixture into the standalone cold-build
+path under `pytest --timeout=300` (setup timeouts / ENOSPC on cold runners).
+Local standalone runs (no pre-started stack) still clear or omit
+`ADCP_TESTING` so conftest owns build+up.
 
 ## Reference Creative Agent
 

--- a/tests/e2e/_webhook_capture.py
+++ b/tests/e2e/_webhook_capture.py
@@ -1,9 +1,9 @@
-"""HTTP-client webhook receiver for e2e tests (salesagent-amht.3).
+"""HTTP-client webhook receiver for e2e tests (GH #1802).
 
 Backed by the long-lived ``webhook-capture`` compose service
 (``tests/e2e/webhook_capture_service.py``), fronted by the shared
 ``tls-proxy`` at a fixed ``webhooks.adcp.test`` alias
-(salesagent-amht.2) — not a per-test, ephemeral-port, in-process receiver
+(GH #1802) — not a per-test, ephemeral-port, in-process receiver
 anymore. That is what a webhook receiver is in production.
 
 Two traffic patterns, never conflated:
@@ -22,7 +22,7 @@ Scope note: this module serves the 3 COMPOSE-COUPLED e2e consumers only.
 hermetic (no Docker stack — its sender runs in-process on the host) and
 cannot resolve ``webhooks.adcp.test`` at all; it keeps using
 ``tests.e2e._webhook_capture_loopback`` unchanged (owner scope decision,
-2026-08-05, recorded in salesagent-amht.3).
+2026-08-05, recorded in GH #1802).
 """
 
 from __future__ import annotations
@@ -51,7 +51,7 @@ class WebhookReadbackError(RuntimeError):
 
 def _readback_base_url() -> str:
     host = os.getenv("WEBHOOK_CAPTURE_HOST", "localhost")
-    port = os.getenv("WEBHOOK_CAPTURE_PORT", "8080")
+    port = os.getenv("WEBHOOK_CAPTURE_PORT", "8090")
     return f"http://{host}:{port}"
 
 

--- a/tests/unit/_architecture_helpers.py
+++ b/tests/unit/_architecture_helpers.py
@@ -980,6 +980,49 @@ def runtime_user_directives(lines: Iterable[str]) -> list[str]:
 _PRE_COMMIT_CONFIG_PATH = Path(".pre-commit-config.yaml")
 
 
+def load_yaml_mapping(path: Path) -> dict[str, Any]:
+    """Read a YAML file and require a top-level mapping (shared guard preamble)."""
+    assert path.is_file(), f"missing {path}"
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert isinstance(data, dict), f"{path} must parse to a mapping"
+    return data
+
+
+def job_run_text(job: dict[str, Any]) -> str:
+    """Flatten all ``run:`` step bodies from a workflow job into one string."""
+    chunks: list[str] = []
+    for step in job.get("steps") or []:
+        if isinstance(step, dict) and isinstance(step.get("run"), str):
+            chunks.append(step["run"])
+    return "\n".join(chunks)
+
+
+def find_step(
+    steps: list[dict[str, Any]],
+    *,
+    name_contains: str | None = None,
+    uses_contains: str | None = None,
+) -> dict[str, Any] | None:
+    """Locate the first workflow step matching name/uses substring predicates.
+
+    Returns the matched step mapping, or ``None``. At least one of
+    ``name_contains`` / ``uses_contains`` must be provided; when both are set,
+    both must match. Callers that need the index should enumerate ``steps``
+    themselves (see ``_find_free_disk_step``).
+    """
+    if name_contains is None and uses_contains is None:
+        raise ValueError("at least one of name_contains, uses_contains is required")
+    for step in steps:
+        if not isinstance(step, dict):
+            continue
+        if name_contains is not None and name_contains not in str(step.get("name", "")):
+            continue
+        if uses_contains is not None and uses_contains not in str(step.get("uses", "")):
+            continue
+        return step
+    return None
+
+
 def load_pre_commit_config(path: Path | None = None, repo: Path | None = None) -> dict[str, Any]:
     """Load ``.pre-commit-config.yaml`` anchored to *repo* (default: repo root)."""
     root = repo or repo_root()

--- a/tests/unit/test_architecture_ci_suite_coverage.py
+++ b/tests/unit/test_architecture_ci_suite_coverage.py
@@ -9,23 +9,229 @@ must propagate BDD/E2E failures so a red suite turns CI red.
 This is a configuration-contract assertion: the workflow file is parsed as
 YAML data and the job graph is inspected. It is NOT a source-code AST scan.
 
-No allowlist — zero tolerance. Every locally-run suite must have a gating
-CI job, or a broken suite can silently land on main again.
+No allowlist — zero tolerance for mapped suites. Every locally-run suite in
+``run_all_tests.sh`` ALL_SUITES must map to a summary gate **or** an explicit
+documented exclusion (currently ``ui`` — Playwright / full-stack cost, no CI
+job yet). CI-only gates (smoke, bdd-in-network) are listed separately.
 """
+
+import re
+from pathlib import Path
+from typing import Any
 
 import pytest
 
 from scripts.ci.workflow_helpers import load_ci_workflow
+from tests.unit._architecture_helpers import job_run_text, load_yaml_mapping, repo_root
 
-# Suite jobs that must appear in summary.needs — a suite that runs but is absent
-# from summary.needs leaves CI green on its failure (PR #1299 silent-breakage class).
-REQUIRED_SUMMARY_GATES = frozenset({"unit-tests", "integration-tests", "e2e-tests", "bdd-tests", "admin-ui-tests"})
+# Local suite → summary.needs job. Derived from run_all_tests.sh ALL_SUITES;
+# unmapped suites must be listed in UNGATED_LOCAL_SUITES with a documented reason.
+_LOCAL_SUITE_TO_SUMMARY_GATE: dict[str, str] = {
+    "unit": "unit-tests",
+    "integration": "integration-tests",
+    "bdd": "bdd-tests",
+    "admin": "admin-ui-tests",
+    "e2e": "e2e-tests",
+}
+# Intentionally ungated in CI (no job yet). Soften the "every suite" claim:
+# these are excluded at the source map, not silently omitted from a hand list.
+# see #1924 — removal path: add a ui CI Summary gate, then drop this exclusion.
+UNGATED_LOCAL_SUITES = frozenset({"ui"})
+
+# CI-only gates that are not ALL_SUITES entries but must still floor Summary.
+_EXTRA_SUMMARY_GATES = frozenset(
+    {
+        "bdd-in-network",
+        "smoke-tests",
+    }
+)
+
+
+def _all_suites_from_runner() -> list[str]:
+    runner = repo_root() / "run_all_tests.sh"
+    m = re.search(r'ALL_SUITES="([^"]+)"', runner.read_text(encoding="utf-8"))
+    assert m, "run_all_tests.sh must define ALL_SUITES"
+    return [s.strip() for s in m.group(1).split(",") if s.strip()]
+
+
+def _required_summary_gates() -> frozenset[str]:
+    suites = _all_suites_from_runner()
+    unknown = [s for s in suites if s not in _LOCAL_SUITE_TO_SUMMARY_GATE and s not in UNGATED_LOCAL_SUITES]
+    assert not unknown, (
+        f"ALL_SUITES entries {unknown} are neither mapped to a summary gate nor listed in "
+        f"UNGATED_LOCAL_SUITES — add a CI job map entry or an explicit exclusion."
+    )
+    mapped = {_LOCAL_SUITE_TO_SUMMARY_GATE[s] for s in suites if s in _LOCAL_SUITE_TO_SUMMARY_GATE}
+    return frozenset(mapped | _EXTRA_SUMMARY_GATES)
+
+
+# Back-compat name used by tests below (computed once at import).
+REQUIRED_SUMMARY_GATES = _required_summary_gates()
+
+_FREE_DISK_USES = "./.github/actions/_free-disk"
+_FREE_DISK_ACTION = repo_root() / ".github" / "actions" / "_free-disk" / "action.yml"
+_E2E_COMPOSE = repo_root() / "docker-compose.e2e.yml"
+
+
+def _is_adcp_testing_true(value: object) -> bool:
+    """GHA env is always a string at runtime; YAML may parse unquoted ``true`` as bool."""
+    return value is True or str(value).lower() == "true"
+
+
+def _code_of(line: str) -> str:
+    """Strip a shell ``#`` comment — shared so flag/substring helpers agree on \"code\"."""
+    return line.split("#", 1)[0]
+
+
+def _shell_has_flag(script: str, flag: str) -> bool:
+    """True if ``flag`` appears as its own argv token on a non-comment code line.
+
+    Substring checks like ``\"up -d --wait\" in run`` are vacuous against
+    ``up -d --wait-timeout 600`` — ``--wait`` is a prefix of ``--wait-timeout``.
+    Shell comments (``# --wait gates ...``) must not count as the flag either.
+    """
+    for line in script.splitlines():
+        if flag in _code_of(line).split():
+            return True
+    return False
+
+
+def _shell_flag_value(script: str, flag: str) -> str | None:
+    """Return the argv token immediately after ``flag`` on a non-comment line."""
+    for line in script.splitlines():
+        tokens = _code_of(line).split()
+        for i, token in enumerate(tokens):
+            if token == flag and i + 1 < len(tokens):
+                return tokens[i + 1]
+    return None
+
+
+def _shell_has_non_comment_substr(script: str, *needles: str) -> bool:
+    """True if every needle appears on some non-comment code line (not only comments)."""
+    code = "\n".join(_code_of(line) for line in script.splitlines())
+    return all(n in code for n in needles)
+
+
+def _parse_compose_duration_seconds(value: object) -> float:
+    """Parse compose duration strings like ``60s`` / ``1m`` / ints into seconds."""
+    if value is None:
+        raise AssertionError("duration value is missing")
+    if isinstance(value, (int, float)):
+        seconds = float(value)
+    else:
+        text = str(value).strip().lower()
+        if text.endswith("ms"):
+            seconds = float(text[:-2]) / 1000.0
+        elif text.endswith("s"):
+            seconds = float(text[:-1])
+        elif text.endswith("m"):
+            seconds = float(text[:-1]) * 60.0
+        elif text.endswith("h"):
+            seconds = float(text[:-1]) * 3600.0
+        else:
+            seconds = float(text)
+    if seconds <= 0:
+        raise AssertionError(f"duration must be positive (got {value!r})")
+    return seconds
+
+
+def _find_free_disk_step(steps: list[dict[str, Any]]) -> tuple[int, dict[str, Any]]:
+    """Locate the shared _free-disk composite step (name may be present for CI UI).
+
+    Returns ``(index, step)`` — the sole index-carrying caller of the shared
+    step finder (ordering asserts need the index; other guards use ``find_step``).
+    """
+    for i, step in enumerate(steps):
+        if isinstance(step, dict) and "_free-disk" in str(step.get("uses", "")):
+            return i, step
+    raise AssertionError(f"job must include uses: {_FREE_DISK_USES} (single source for runner reclaim).")
+
+
+def _assert_free_disk_action_reclaims_runner(action: dict[str, Any] | Path | None = None) -> None:
+    """Contract lives in a composite *run* step body — not description-only tokens.
+
+    Pass a parsed action mapping (or path) to exercise fixtures; default reads the
+    production ``.github/actions/_free-disk/action.yml``.
+    """
+    label: str
+    if action is None:
+        data = load_yaml_mapping(_FREE_DISK_ACTION)
+        label = str(_FREE_DISK_ACTION)
+    elif isinstance(action, Path):
+        data = load_yaml_mapping(action)
+        label = str(action)
+    else:
+        data = action
+        label = "parsed free-disk action"
+    assert isinstance(data, dict), f"{label} must be a YAML mapping."
+    runs = data.get("runs") or {}
+    steps = runs.get("steps") if isinstance(runs, dict) else None
+    assert isinstance(steps, list) and steps, f"{label} must declare ≥1 composite step."
+    combined = job_run_text({"steps": steps})
+    assert combined, f"{label} must include a step with a run body."
+    assert "/usr/share/dotnet" in combined, "_free-disk run step must remove /usr/share/dotnet."
+    assert "docker builder prune" in combined, "_free-disk run step must prune the Docker builder cache."
+
+
+def _load_e2e_compose() -> dict[str, Any]:
+    data = load_yaml_mapping(_E2E_COMPOSE)
+    assert data.get("services"), f"{_E2E_COMPOSE} must declare services."
+    return data
 
 
 class TestCISuiteCoverage:
     """BDD and E2E suites must run in CI and gate the test summary."""
 
-    @pytest.mark.arch_guard
+    pytestmark = pytest.mark.arch_guard
+
+    def test_shell_has_flag_rejects_wait_timeout_prefix(self):
+        """``--wait`` must not match as a prefix of ``--wait-timeout`` (vacuous guard class)."""
+        wait_timeout_only = "docker compose up -d --wait-timeout 600"
+        assert not _shell_has_flag(wait_timeout_only, "--wait")
+        assert _shell_has_flag(wait_timeout_only, "--wait-timeout")
+        both = "docker compose up -d --wait --wait-timeout 600"
+        assert _shell_has_flag(both, "--wait")
+        assert _shell_has_flag(both, "--wait-timeout")
+        # Comments must not satisfy the flag contract (CI pre-start run has `# --wait gates…`).
+        comment_only = "# --wait gates postgres\nup -d --wait-timeout 600"
+        assert not _shell_has_flag(comment_only, "--wait")
+        assert _shell_has_flag(comment_only, "--wait-timeout")
+        # Adjacent argv after --wait-timeout — comment token "600" must not satisfy.
+        assert _shell_flag_value("up -d --wait-timeout 600", "--wait-timeout") == "600"
+        assert _shell_flag_value("# budget 600\nup -d --wait-timeout 120", "--wait-timeout") == "120"
+        assert _shell_flag_value("# --wait-timeout 600\nup -d --wait-timeout 120", "--wait-timeout") == "120"
+        # curl /health must be on a non-comment line.
+        assert _shell_has_non_comment_substr("curl -sf http://127.0.0.1:8080/health", "curl -sf", "/health")
+        assert not _shell_has_non_comment_substr("# curl -sf /health\necho ok", "curl -sf", "/health")
+
+    def test_free_disk_action_requires_run_step_body(self):
+        """Tokens only in description must not satisfy the reclaim contract.
+
+        Mutation-shaped fixture: description mentions reclaim tokens, and a
+        non-empty ``run`` step omits them — so the ≥1-step gate passes and the
+        reclaim-token asserts are what must fail (empty ``steps: []`` never
+        reaches those asserts).
+        """
+        vacuous = {
+            "name": "Free disk space",
+            "description": "Reclaim /usr/share/dotnet and docker builder prune",
+            "runs": {
+                "using": "composite",
+                "steps": [
+                    {
+                        "name": "noop",
+                        "run": "echo 'no reclaim tokens here'",
+                        "shell": "bash",
+                    }
+                ],
+            },
+        }
+        # Live helper must reject description-only contracts (MUT8 class).
+        with pytest.raises(AssertionError):
+            _assert_free_disk_action_reclaims_runner(vacuous)
+        # Production composite still passes the real assert.
+        _assert_free_disk_action_reclaims_runner()
+
     def test_bdd_job_exists(self):
         """BDD aggregate + parallel shard jobs must exist in CI."""
         jobs = load_ci_workflow()["jobs"]
@@ -33,7 +239,6 @@ class TestCISuiteCoverage:
         assert "bdd-tests" in jobs, "No 'bdd-tests' aggregate job in .github/workflows/ci.yml."
         assert "bdd-tests-shard" in jobs, "No 'bdd-tests-shard' matrix job in .github/workflows/ci.yml."
 
-    @pytest.mark.arch_guard
     def test_bdd_shards_run_the_bdd_suite(self):
         """Each BDD shard must resolve paths via shard_paths and run pytest."""
         shard_job = load_ci_workflow()["jobs"]["bdd-tests-shard"]
@@ -49,24 +254,21 @@ class TestCISuiteCoverage:
             "bdd-tests-shard must invoke pytest (via _pytest composite or explicit run)."
         )
 
-    @pytest.mark.arch_guard
     def test_bdd_shards_have_postgres_service(self):
         """BDD harnesses use the integration_db fixture (real PostgreSQL)."""
         services = load_ci_workflow()["jobs"]["bdd-tests-shard"].get("services", {})
 
         assert "postgres" in services, "bdd-tests-shard has no postgres service."
 
-    @pytest.mark.arch_guard
     def test_bdd_aggregate_is_status_proxy_only(self):
         """Aggregate BDD job must gate shard status, not merge coverage."""
         aggregate = load_ci_workflow()["jobs"]["bdd-tests"]
-        steps_text = " ".join(str(step.get("run", "")) for step in aggregate.get("steps", []))
+        steps_text = job_run_text(aggregate)
         assert "needs.bdd-tests-shard.result" in steps_text, "bdd-tests aggregate must fail when bdd-tests-shard fails."
         assert "coverage combine" not in steps_text, (
             "bdd-tests aggregate must not merge coverage; that belongs in the Coverage job."
         )
 
-    @pytest.mark.arch_guard
     def test_admin_job_has_postgres_service(self):
         """Admin blueprint tests use integration_db and require PostgreSQL."""
         admin_job = load_ci_workflow()["jobs"]["admin-ui-tests"]
@@ -77,7 +279,6 @@ class TestCISuiteCoverage:
             "the integration_db fixture and require a real PostgreSQL instance."
         )
 
-    @pytest.mark.arch_guard
     def test_integration_job_uses_entity_shards(self):
         """Integration tests must run in parallel entity shards (legacy parity)."""
         integration_job = load_ci_workflow()["jobs"]["integration-tests"]
@@ -97,7 +298,6 @@ class TestCISuiteCoverage:
             "integration-tests must filter pytest with matrix.marker, not run the full suite serially."
         )
 
-    @pytest.mark.arch_guard
     def test_integration_shards_use_strict_partition(self):
         """Shards 2–4 must exclude earlier shard markers to avoid duplicate runs."""
         integration_job = load_ci_workflow()["jobs"]["integration-tests"]
@@ -112,16 +312,14 @@ class TestCISuiteCoverage:
         assert "and not media_buy" in markers["infra"]
         assert "and not delivery" in markers["infra"]
 
-    @pytest.mark.arch_guard
     def test_quality_gate_does_not_run_unit_tests(self):
         """Quality Gate runs static checks only; unit tests run once in unit-tests."""
         quality_job = load_ci_workflow()["jobs"]["quality-gate"]
-        run_steps = " ".join(str(step.get("run", "")) for step in quality_job.get("steps", []))
+        run_steps = job_run_text(quality_job)
 
         assert "make quality-ci" in run_steps, "quality-gate must invoke make quality-ci (no pytest)."
         assert "pytest" not in run_steps, "quality-gate must not re-run unit tests."
 
-    @pytest.mark.arch_guard
     def test_coverage_job_reuses_test_artifacts(self):
         """Coverage gate must not re-run pytest; it combines unit + BDD artifacts."""
         coverage_job = load_ci_workflow()["jobs"]["coverage"]
@@ -135,15 +333,14 @@ class TestCISuiteCoverage:
         assert steps_text.count("download-artifact") >= 2, (
             "coverage job must download unit and BDD shard coverage artifacts."
         )
-        run_steps = " ".join(str(step.get("run", "")) for step in coverage_job.get("steps", []))
+        run_steps = job_run_text(coverage_job)
         assert "pytest" not in run_steps, "coverage job must not re-run tests."
         assert "coverage combine" in run_steps, "coverage job must combine unit and BDD coverage data."
 
-    @pytest.mark.arch_guard
     def test_coverage_gate_requires_all_bdd_shard_artifacts(self):
         """Coverage must fail on partial BDD shard artifact sets, not combine survivors."""
         coverage_job = load_ci_workflow()["jobs"]["coverage"]
-        run_steps = " ".join(str(step.get("run", "")) for step in coverage_job.get("steps", []))
+        run_steps = job_run_text(coverage_job)
 
         assert "SHARD_COUNTS" in run_steps, "coverage gate must read SHARD_COUNTS from shard_split."
         assert "expected_bdd_shards" in run_steps, "coverage gate must bind BDD shard count to a variable."
@@ -160,7 +357,6 @@ class TestCISuiteCoverage:
             "BDD shard coverage artifacts must land under bdd-coverage-shards/."
         )
 
-    @pytest.mark.arch_guard
     def test_ci_jobs_declare_permissions_and_timeout(self):
         """Every CI job must declare permissions and timeout (workflow hygiene)."""
         jobs = load_ci_workflow()["jobs"]
@@ -172,13 +368,18 @@ class TestCISuiteCoverage:
                 missing.append(f"{job_name}: timeout-minutes")
         assert not missing, "CI jobs missing hygiene fields:\n" + "\n".join(f"  - {m}" for m in missing)
 
-    @pytest.mark.arch_guard
+    def test_local_suites_map_or_explicit_exclusion(self):
+        """ALL_SUITES must map to summary gates or UNGATED_LOCAL_SUITES (no silent drops)."""
+        suites = _all_suites_from_runner()
+        assert "ui" in UNGATED_LOCAL_SUITES, "ui must stay an explicit ungated exclusion until a CI job exists"
+        assert "ui" in suites, "run_all_tests.sh ALL_SUITES must still list ui (exclusion is at the gate map)"
+
     def test_summary_gates_every_required_job(self):
         """summary must include every suite gate AND fail for every job in summary.needs."""
         workflow = load_ci_workflow()
         summary = workflow["jobs"]["summary"]
         needs = summary["needs"]
-        check_text = " ".join(str(step.get("run", "")) for step in summary.get("steps", []))
+        check_text = job_run_text(summary)
 
         assert isinstance(needs, list) and needs, "summary.needs must list every upstream gate job."
         missing = REQUIRED_SUMMARY_GATES - set(needs)
@@ -196,14 +397,12 @@ class TestCISuiteCoverage:
                 f"A failing {required} job would not fail CI even though it is listed in needs[]."
             )
 
-    @pytest.mark.arch_guard
     def test_type_check_uses_make_target(self):
         """Type Check job must invoke the same entrypoint as local make typecheck."""
         type_check = load_ci_workflow()["jobs"]["type-check"]
-        run_steps = " ".join(str(step.get("run", "")) for step in type_check.get("steps", []))
+        run_steps = job_run_text(type_check)
         assert "make typecheck" in run_steps, "type-check job must run make typecheck for CI/local parity."
 
-    @pytest.mark.arch_guard
     def test_smoke_tests_do_not_duplicate_skip_guard(self):
         """Skip-decorator enforcement belongs in the smoke suite, not a workflow grep step."""
         smoke_job = load_ci_workflow()["jobs"]["smoke-tests"]
@@ -214,7 +413,6 @@ class TestCISuiteCoverage:
             "TestNoSkippedTests is the single source of truth."
         )
 
-    @pytest.mark.arch_guard
     def test_skip_guard_single_source_of_truth_exists(self):
         """The SSoT the workflow delegates to must exist, or enforcement is unguarded."""
         from tests.smoke.test_smoke_basic import TestNoSkippedTests
@@ -223,7 +421,202 @@ class TestCISuiteCoverage:
             "TestNoSkippedTests.test_no_skip_decorators is the declared single source of truth for skip enforcement."
         )
 
-    @pytest.mark.arch_guard
+    def test_e2e_job_prestarts_stack_with_adcp_testing(self):
+        """E2E CI must pre-start compose; pytest must not cold-build under --timeout.
+
+        Regression: clearing ADCP_TESTING forced docker_services_e2e into the
+        standalone build+up path inside pytest setup, which pytest-timeout=300
+        killed on cold runners (~40 setup ERRORs). Inheritance alone is not
+        durable — the pytest step must pin ADCP_TESTING=true.
+        """
+        workflow = load_ci_workflow()
+        workflow_env = workflow.get("env") or {}
+        assert _is_adcp_testing_true(workflow_env.get("ADCP_TESTING")), (
+            "workflow env must set ADCP_TESTING true (pytest inherits when step omits it)."
+        )
+
+        job = workflow["jobs"]["e2e-tests"]
+        steps = job.get("steps", [])
+        assert steps, "e2e-tests must declare steps (empty job is a vacuous pass)."
+
+        step_names = [s.get("name") for s in steps]
+        assert "Build and start E2E stack" in step_names, "e2e-tests must pre-start the compose stack before pytest."
+        free_idx, _ = _find_free_disk_step(steps)
+        _assert_free_disk_action_reclaims_runner()
+
+        prestart = next(s for s in steps if s.get("name") == "Build and start E2E stack")
+        prestart_run = str(prestart.get("run", ""))
+        prestart_env = prestart.get("env") or {}
+        job_env = job.get("env") or {}
+        assert "ensure-test-tls.sh" in prestart_run, (
+            "Pre-start must call scripts/dev/ensure-test-tls.sh before compose build/up "
+            "(tls-proxy bind-mounts .test-tls/; empty dir fails nginx)."
+        )
+        assert "creative-agent-stack.sh build" in prestart_run, "Pre-start must build the pinned creative-agent image."
+        # Overlay may be literal -f flags in the run script OR job-level COMPOSE_FILE
+        # (docker compose native multi-file, colon-separated).
+        compose_file = str(job_env.get("COMPOSE_FILE", "") or prestart_env.get("COMPOSE_FILE", ""))
+        assert "docker-compose.e2e.ports.yml" in prestart_run or "docker-compose.e2e.ports.yml" in compose_file, (
+            "Pre-start must overlay docker-compose.e2e.ports.yml via run -f flags or "
+            "job/step COMPOSE_FILE (host curl/pytest ports)."
+        )
+        sales_port = str(job_env.get("ADCP_SALES_PORT", "") or prestart_env.get("ADCP_SALES_PORT", ""))
+        assert sales_port, "job/step must set ADCP_SALES_PORT for host health curl."
+        webhook_port = str(job_env.get("WEBHOOK_CAPTURE_PORT", "") or prestart_env.get("WEBHOOK_CAPTURE_PORT", ""))
+        assert webhook_port, (
+            "job/step must pin WEBHOOK_CAPTURE_PORT for webhook-capture readback "
+            "(docker-compose.e2e.ports.yml publishes host port; default 8090)."
+        )
+        assert webhook_port != sales_port, (
+            f"WEBHOOK_CAPTURE_PORT ({webhook_port!r}) must differ from ADCP_SALES_PORT ({sales_port!r}) "
+            "— 8080 readback hits proxy/nginx, not webhook-capture (404)."
+        )
+        assert "CREATIVE_AGENT_GHCR_IMAGE" in prestart_env, (
+            "Pre-start must set CREATIVE_AGENT_GHCR_IMAGE (CI owns the only cold-build path)."
+        )
+        assert "ghcr.io" in str(prestart_env.get("CREATIVE_AGENT_GHCR_IMAGE", "")), (
+            "CREATIVE_AGENT_GHCR_IMAGE must point at ghcr.io for pin-keyed pull preference."
+        )
+        # Token match — substring "up -d --wait" falsely matches "--wait-timeout" alone.
+        assert _shell_has_flag(prestart_run, "--wait"), (
+            "Pre-start must use compose up --wait as its own flag (healthcheck gate)."
+        )
+        assert _shell_has_flag(prestart_run, "--wait-timeout"), "Pre-start must budget --wait-timeout for migrations."
+        assert _shell_flag_value(prestart_run, "--wait-timeout") == "600", (
+            "Pre-start --wait-timeout must be 600 (adjacent argv; comment tokens do not count)."
+        )
+        assert _shell_has_non_comment_substr(prestart_run, "curl -sf", "/health"), (
+            "Pre-start must curl /health after up --wait on a non-comment line."
+        )
+        assert _is_adcp_testing_true(prestart_env.get("ADCP_TESTING")), "Pre-start must set ADCP_TESTING=true."
+        # Interval ownership: compose declares the service default; CI must not
+        # re-export a fourth launcher copy (review 4954112613 / #1667 pre-start).
+        assert "DELIVERY_WEBHOOK_INTERVAL" not in prestart_env, (
+            "Pre-start must not set DELIVERY_WEBHOOK_INTERVAL; default lives in "
+            "docker-compose.e2e.yml (${DELIVERY_WEBHOOK_INTERVAL:-5})."
+        )
+        compose_e2e = _E2E_COMPOSE.read_text(encoding="utf-8")
+        assert "DELIVERY_WEBHOOK_INTERVAL: ${DELIVERY_WEBHOOK_INTERVAL:-5}" in compose_e2e, (
+            "docker-compose.e2e.yml must default DELIVERY_WEBHOOK_INTERVAL to 5 "
+            "so CI pre-start verify-only path does not depend on a launcher re-export."
+        )
+        assert int(job.get("timeout-minutes") or 0) >= 40, (
+            f"e2e-tests timeout-minutes must be >= 40 to cover --wait-timeout 600 (got {job.get('timeout-minutes')!r})."
+        )
+
+        pytest_steps = [
+            s for s in steps if "pytest" in str(s.get("uses", "")).lower() or "tests/e2e" in str(s.get("with", {}))
+        ]
+        assert pytest_steps, "e2e-tests must invoke pytest on tests/e2e/."
+        pytest_env = pytest_steps[0].get("env") or {}
+        # Explicit pin — do not treat "key absent → inherits workflow" as sufficient.
+        assert "ADCP_TESTING" in pytest_env, (
+            "e2e-tests pytest must set ADCP_TESTING explicitly "
+            "(absent key makes the inheritance path untested / vacuous)."
+        )
+        assert _is_adcp_testing_true(pytest_env["ADCP_TESTING"]), (
+            f"e2e-tests pytest must keep ADCP_TESTING=true (got {pytest_env['ADCP_TESTING']!r}); "
+            "empty/false forces fixture cold-build under pytest-timeout."
+        )
+        # GHCR preference belongs on pre-start build, not verify-only pytest.
+        assert "CREATIVE_AGENT_GHCR_IMAGE" not in pytest_env, (
+            "CREATIVE_AGENT_GHCR_IMAGE must not sit only on verify-only pytest "
+            "(move/keep it on the pre-start build step)."
+        )
+        extra = str(pytest_steps[0].get("with", {}).get("extra_args", ""))
+        assert "--timeout=300" in extra, "e2e-tests must keep per-test --timeout=300 on test bodies."
+        assert "timeout_func_only=true" in extra, (
+            "e2e-tests must keep timeout_func_only=true (300s applies to bodies, not fixtures)."
+        )
+
+        pre_idx = step_names.index("Build and start E2E stack")
+        pytest_idx = steps.index(pytest_steps[0])
+        assert free_idx < pre_idx < pytest_idx, (
+            f"Order must be Free disk → pre-start → pytest (got {free_idx}, {pre_idx}, {pytest_idx})."
+        )
+
+    def test_e2e_compose_proxy_waits_for_adcp_healthy(self):
+        """Proxy must not race adcp start_period under ``compose up --wait``.
+
+        Regression: proxy healthcheck (no start_period) could fail with 502
+        while adcp was still inside its start_period; ``up --wait`` flaked.
+        """
+        services = _load_e2e_compose()["services"]
+        assert "adcp-server" in services and "proxy" in services, (
+            "docker-compose.e2e.yml must declare adcp-server and proxy."
+        )
+        assert "creative-agent" in services, "docker-compose.e2e.yml must declare creative-agent."
+        adcp_hc = services["adcp-server"].get("healthcheck") or {}
+        proxy = services["proxy"]
+        proxy_deps = proxy.get("depends_on") or {}
+        proxy_hc = proxy.get("healthcheck") or {}
+        creative_hc = services["creative-agent"].get("healthcheck") or {}
+
+        # Positive concrete durations — truthy "0s" must not pass.
+        assert _parse_compose_duration_seconds(adcp_hc.get("start_period")) >= 60, (
+            f"adcp-server start_period must be >= 60s (got {adcp_hc.get('start_period')!r})."
+        )
+        assert _parse_compose_duration_seconds(adcp_hc.get("interval")) == 5, (
+            f"adcp-server interval must be 5s (got {adcp_hc.get('interval')!r})."
+        )
+        assert int(str(adcp_hc.get("retries", 0))) >= 36, (
+            f"adcp-server retries must be >= 36 (got {adcp_hc.get('retries')!r})."
+        )
+        # Mapping form with condition — list form ``- adcp-server`` is the race.
+        assert isinstance(proxy_deps, dict), (
+            f"proxy depends_on must be a mapping with condition: service_healthy (got {type(proxy_deps).__name__})."
+        )
+        adcp_dep = proxy_deps.get("adcp-server") or {}
+        assert isinstance(adcp_dep, dict) and adcp_dep.get("condition") == "service_healthy", (
+            f"proxy must depends_on adcp-server with condition: service_healthy (got {adcp_dep!r})."
+        )
+        assert _parse_compose_duration_seconds(proxy_hc.get("start_period")) >= 15, (
+            f"proxy start_period must be >= 15s (got {proxy_hc.get('start_period')!r})."
+        )
+        assert _parse_compose_duration_seconds(proxy_hc.get("interval")) == 5, (
+            f"proxy interval must be 5s (got {proxy_hc.get('interval')!r})."
+        )
+        assert int(str(proxy_hc.get("retries", 0))) >= 12, (
+            f"proxy healthcheck retries must be >= 12 (got {proxy_hc.get('retries')!r})."
+        )
+        # compose --wait only waits services that declare healthchecks (creative-agent hard gate).
+        creative_test = creative_hc.get("test")
+        assert creative_test, "creative-agent healthcheck.test must be non-empty (compose --wait hard gate)."
+        assert _parse_compose_duration_seconds(creative_hc.get("start_period")) > 0, (
+            f"creative-agent start_period must be positive (got {creative_hc.get('start_period')!r})."
+        )
+
+    def test_bdd_in_network_frees_disk_before_compose(self):
+        """In-network e2e_rest must reclaim runner disk before image build.
+
+        Regression: ``uv sync`` into ``tox_data`` hit ENOSPC on ubuntu-latest
+        (image + /opt/venv + second full tox env). The job must free
+        preinstalled toolchains and cap PGDATA tmpfs for the serial leg.
+        """
+        job = load_ci_workflow()["jobs"]["bdd-in-network"]
+        steps = job.get("steps", [])
+        assert steps, "bdd-in-network must declare steps (empty job is a vacuous pass)."
+
+        step_names = [s.get("name") for s in steps]
+        assert "Run BDD suite in-network" in step_names, "bdd-in-network must run ./run_all_tests.sh bdd_e2e."
+        free_idx, _ = _find_free_disk_step(steps)
+        _assert_free_disk_action_reclaims_runner()
+        run_idx = step_names.index("Run BDD suite in-network")
+        assert free_idx < run_idx, (
+            "Free disk space must run before 'Run BDD suite in-network' "
+            f"(found Free disk at {free_idx}, run at {run_idx})."
+        )
+
+        run_step = steps[run_idx]
+        env = run_step.get("env") or {}
+        assert env.get("PGDATA_TMPFS_SIZE") == "2g", (
+            "bdd-in-network must set PGDATA_TMPFS_SIZE=2g "
+            "(serial leg; default 10g wastes RAM — tmpfs size= is a RAM ceiling)."
+        )
+        assert "run_all_tests.sh bdd_e2e" in str(run_step.get("run", "")), (
+            "bdd-in-network must invoke ./run_all_tests.sh bdd_e2e."
+        )
+
     def test_bdd_and_e2e_run_on_pull_request(self):
         """The gate is worthless if it doesn't run on PRs.
 


### PR DESCRIPTION
## Summary

Leaf fixes for red `main` CI (#1667, #1662):

1. **#1667 / E2E readiness** — CI pre-starts compose (`up -d --wait --wait-timeout 600`) before pytest; keeps `ADCP_TESTING=true` so `docker_services_e2e` is verify-only; generates test TLS before build; pins webhook-capture readback port; tightens compose health/proxy gates.
2. **#1662 / BDD In-Network ENOSPC** — shared `_free-disk` composite before compose build; `PGDATA_TMPFS_SIZE=2g` for serial e2e_rest tox sync.
3. **Guards + docs** — arch guards for E2E pre-start / free-disk / BDD disk; `docs/development/ci-pipeline.md` E2E section.

Closes #1667. Closes #1662.

Parent epic #1666 stays open.

## Test plan

- [x] `pytest tests/unit/test_architecture_ci_suite_coverage.py`
- [x] Pre-commit on commit tip
- [ ] CI green on PR tip

## Out of scope (separate PRs)

- IPR verify/sign workflow hardening
- `datamodel-code-generator` CVE bump
- Security workflow GitHub Releases retry helper