### PR TITLE
fix: surface TARGETING_REHYDRATION_FAILED advisory for corrupt targeting

### DIFF
--- a/src/core/tools/media_buy_list.py
+++ b/src/core/tools/media_buy_list.py
@@ -248,11 +248,12 @@ def _get_media_buys_impl(
 
     # Build response
     response_media_buys = []
-    buyer_named_rows = _buyer_named_rows(req)
-    for buy in target_media_buys:
-        # No policy here, and none is possible: the row's status was resolved at the
-        # fetch seam and a row whose status could not be resolved never became a
-        # _MediaBuyData. This loop projects; it does not decide.
+    # Accumulate non-fatal targeting-rehydration failures here; one row per
+    # affected (media_buy_id, package_id). Surfaced on the response so the
+    # buyer can reconcile out-of-band — beats silently coercing to
+    # targeting_overlay=None which is indistinguishable from "no targeting".
+    hydration_errors: list[Error] = []
+    for buy_i, buy in enumerate(target_media_buys):
         status = buy.wire_status
 
         # Build packages
@@ -260,7 +261,7 @@ def _get_media_buys_impl(
         response_packages = []
         buy_snapshots = snapshot_data.get(buy.media_buy_id, {})
 
-        for pkg in packages:
+        for pkg_i, pkg in enumerate(packages):
             pkg_config = pkg.package_config or {}
             pkg_id = pkg.package_id
 
@@ -275,13 +276,12 @@ def _get_media_buys_impl(
 
             # Materialize targeting_overlay from package_config so callers can verify
             # what was persisted. Tolerates the legacy "targeting" key for data written
-            # before the targeting_overlay rename.
-            # OPTIONAL-field branch of the module's per-row failure policy (see the
-            # module docstring): targeting_overlay has a legal empty value, so a
-            # single corrupted package_config row renders as None with a non-fatal
-            # TARGETING_REHYDRATION_FAILED advisory rather than crashing the whole
-            # tenant's get_media_buys response. The REQUIRED-field branch of the same
-            # policy is _persisted_revision / _compute_status, which refuse.
+            # before the targeting_overlay rename (see media_buy_create.py:638-642).
+            # A single corrupted package_config row must not crash the whole tenant's
+            # get_media_buys response — log the bad row, surface a non-fatal
+            # platform-specific ``TARGETING_REHYDRATION_FAILED`` advisory on errors[],
+            # and set this package's targeting_overlay=None so the rest of the buy
+            # still renders.
             #
             # Narrow ``except`` to ``TypeError`` only: production
             # ``extra="ignore"`` already absorbs unknown-field drift, so
@@ -304,25 +304,39 @@ def _get_media_buys_impl(
                         pkg_id,
                         exc,
                     )
-                    # Seller-side data-integrity failure (the buyer can't fix it),
-                    # surfaced with ``CONFIGURATION_ERROR`` / recovery ``terminal``
-                    # (see _BLOB_DEFECT_CODE) rather than the ``SERVICE_UNAVAILABLE``
-                    # the sibling per-creative advisory in creatives/_processing.py
-                    # uses: that code's pinned recovery is ``transient``, which advises
-                    # a retry that can never succeed against a permanently corrupt
-                    # stored blob. The ``TARGETING_REHYDRATION_FAILED`` shape stays in
-                    # the message so callers can still grep/route on it.
-                    row_advisories.append(
+                    # Seller-side persisted-data integrity failure (buyer cannot
+                    # fix the row). Platform-specific code per AdCP 3.1.1
+                    # ``core/error.json`` (MAY use codes outside the standard
+                    # vocabulary; agents fall back to ``recovery``).
+                    # ``recovery="terminal"`` — corrupt persisted row never
+                    # self-heals (MUST NOT auto-retry).
+                    hydration_errors.append(
                         Error(  # structural-guard: advisory per-package result in GetMediaBuysResponse.errors[]
-                            code=_BLOB_DEFECT_CODE,
-                            recovery=_BLOB_DEFECT_RECOVERY,
+                            code="TARGETING_REHYDRATION_FAILED",
+                            # Discriminator lives in ``code`` only — do not
+                            # restate the token in ``message``.
                             message=(
-                                f"TARGETING_REHYDRATION_FAILED: targeting overlay for "
-                                f"package '{pkg_id}' on media buy '{buy.media_buy_id}' "
-                                f"could not be rehydrated; returning "
-                                f"targeting_overlay=None for this package."
+                                f"targeting overlay for package '{pkg_id}' on "
+                                f"media buy '{buy.media_buy_id}' could not be "
+                                f"rehydrated; returning targeting_overlay=None "
+                                f"for this package."
                             ),
-                            field=f"media_buys[].packages[{pkg_id}].targeting_overlay",
+                            # JSONPath-lite per pinned core/error.json — numeric
+                            # indices only; buy/package ids stay in message/details.
+                            field=(f"media_buys[{buy_i}].packages[{pkg_i}].targeting_overlay"),
+                            details={
+                                "media_buy_id": buy.media_buy_id,
+                                "package_id": pkg_id,
+                            },
+                            # Buyer hint for BR-RULE-294 / UC-019: seller-side
+                            # persisted-targeting corruption — buyer cannot fix
+                            # the row; contact seller to repair it.
+                            suggestion=(
+                                "Contact the seller to repair the stored package "
+                                "targeting data; this package's targeting_overlay "
+                                "stays null until then."
+                            ),
+                            recovery="terminal",
                         )
                     )
                     targeting_overlay = None
@@ -394,10 +408,11 @@ def _get_media_buys_impl(
             )
         )
 
+    all_advisories = row_advisories + hydration_errors
     return GetMediaBuysResponse(
         media_buys=response_media_buys,
         context=req.context,
-        errors=row_advisories or None,
+        errors=all_advisories or None,
     )
 
 

--- a/tests/bdd/features/BR-UC-019-query-media-buys.feature
+++ b/tests/bdd/features/BR-UC-019-query-media-buys.feature
@@ -1199,7 +1199,7 @@ Feature: BR-UC-019 Query Media Buys
     When the Buyer Agent sends a get_media_buys request for media_buy_ids ["mb-001"]
     Then the response should include media buy "mb-001" with package "pkg-001"
     And the package "pkg-001" wire field <field> should be null or absent
-    And response.errors[] should carry exactly one advisory for package "pkg-001" field <field> with code "CONFIGURATION_ERROR" and recovery "terminal"
+    And response.errors[] should carry exactly one advisory for package "pkg-001" field <field> with code "<code>" and recovery "terminal"
     And response.errors[] should carry no advisory with code "SERVICE_UNAVAILABLE"
     # THE BLOB RULE. `package_config` is an untyped JSON column, so
     # every value read out of it is a legacy value the current pinned types may reject.
@@ -1226,12 +1226,12 @@ Feature: BR-UC-019 Query Media Buys
     # @source repo=adcp ref=v3.1.1 commit=467fd93d7 path=static/schemas/source/media-buy/get-media-buys-response.json
 
     Examples:
-      | field             | legacy_value          |
-      | product_id        | 123                   |
-      | start_time        | "2026-01-01T00:00:00" |
-      | end_time          | "2026-01-31T00:00:00" |
-      | paused            | "maybe"               |
-      | targeting_overlay | "not a dict"          |
+      | field             | legacy_value          | code                         |
+      | product_id        | 123                   | CONFIGURATION_ERROR          |
+      | start_time        | "2026-01-01T00:00:00" | CONFIGURATION_ERROR          |
+      | end_time          | "2026-01-31T00:00:00" | CONFIGURATION_ERROR          |
+      | paused            | "maybe"               | CONFIGURATION_ERROR          |
+      | targeting_overlay | "not a dict"          | TARGETING_REHYDRATION_FAILED |
 
   @T-UC-019-blob-rule-raw-request @invariant @BR-RULE-150 @schema-v3.1
   Scenario: a legacy-invalid buyer_campaign_ref in raw_request degrades that field alone

--- a/tests/unit/test_architecture_error_code_compliance.py
+++ b/tests/unit/test_architecture_error_code_compliance.py
@@ -25,6 +25,7 @@ logger = logging.getLogger(__name__)
 # These are mandated by AdCP BDD feature files but the SDK hasn't added them yet.
 _SPEC_CODES = {
     "BILLING_NOT_SUPPORTED",  # BR-UC-011 BR-RULE-059: unsupported billing model
+    "TARGETING_REHYDRATION_FAILED",  # FIXME(#1646): platform-specific per AdCP core/error.json MAY
 }
 
 # All acceptable codes: wire-standard (SDK + spec supplement) + justified

--- a/tests/unit/test_get_media_buys.py
+++ b/tests/unit/test_get_media_buys.py
@@ -716,20 +716,24 @@ class TestTargetingOverlayRoundTrip:
         assert good_response_pkg.targeting_overlay.property_list.list_id == "v1"
 
         # Failure surfaced via the response errors channel — buyer can reconcile.
-        # CONFIGURATION_ERROR / recovery "terminal", not the sibling per-creative
-        # advisory's SERVICE_UNAVAILABLE. Selected by lookup rather than by name: the
-        # pin gives SERVICE_UNAVAILABLE recovery "transient", which advises a retry that
-        # can never succeed against a permanently corrupt stored blob. Both halves are
-        # asserted because the code alone cannot carry the claim -- core/error.json makes
-        # error.recovery authoritative and enumMetadata only its documentary mirror, so a
-        # test checking the code would pass with the buyer still told to retry forever.
+        # Wire ``TARGETING_REHYDRATION_FAILED`` + ``recovery="terminal"``
+        # (seller/admin must repair; retry cannot help).
         assert response.errors is not None
         assert len(response.errors) == 1
         err = response.errors[0]
-        assert err.code == "CONFIGURATION_ERROR"
+        assert err.code == "TARGETING_REHYDRATION_FAILED"
+        assert "could not be rehydrated" in err.message
+        # JSONPath-lite numeric indices (pinned core/error.json); ids in details.
+        assert err.field == "media_buys[0].packages[0].targeting_overlay"
+        assert err.details == {"media_buy_id": buy.media_buy_id, "package_id": bad_pkg.package_id}
+        # BR-RULE-294 / UC-019: seller-side imperative suggestion (buyer cannot
+        # repair persisted targeting). Do not pin internal storage key names.
+        assert err.suggestion is not None
+        suggestion_lower = err.suggestion.lower()
+        assert "seller" in suggestion_lower
+        assert "repair" in suggestion_lower
+        assert "package_config" not in suggestion_lower
         assert err.recovery == "terminal"
-        assert "TARGETING_REHYDRATION_FAILED" in err.message
-        assert err.field is not None and "targeting_overlay" in err.field
 
 
 class TestGetMediaBuysResponseStructure:


### PR DESCRIPTION
## Summary

Leaf #1646 only: surface a non-fatal platform-specific `TARGETING_REHYDRATION_FAILED` advisory (`recovery="terminal"`) when a corrupt `package_config` targeting row cannot be rehydrated; wire JSONPath-lite `field`, seller-facing `suggestion`, and matching unit/BDD pins.

Out-of-leaf surfaces (REST `get_media_buys` route, A2A auth/builder, repository SQL rewrite, broad UC-019 harness) were removed from this branch — tracked separately on #1762, #1555, #1830, #1831.

Closes #1646

## Spec grounding

- AdCP `core/error.json` (pinned): sellers **MAY** use codes outside the standard vocabulary for platform-specific errors; agents fall back to `recovery`. `recovery="terminal"` = requires human action (corrupt persisted row never self-heals).
- Storyboard: ungraded (BR-RULE-294 / UC-019 seller-side rehydration).

## Test plan

- [x] Unit: `test_corrupted_targeting_surfaces_via_errors_channel` pins `TARGETING_REHYDRATION_FAILED` + terminal + suggestion + JSONPath-lite `field`
- [x] Architecture: `TARGETING_REHYDRATION_FAILED` in error-code compliance `_SPEC_CODES`
- [x] BDD: blob-degraded `targeting_overlay` row expects `TARGETING_REHYDRATION_FAILED` (other blob fields stay `CONFIGURATION_ERROR`)
- [x] Tip CI green on `97b7286ec`

## Follow-ups (not in this PR)

- #1762 — REST `get_media_buys` route + UC-019 REST tranche
- #1555 — UC-019 BDD wiring across transports
- #1830 — e2e_rest controllable clock
- #1831 — creatives/_processing advisory code reconcile