### PR TITLE
fix(e2e): align local docker_services_e2e with shared readiness helper

### DIFF
--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -27,6 +27,14 @@ the `live_server` fixture turns into URLs. `live_server["tls"]` is present
 only when the stack serves a verified TLS listener; tests that need HTTPS
 request that key and fail with an explicit error when it is absent.
 
+## Stack readiness
+
+`docker_services_e2e` waits through `stack_readiness.wait_for_e2e_stack` with
+required probe order `postgres → creative-agent → adcp /health` (both when
+reusing an already-running stack via `ADCP_TESTING=true` / `--skip-docker`, and
+after a self-`up`). On timeout it dumps compose logs (including
+`creative-agent`) once and fails once. See `stack_readiness.py`.
+
 ## Testing hooks
 
 The suite implements the AdCP testing hooks from

--- a/tests/e2e/_webhook_capture.py
+++ b/tests/e2e/_webhook_capture.py
@@ -1,9 +1,9 @@
-"""HTTP-client webhook receiver for e2e tests (salesagent-amht.3).
+"""HTTP-client webhook receiver for e2e tests (GH #1802).
 
 Backed by the long-lived ``webhook-capture`` compose service
 (``tests/e2e/webhook_capture_service.py``), fronted by the shared
 ``tls-proxy`` at a fixed ``webhooks.adcp.test`` alias
-(salesagent-amht.2) — not a per-test, ephemeral-port, in-process receiver
+(GH #1802) — not a per-test, ephemeral-port, in-process receiver
 anymore. That is what a webhook receiver is in production.
 
 Two traffic patterns, never conflated:
@@ -22,7 +22,7 @@ Scope note: this module serves the 3 COMPOSE-COUPLED e2e consumers only.
 hermetic (no Docker stack — its sender runs in-process on the host) and
 cannot resolve ``webhooks.adcp.test`` at all; it keeps using
 ``tests.e2e._webhook_capture_loopback`` unchanged (owner scope decision,
-2026-08-05, recorded in salesagent-amht.3).
+2026-08-05, recorded in GH #1802).
 """
 
 from __future__ import annotations
@@ -51,7 +51,7 @@ class WebhookReadbackError(RuntimeError):
 
 def _readback_base_url() -> str:
     host = os.getenv("WEBHOOK_CAPTURE_HOST", "localhost")
-    port = os.getenv("WEBHOOK_CAPTURE_PORT", "8080")
+    port = os.getenv("WEBHOOK_CAPTURE_PORT", "8090")
     return f"http://{host}:{port}"
 
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -27,16 +27,30 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 
 # Import contract validation - this automatically validates tool calls at test collection time
 from tests.e2e.conftest_contract_validation import pytest_collection_modifyitems  # noqa: F401
+from tests.e2e.stack_readiness import (
+    DEFAULT_E2E_COMPOSE_FILES,
+    E2EPorts,
+    compose_argv,
+    compose_available,
+    compose_down_argv,
+    compose_exec_argv,
+    e2e_db_url_build,
+    e2e_db_url_default,
+    e2e_host_default,
+    e2e_ports,
+    use_container_exec,
+    wait_for_e2e_stack,
+)
 
 
 def e2e_host() -> str:
-    """Host for e2e server URLs.
+    """Host for e2e server URLs — delegates to ``stack_readiness.e2e_host_default``.
 
     'localhost' on the host path (Docker publishes host ports); a compose service
     name (e.g. 'proxy') when the runner is in-network and reaches the server over
     the compose network with no published ports (ADCP_TEST_HOST).
     """
-    return os.getenv("ADCP_TEST_HOST", "localhost")
+    return e2e_host_default()
 
 
 def e2e_tls_host() -> str:
@@ -98,21 +112,30 @@ def e2e_db_url(fallback_port: int) -> str:
     """Server-side Postgres URL for direct-DB e2e helpers — the DB counterpart of
     :func:`e2e_host`.
 
-    Single source for the host/port/dbname the e2e stack's database lives at, so
-    every direct-DB helper resolves it the same way. Preference order::
+    Delegates to ``stack_readiness.e2e_db_url_default`` (env chain + endpoint SSOT)::
 
         E2E_DATABASE_URL  — in-network DB by compose service name (postgres:5432/adcp)
         DATABASE_URL      — host path: the e2e stack's localhost:<published>/adcp
         localhost:<fallback_port>/adcp — last-resort fallback
-
-    Replaces the ad-hoc ``ADCP_TEST_DB_HOST``/``ADCP_TEST_DB_PORT`` split, which
-    ignored ``E2E_DATABASE_URL`` and so pointed the post-reset diagnostic at
-    localhost in-network instead of the compose service.
     """
-    return (
-        os.getenv("E2E_DATABASE_URL")
-        or os.getenv("DATABASE_URL")
-        or f"postgresql://adcp_user:secure_password_change_me@localhost:{fallback_port}/adcp"
+    return e2e_db_url_default(fallback_host="localhost", fallback_port=fallback_port)
+
+
+def _export_and_wait(ports: E2EPorts, *, timeout_s: float) -> None:
+    """Export host-published ports for compose/tests, then run the ordered hard gate.
+
+    Collapses the verify-only and standalone wait blocks onto one seam. Compose
+    still needs ``POSTGRES_PORT`` / ``ADCP_SALES_PORT`` in the process env;
+    ``wait_for_server_readiness`` takes ``postgres_port`` explicitly and must
+    not read those exports.
+    """
+    os.environ["ADCP_SALES_PORT"] = str(ports["mcp"])
+    os.environ["POSTGRES_PORT"] = str(ports["postgres"])
+    wait_for_e2e_stack(
+        ports=ports,
+        compose_files=DEFAULT_E2E_COMPOSE_FILES,
+        host=e2e_host(),
+        timeout_s=timeout_s,
     )
 
 
@@ -217,36 +240,32 @@ def docker_services_e2e(request):
         a2a_port = mcp_port  # A2A is on same port as MCP (unified FastAPI process)
         admin_port = mcp_port  # Admin is on same port as MCP (unified FastAPI process)
         postgres_port = int(os.getenv("POSTGRES_PORT", "5435"))
+        # webhook-capture readback — must match docker-compose.e2e.ports.yml
+        # (${WEBHOOK_CAPTURE_PORT:-8090}:8080). CI pins ADCP_SALES_PORT=8080 for
+        # the proxy; without exporting this, _webhook_capture defaults would hit
+        # the wrong host port and DELETE /webhook/<key> 404s on /health's stack.
+        webhook_capture_port = int(os.getenv("WEBHOOK_CAPTURE_PORT", "8090"))
         # The TLS listener is OPTIONAL here: in-network it has no host port at
         # all (it is reached by its dotted network alias via E2E_TLS_BASE_URL),
         # and an older stack may predate it. Absent -> live_server has no "tls"
         # key, and the tests that need one fail saying so.
         tls_port = int(os.getenv("ADCP_TLS_PORT")) if os.getenv("ADCP_TLS_PORT") else None
 
-        print(f"✓ Using ports: Server={mcp_port} (MCP+A2A+Admin), Postgres={postgres_port}")
+        # Export resolved ports so later wrappers (e.g. wait_for_server_readiness)
+        # see the same values the fixture used — same contract as standalone.
+        os.environ["ADCP_SALES_PORT"] = str(mcp_port)
+        os.environ["POSTGRES_PORT"] = str(postgres_port)
+        os.environ["WEBHOOK_CAPTURE_PORT"] = str(webhook_capture_port)
 
-        # Wait for server to be ready. /health is proxied to the upstream
-        # (not returned by nginx directly), so this confirms the app is serving.
-        # 60s budget covers: alembic migration run on a fresh schema (~5-15s
-        # in CI), MCP/A2A/REST router registration, and the first-call cold
-        # path through the import graph (typed creative-format registry +
-        # adcp library module load). Empirically 25-45s in CI; 60s leaves
-        # ~30% headroom. Drop only if the startup cold-path measurably
-        # shrinks — don't widen further without root-causing the slowness.
-        max_wait = 60
-        start_time = time.time()
-        for _ in range(max_wait // 2):
-            try:
-                response = requests.get(f"http://{e2e_host()}:{mcp_port}/health", timeout=2)
-                if response.status_code == 200:
-                    elapsed = int(time.time() - start_time)
-                    print(f"✓ Server is healthy ({elapsed}s)")
-                    break
-            except requests.RequestException:
-                pass
-            time.sleep(2)
-        else:
-            pytest.fail(f"Server not ready after {max_wait}s (port {mcp_port})")
+        print(
+            f"✓ Using ports: Server={mcp_port} (MCP+A2A+Admin), Postgres={postgres_port}, "
+            f"WebhookCapture={webhook_capture_port}"
+        )
+
+        # Shared ordered readiness (postgres → creative-agent → adcp /health).
+        # CI already compose --wait'd; 60s is a safety net, not a cold start budget.
+        ports = e2e_ports(mcp=mcp_port, postgres=postgres_port)
+        _export_and_wait(ports, timeout_s=60)
 
     else:
         # Check if Docker is available
@@ -258,7 +277,9 @@ def docker_services_e2e(request):
         # Always clean up existing services and volumes to ensure fresh state
         print("Cleaning up any existing Docker services and volumes...")
         subprocess.run(
-            ["docker-compose", "-f", "docker-compose.e2e.yml", "down", "-v"], capture_output=True, check=False
+            compose_down_argv(),
+            capture_output=True,
+            check=False,
         )
 
         # Explicitly remove volumes in case docker-compose down -v didn't work
@@ -285,7 +306,7 @@ def docker_services_e2e(request):
         # clear of the Linux ephemeral range (32768+), which the 20000-30000
         # choice for those two was already picked to avoid.
         tls_port = int(os.getenv("ADCP_TLS_PORT")) if os.getenv("ADCP_TLS_PORT") else find_free_port(15000, 20000)
-        # webhook-capture's plain-HTTP READBACK control-plane (salesagent-amht.3)
+        # webhook-capture's plain-HTTP READBACK control-plane (GH #1802)
         # — same dynamic-allocation reasoning as tls_port above (a fixed default
         # would let two concurrent stacks cross-wire onto the same host port).
         # DELIVERY never uses this port; it goes through tls_port above.
@@ -345,96 +366,23 @@ def docker_services_e2e(request):
             raise subprocess.CalledProcessError(agent_build.returncode, "creative-agent-stack.sh build")
 
         print("Step 1/2: Building Docker images...")
-        compose_files = ["-f", "docker-compose.e2e.yml", "-f", "docker-compose.e2e.ports.yml"]
+        # Same argv preference as readiness (`docker compose` plugin first).
+        compose_base = compose_argv(DEFAULT_E2E_COMPOSE_FILES)
         build_result = subprocess.run(
-            ["docker-compose", *compose_files, "build", "--progress=plain"],
+            [*compose_base, "build", "--progress=plain"],
             env=env,
             capture_output=False,  # Show build output
         )
         if build_result.returncode != 0:
             print(f"❌ Docker build failed with exit code {build_result.returncode}")
-            raise subprocess.CalledProcessError(build_result.returncode, "docker-compose build")
+            raise subprocess.CalledProcessError(build_result.returncode, [*compose_base, "build"])
 
         print("Step 2/2: Starting services...")
-        subprocess.run(["docker-compose", *compose_files, "up", "-d"], check=True, env=env)
+        subprocess.run([*compose_base, "up", "-d"], check=True, env=env)
 
-        # Wait for unified server to be healthy (MCP + A2A + Admin all on same port)
-        max_wait = 120  # Increased from 60 to 120 seconds for CI
-        start_time = time.time()
-
-        server_ready = False
-
-        print(f"Waiting for server (max {max_wait}s)...")
-        print(f"  Health: http://{e2e_host()}:{mcp_port}/health")
-
-        while time.time() - start_time < max_wait:
-            elapsed = int(time.time() - start_time)
-
-            # Show progress every 5 seconds
-            if elapsed > 0 and elapsed % 5 == 0 and not server_ready:
-                print(f"  ⏱️  Still waiting... ({elapsed}s / {max_wait}s)")
-                # Show container status for debugging
-                try:
-                    ps_result = subprocess.run(
-                        ["docker-compose", "-f", "docker-compose.e2e.yml", "ps", "--format", "table"],
-                        capture_output=True,
-                        text=True,
-                        timeout=2,
-                    )
-                    if ps_result.returncode == 0 and ps_result.stdout:
-                        print(f"  Container status:\n{ps_result.stdout}")
-                except:
-                    pass
-
-            # Check server health. /health is proxied to upstream, so it
-            # confirms the FastAPI app is actually serving (not just nginx).
-            if not server_ready:
-                try:
-                    response = requests.get(f"http://{e2e_host()}:{mcp_port}/health", timeout=2)
-                    if response.status_code == 200:
-                        print(f"✓ Server is ready (after {elapsed}s)")
-                        server_ready = True
-                except requests.RequestException as e:
-                    if elapsed % 10 == 0:  # Log every 10 seconds
-                        print(f"  Server not ready yet ({elapsed}s): {type(e).__name__}")
-
-            if server_ready:
-                break
-
-            time.sleep(2)
-        else:
-            # Timeout - try to get container logs for debugging
-            print("\n❌ Health check timeout. Attempting to get container logs...")
-
-            # Get logs from all services
-            for service in ["proxy", "adcp-server", "postgres"]:
-                try:
-                    print(f"\n📋 {service} logs (last 100 lines):")
-                    result = subprocess.run(
-                        ["docker-compose", "-f", "docker-compose.e2e.yml", "logs", "--tail=100", service],
-                        capture_output=True,
-                        text=True,
-                        timeout=5,
-                    )
-                    if result.stdout:
-                        print(result.stdout)
-                    if result.stderr:
-                        print(f"STDERR: {result.stderr}")
-                except Exception as e:
-                    print(f"Could not get {service} logs: {e}")
-
-            # Show container status
-            try:
-                print("\n📊 Container status:")
-                ps_result = subprocess.run(
-                    ["docker-compose", "-f", "docker-compose.e2e.yml", "ps"], capture_output=True, text=True, timeout=2
-                )
-                print(ps_result.stdout)
-            except Exception as e:
-                print(f"Could not get container status: {e}")
-
-            if not server_ready:
-                pytest.fail(f"Server did not become healthy in time (waited {max_wait}s, port {mcp_port})")
+        # Same ordered readiness helper as verify-only (migrations + creative-agent start_period).
+        ports = e2e_ports(mcp=mcp_port, postgres=postgres_port)
+        _export_and_wait(ports, timeout_s=120)
 
     # Initialize CI test data now that services are healthy
     print("📦 Initializing CI test data (products, principals, etc.)...")
@@ -452,8 +400,11 @@ def docker_services_e2e(request):
     # fills the gap when E2E_DATABASE_URL is genuinely absent (this leak
     # case) — a real in-network run that already sets it (compose service
     # name, not a published port) is left untouched (#1838 review).
+    # Build via SSOT (no second DSN literal); prefer_env is skipped because
+    # setdefault must not read the stale DATABASE_URL we are protecting against.
     os.environ.setdefault(
-        "E2E_DATABASE_URL", f"postgresql://adcp_user:secure_password_change_me@localhost:{postgres_port}/adcp"
+        "E2E_DATABASE_URL",
+        e2e_db_url_build(host="localhost", port=postgres_port),
     )
 
     # Setup environment for init script - reuse existing env if available, else create minimal
@@ -462,26 +413,11 @@ def docker_services_e2e(request):
     init_env["POSTGRES_PORT"] = str(postgres_port)
     init_env["DATABASE_URL"] = e2e_db_url(postgres_port)
 
-    # Seed CI test data. On the host we shell into the server container via
-    # docker-compose exec (the host process can't reach the container DB
-    # directly) — that path uses the container's own DATABASE_URL, already
-    # correct, and ignores init_env. In-network there is no docker-compose
-    # binary, so it runs the seed script itself using init_env above (which
-    # carries the corrected DATABASE_URL set above) — the script only needs a
-    # DB connection, not Docker.
-    import shutil
-
-    if shutil.which("docker-compose"):
-        init_cmd = [
-            "docker-compose",
-            "-f",
-            "docker-compose.e2e.yml",
-            "exec",
-            "-T",
-            "adcp-server",
-            "python",
-            "scripts/setup/init_database_ci.py",
-        ]
+    # Seed CI test data. Host-path topology prefers compose exec; in-network
+    # runners reach the DB by service name and run the seed in-process.
+    # Topology (use_container_exec), not compose_available(), chooses the seam.
+    if use_container_exec(e2e_host()) and compose_available():
+        init_cmd = compose_exec_argv("adcp-server", "python", "scripts/setup/init_database_ci.py")
     else:
         init_cmd = [sys.executable, "scripts/setup/init_database_ci.py"]
 
@@ -607,7 +543,7 @@ def docker_services_e2e(request):
         try:
             # Stop and remove containers + volumes
             subprocess.run(
-                ["docker-compose", "-f", "docker-compose.e2e.yml", "down", "-v"],
+                compose_down_argv(),
                 capture_output=True,
                 check=False,
                 timeout=30,

--- a/tests/e2e/stack_readiness.py
+++ b/tests/e2e/stack_readiness.py
@@ -1,0 +1,509 @@
+"""Shared E2E stack readiness — ordered probes + one structured failure path.
+
+SSOT for ``docker_services_e2e`` (verify-only and standalone) and
+``wait_for_server_readiness``. Required hard-gate order:
+
+    postgres → creative-agent → adcp ``/health``
+
+Creative-agent has no host-published port in the e2e ports overlay; on the
+host path we inspect compose health, and in-network we HTTP-probe the
+compose service name. Do not assume ``localhost:9999`` (that is the
+standalone ``creative-agent-stack.sh`` network).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import socket
+import subprocess
+import time
+from collections.abc import Mapping, Sequence
+from enum import StrEnum
+from typing import Final, NotRequired, Protocol, TypedDict, cast
+from urllib.parse import urlparse
+
+import httpx
+import pytest
+
+REQUIRED_E2E_PROBES: Final[tuple[str, ...]] = ("postgres", "creative-agent", "adcp_health")
+
+_LOG_DUMP_SERVICES: Final[tuple[str, ...]] = (
+    "postgres",
+    "creative-pg",
+    "creative-agent",
+    "adcp-server",
+    "proxy",
+)
+
+# Public SSOT — imported by ``tests.e2e.conftest`` (fixture + wrapper must share).
+DEFAULT_E2E_COMPOSE_FILES: Final[tuple[str, ...]] = (
+    "docker-compose.e2e.yml",
+    "docker-compose.e2e.ports.yml",
+)
+
+# Base compose file only (no ports overlay) — teardown / init / down paths.
+BASE_E2E_COMPOSE_FILE: Final[str] = DEFAULT_E2E_COMPOSE_FILES[0]
+
+_CREATIVE_AGENT_IN_NETWORK_HEALTH: Final[str] = "http://creative-agent:8080/api/creative-agent/health"
+
+# Shared diagnostic fragment for host-path compose JSON-ps failures (three branches).
+_COMPOSE_JSON_PS_REQUIRED: Final[str] = "Compose V2 JSON ps is required for host-path creative-agent gating"
+
+# Parenthetical health token in compose State/Status when Health is empty.
+_STATE_HEALTH_RE: Final[re.Pattern[str]] = re.compile(r"\((healthy|unhealthy|starting)\)")
+
+
+class ServiceHealth(StrEnum):
+    """Closed set of compose healthcheck verdicts — fail-closed outside HEALTHY."""
+
+    HEALTHY = "healthy"
+    UNHEALTHY = "unhealthy"
+    STARTING = "starting"
+    UNKNOWN = "unknown"
+
+
+class _ComposePsRecord(TypedDict):
+    """Known keys from ``docker compose ps --format json`` (extra keys allowed)."""
+
+    Health: NotRequired[str]
+    State: NotRequired[str]
+    Status: NotRequired[str]
+    Name: NotRequired[str]
+
+
+class E2EPorts(TypedDict):
+    """Published ports the ordered hard gate needs — typos fail at the type boundary."""
+
+    mcp: int
+    postgres: int
+
+
+def e2e_ports(*, mcp: int, postgres: int) -> E2EPorts:
+    """Build the ports mapping every wait/probe call site must share."""
+    return {"mcp": mcp, "postgres": postgres}
+
+
+class _Probe(Protocol):
+    def __call__(
+        self,
+        *,
+        ports: E2EPorts,
+        host: str,
+        compose_files: Sequence[str],
+    ) -> bool: ...
+
+
+def e2e_host_default() -> str:
+    """Host for e2e server URLs — SSOT for ``conftest.e2e_host`` and wait defaults."""
+    return os.getenv("ADCP_TEST_HOST", "localhost")
+
+
+def _e2e_db_env_url() -> str | None:
+    """Read the e2e DB URL env chain once — SSOT for endpoint + URL resolvers."""
+    return os.getenv("E2E_DATABASE_URL") or os.getenv("DATABASE_URL")
+
+
+def resolve_e2e_db_endpoint(
+    *,
+    fallback_host: str = "localhost",
+    fallback_port: int = 5432,
+) -> tuple[str, int]:
+    """Resolve (host, port) for the e2e Postgres endpoint.
+
+    Preference: ``E2E_DATABASE_URL`` → ``DATABASE_URL`` → ``(fallback_host, fallback_port)``.
+    SSOT for ``_probe_postgres`` and ``conftest.e2e_db_url`` so the readiness gate
+    and direct-DB helpers cannot drift on defaults.
+    """
+    db_url = _e2e_db_env_url()
+    if db_url:
+        parsed = urlparse(db_url)
+        return (parsed.hostname or fallback_host, parsed.port or fallback_port)
+    return (fallback_host, fallback_port)
+
+
+def e2e_db_url_build(*, host: str = "localhost", port: int = 5432) -> str:
+    """Build the canonical e2e Postgres URL (no env read) — for setdefault/seed paths."""
+    return f"postgresql://adcp_user:secure_password_change_me@{host}:{port}/adcp"
+
+
+def e2e_db_url_default(*, fallback_host: str = "localhost", fallback_port: int = 5432) -> str:
+    """Full Postgres URL for direct-DB e2e helpers — env wins, else build from endpoint.
+
+    SSOT for ``conftest.e2e_db_url`` (mirrors the ``e2e_host_default`` wrapper
+    naming rule — shared stem + ``_default``, no ``db``/``database`` token split).
+    """
+    env_url = _e2e_db_env_url()
+    if env_url:
+        return env_url
+    host, port = resolve_e2e_db_endpoint(fallback_host=fallback_host, fallback_port=fallback_port)
+    return e2e_db_url_build(host=host, port=port)
+
+
+def in_network(host: str) -> bool:
+    """True when the runner reaches the stack by compose service name (topology)."""
+    return host not in {"localhost", "127.0.0.1", "::1"}
+
+
+def use_container_exec(host: str) -> bool:
+    """True when seed/update should prefer ``compose exec`` (host-path topology)."""
+    return not in_network(host)
+
+
+def compose_argv(compose_files: Sequence[str]) -> list[str]:
+    """Build compose argv, preferring the Compose V2 plugin when available.
+
+    Host-path creative-agent gating needs ``ps --format json``. Prefer
+    ``docker compose`` (plugin) over a legacy ``docker-compose`` V1 binary that
+    may lack JSON ``ps`` and make health always look unknown.
+    """
+    argv: list[str]
+    if shutil.which("docker"):
+        try:
+            version = subprocess.run(
+                ["docker", "compose", "version"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+                check=False,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            version = None
+        if version is not None and version.returncode == 0:
+            argv = ["docker", "compose"]
+        elif shutil.which("docker-compose"):
+            argv = ["docker-compose"]
+        else:
+            argv = ["docker", "compose"]
+    elif shutil.which("docker-compose"):
+        argv = ["docker-compose"]
+    else:
+        argv = ["docker", "compose"]
+
+    for path in compose_files:
+        argv.extend(["-f", path])
+    return argv
+
+
+def compose_exec_argv(service: str, *cmd: str, compose_files: Sequence[str] = (BASE_E2E_COMPOSE_FILE,)) -> list[str]:
+    """Build ``compose exec -T <service> <cmd>`` argv.
+
+    SSOT for the "run this command inside this compose service" unit —
+    ``compose_argv`` only single-sources the binary+files, not the
+    ``"exec", "-T", <service>`` tail that call sites used to hand-assemble
+    (four diff-introduced sites forked this before it existed).
+    """
+    return [*compose_argv(compose_files), "exec", "-T", service, *cmd]
+
+
+def compose_down_argv(compose_files: Sequence[str] = (BASE_E2E_COMPOSE_FILE,)) -> list[str]:
+    """Build ``compose down -v`` argv — SSOT for the two teardown call sites."""
+    return [*compose_argv(compose_files), "down", "-v"]
+
+
+def compose_available() -> bool:
+    """True when a docker/compose CLI is on PATH — gates compose inspect/log dump."""
+    return shutil.which("docker-compose") is not None or shutil.which("docker") is not None
+
+
+def _dump_e2e_compose_logs(compose_files: Sequence[str]) -> None:
+    """Print last-100-line logs for the standard E2E service set (once)."""
+    if not compose_available():
+        print("⚠️  docker/compose unavailable — skipping service log dump")
+        return
+
+    base = compose_argv(compose_files)
+    print("\n❌ E2E readiness failed. Dumping compose logs...")
+    for service in _LOG_DUMP_SERVICES:
+        try:
+            print(f"\n📋 {service} logs (last 100 lines):")
+            result = subprocess.run(
+                [*base, "logs", "--tail=100", service],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                check=False,
+            )
+            if result.stdout:
+                print(result.stdout)
+            if result.stderr:
+                print(f"STDERR: {result.stderr}")
+        except Exception as exc:  # noqa: BLE001 — best-effort diagnostics
+            print(f"Could not get {service} logs: {exc}")
+
+    try:
+        print("\n📊 Container status:")
+        ps_result = subprocess.run(
+            [*base, "ps"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+        if ps_result.stdout:
+            print(ps_result.stdout)
+    except Exception as exc:  # noqa: BLE001
+        print(f"Could not get container status: {exc}")
+
+
+def _map_health_token(token: str) -> ServiceHealth:
+    """Map a normalized health token to the closed enum (unknown otherwise)."""
+    try:
+        return ServiceHealth(token)
+    except ValueError:
+        return ServiceHealth.UNKNOWN
+
+
+def health_of(record: Mapping[str, object]) -> ServiceHealth:
+    """Pure compose-ps verdict — fetch is elsewhere; this never substring-matches.
+
+    ``"unhealthy"`` must not count as ready because it contains ``"healthy"``.
+    Empty Health falls back to a parenthetical token in State/Status only.
+    """
+    raw = record.get("Health")
+    if isinstance(raw, str) and raw.strip():
+        return _map_health_token(raw.strip().lower())
+
+    state = str(record.get("State") or record.get("Status") or "").lower()
+    match = _STATE_HEALTH_RE.search(state)
+    if match:
+        return _map_health_token(match.group(1))
+    return ServiceHealth.UNKNOWN
+
+
+def _compose_service_health(service: str, compose_files: Sequence[str]) -> tuple[ServiceHealth | None, str | None]:
+    """Return ``(health, error_diag)``.
+
+    ``health`` is a ``ServiceHealth`` from a successful parse, or None when
+    compose JSON-ps could not be fetched/parsed. ``error_diag`` is set when
+    health could not be determined due to a tooling/parse failure.
+    """
+    if not compose_available():
+        return None, "docker/compose unavailable for host-path health inspect"
+    try:
+        result = subprocess.run(
+            [*compose_argv(compose_files), "ps", "--format", "json", service],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return None, (
+            f"compose ps --format json for {service!r} raised {type(exc).__name__}: {exc}; {_COMPOSE_JSON_PS_REQUIRED}"
+        )
+    if result.returncode != 0 or not result.stdout.strip():
+        return None, (
+            f"compose ps --format json for {service!r} failed "
+            f"(rc={result.returncode}, stdout_empty={not bool(result.stdout.strip())}); "
+            f"{_COMPOSE_JSON_PS_REQUIRED}. "
+            f"stderr={result.stderr.strip()!r}"
+        )
+
+    # Compose v2 may emit one JSON object, an array, or NDJSON lines.
+    payload = result.stdout.strip()
+    records: list[_ComposePsRecord] = []
+    try:
+        parsed = json.loads(payload)
+        if isinstance(parsed, list):
+            records = [cast(_ComposePsRecord, r) for r in parsed if isinstance(r, dict)]
+        elif isinstance(parsed, dict):
+            records = [cast(_ComposePsRecord, parsed)]
+    except json.JSONDecodeError:
+        for line in payload.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(obj, dict):
+                records.append(cast(_ComposePsRecord, obj))
+
+    if not records:
+        return None, (
+            f"compose ps --format json for {service!r} produced no parseable records; "
+            f"{_COMPOSE_JSON_PS_REQUIRED}. "
+            f"raw_stdout={payload[:200]!r}"
+        )
+    return health_of(records[0]), None
+
+
+def _compose_reports_ready(health: ServiceHealth | None) -> bool:
+    """True only when compose reports an explicit healthcheck pass — fail-closed."""
+    return health is ServiceHealth.HEALTHY
+
+
+def _compose_service_ready(service: str, compose_files: Sequence[str]) -> bool:
+    """True when compose reports the named service as healthcheck-ready."""
+    health, _err = _compose_service_health(service, compose_files)
+    return _compose_reports_ready(health)
+
+
+def _tcp_open(host: str, port: int, *, timeout_s: float = 2.0) -> bool:
+    try:
+        with socket.create_connection((host, port), timeout=timeout_s):
+            return True
+    except OSError:
+        return False
+
+
+def _http_authority(host: str, port: int) -> str:
+    """Format ``host:port``, bracketing IPv6 literals so httpx accepts the URL."""
+    if ":" in host and not host.startswith("["):
+        return f"[{host}]:{port}"
+    return f"{host}:{port}"
+
+
+def _http_ok(url: str, *, timeout_s: float = 2.0) -> bool:
+    try:
+        with httpx.Client() as client:
+            resp = client.get(url, timeout=timeout_s)
+            return resp.status_code == 200
+    except (httpx.HTTPError, httpx.InvalidURL):
+        return False
+
+
+def _probe_postgres(
+    *,
+    ports: E2EPorts,
+    host: str,
+    compose_files: Sequence[str],
+) -> bool:
+    del compose_files  # host path must use the published port — no compose-health degrade
+    if in_network(host):
+        # Runner is on the compose network — shared env/default endpoint SSOT.
+        db_host, db_port = resolve_e2e_db_endpoint(fallback_host="postgres", fallback_port=5432)
+        return _tcp_open(db_host, db_port)
+
+    postgres_port = ports.get("postgres")
+    if postgres_port is None:
+        # Absent key must fail closed — never silently fall through to compose health.
+        return False
+    return _tcp_open(host, int(postgres_port))
+
+
+def _probe_creative_agent(
+    *,
+    ports: E2EPorts,
+    host: str,
+    compose_files: Sequence[str],
+) -> bool:
+    del ports  # creative-agent has no host-published port in the e2e overlay
+    if in_network(host):
+        return _http_ok(_CREATIVE_AGENT_IN_NETWORK_HEALTH)
+
+    return _compose_service_ready("creative-agent", compose_files)
+
+
+def _probe_adcp_health(
+    *,
+    ports: E2EPorts,
+    host: str,
+    compose_files: Sequence[str],
+) -> bool:
+    del compose_files  # adcp readiness is HTTP /health on the published port
+    # Live contract: producers emit {"mcp": …, "postgres": …} only — no admin/adcp keys.
+    port = ports.get("mcp")
+    if port is None:
+        return False
+    return _http_ok(f"http://{_http_authority(host, int(port))}/health")
+
+
+_PROBE_FUNCS: dict[str, _Probe] = {
+    "postgres": _probe_postgres,
+    "creative-agent": _probe_creative_agent,
+    "adcp_health": _probe_adcp_health,
+}
+
+# One home for the probe-set invariant (imported modules + arch guard share this).
+assert frozenset(_PROBE_FUNCS) >= frozenset(REQUIRED_E2E_PROBES), (
+    f"_PROBE_FUNCS keys {sorted(_PROBE_FUNCS)} must cover REQUIRED_E2E_PROBES {list(REQUIRED_E2E_PROBES)}"
+)
+
+
+def _wait_for_probes(
+    names: Sequence[str],
+    *,
+    ports: E2EPorts,
+    compose_files: Sequence[str],
+    host: str,
+    timeout_s: float = 60.0,
+    poll_interval_s: float = 2.0,
+) -> None:
+    """Ordered named probes; on timeout dump logs once and ``pytest.fail`` once.
+
+    Private seam for helper unit tests that need a narrowed name list. Production
+    callers use :func:`wait_for_e2e_stack`, which always runs ``REQUIRED_E2E_PROBES``.
+    """
+    probe_names = tuple(names)
+    if not probe_names:
+        raise ValueError("wait_for_e2e_stack requires a non-empty required probe list")
+
+    unknown = [name for name in probe_names if name not in _PROBE_FUNCS]
+    if unknown:
+        raise ValueError(f"Unknown E2E readiness probes: {unknown}")
+
+    print(f"Waiting for E2E stack readiness (probes={list(probe_names)}, timeout={timeout_s}s, host={host})...")
+    deadline = time.monotonic() + timeout_s
+    last_failed: str | None = None
+
+    while time.monotonic() < deadline:
+        last_failed = None
+        for name in probe_names:
+            ok = _PROBE_FUNCS[name](ports=ports, host=host, compose_files=compose_files)
+            if not ok:
+                last_failed = name
+                break
+        else:
+            print(f"✓ E2E stack ready ({', '.join(probe_names)})")
+            return
+
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            break
+        time.sleep(min(poll_interval_s, remaining))
+
+    failed = last_failed or probe_names[0]
+    _dump_e2e_compose_logs(compose_files)
+    compose_hint = ""
+    if failed == "creative-agent" and use_container_exec(host):
+        health, compose_err = _compose_service_health("creative-agent", compose_files)
+        if compose_err:
+            compose_hint = f"; compose_ps_diag={compose_err}"
+        else:
+            compose_hint = f"; compose_health={health!r}"
+    pytest.fail(
+        f"E2E stack not ready after {timeout_s}s — failed probe: {failed} "
+        f"(required order: {list(probe_names)}; host={host}; ports={dict(ports)}"
+        f"{compose_hint})"
+    )
+
+
+def wait_for_e2e_stack(
+    *,
+    ports: E2EPorts,
+    compose_files: Sequence[str] | None = None,
+    host: str | None = None,
+    timeout_s: float = 60.0,
+    poll_interval_s: float = 2.0,
+) -> None:
+    """Ordered required probes; on timeout dump logs once and ``pytest.fail`` once.
+
+    Always runs ``REQUIRED_E2E_PROBES`` in order and short-circuits on the first
+    miss each poll. Parallel "any healthy" semantics are intentionally forbidden
+    so creative-agent cannot be skipped when adcp ``/health`` is already up.
+    """
+    files = tuple(compose_files) if compose_files is not None else DEFAULT_E2E_COMPOSE_FILES
+    resolved_host = host if host is not None else e2e_host_default()
+    _wait_for_probes(
+        REQUIRED_E2E_PROBES,
+        ports=ports,
+        compose_files=files,
+        host=resolved_host,
+        timeout_s=timeout_s,
+        poll_interval_s=poll_interval_s,
+    )

--- a/tests/e2e/test_delivery_webhooks_e2e.py
+++ b/tests/e2e/test_delivery_webhooks_e2e.py
@@ -134,7 +134,10 @@ class TestDailyDeliveryWebhookFlow:
         set_live_adapter_behavior(live_server, manual_approval_required=False)
 
         # Wait for server readiness
-        wait_for_server_readiness(live_server["mcp"])
+        wait_for_server_readiness(
+            live_server["mcp"],
+            postgres_port=live_server["postgres_params"]["port"],
+        )
 
         async with make_mcp_client(live_server, token=test_auth_token) as client:
             # 1. Discover Product
@@ -181,13 +184,13 @@ class TestDailyDeliveryWebhookFlow:
 
             # 5. Wait for Webhook
             # The scheduler runs inside the container.
-            # We configured DELIVERY_WEBHOOK_INTERVAL=5 in conftest.py for E2E tests.
+            # DELIVERY_WEBHOOK_INTERVAL defaults to 5 via docker-compose.e2e.yml (${DELIVERY_WEBHOOK_INTERVAL:-5}); launchers may still export it.
             # It should trigger in 5 seconds.
 
             received = delivery_webhook_server["received"]
 
             # Wait for webhook. Each `received` access is now a readback HTTP round
-            # trip (salesagent-amht.3), not free like the old in-process shared
+            # trip (GH #1802), not free like the old in-process shared
             # list — wait_until's monotonic deadline keeps the actual wait bounded
             # at timeout_seconds regardless of readback latency, where an
             # iteration counter would silently drift past it.

--- a/tests/e2e/utils.py
+++ b/tests/e2e/utils.py
@@ -1,14 +1,23 @@
-import shutil
 import subprocess
 import time
 from contextlib import contextmanager
+from urllib.parse import urlparse
 
-import httpx
 import psycopg2
 import pytest
 from fastmcp.client import Client
 from fastmcp.client.transports import StreamableHttpTransport
 from sqlalchemy import select
+
+from tests.e2e.stack_readiness import (
+    DEFAULT_E2E_COMPOSE_FILES,
+    compose_available,
+    compose_exec_argv,
+    e2e_host_default,
+    e2e_ports,
+    use_container_exec,
+    wait_for_e2e_stack,
+)
 
 
 def make_mcp_client(
@@ -112,7 +121,7 @@ def wait_until(predicate, timeout_seconds: float, poll_interval: float = 0.5) ->
 
     A ``time.monotonic()`` deadline, not an iteration counter — the caller's
     ``predicate`` may itself be a network round trip (e.g. a webhook-capture
-    readback, salesagent-amht.3), so counting iterations under-waits whenever
+    readback, GH #1802), so counting iterations under-waits whenever
     a single check costs more than ``poll_interval``. Returns whether
     ``predicate`` was ever truthy, so a caller can assert on the return value
     instead of re-evaluating ``predicate`` a second time.
@@ -125,32 +134,32 @@ def wait_until(predicate, timeout_seconds: float, poll_interval: float = 0.5) ->
     return bool(predicate())
 
 
-def wait_for_server_readiness(mcp_url: str, timeout: int = 60):
-    """
-    Wait for the MCP server to become ready by checking its health endpoint.
+def wait_for_server_readiness(mcp_url: str, *, postgres_port: int, timeout: int = 60):
+    """Wait for the E2E stack via the shared readiness helper.
+
+    Thin wrapper around :func:`tests.e2e.stack_readiness.wait_for_e2e_stack`.
+    Derives host/port from ``mcp_url`` and takes an explicit ``postgres_port``
+    so the full ordered hard gate (postgres → creative-agent → adcp ``/health``)
+    applies without reading process-global env.
 
     Args:
         mcp_url: Base URL of the MCP server (e.g., http://localhost:8080)
+        postgres_port: Host-published (or in-network) Postgres port for the gate
         timeout: Maximum time to wait in seconds (default: 60)
 
     Raises:
-        pytest.fail if server does not become ready within timeout
+        pytest.fail if the stack does not become ready within timeout
     """
-    print(f"Waiting for MCP server at {mcp_url}...")
-    for _ in range(timeout):
-        try:
-            # Synchronous wait logic using httpx for simplicity in sync/async contexts
-            # But since we are in a helper, we can use sync httpx.Client or requests
-            with httpx.Client() as client:
-                resp = client.get(f"{mcp_url}/health", timeout=1.0)
-                if resp.status_code == 200:
-                    print("✓ Server is ready")
-                    return
-        except Exception:
-            pass
-        time.sleep(1)
+    parsed = urlparse(mcp_url)
+    if not parsed.hostname or parsed.port is None:
+        pytest.fail(f"wait_for_server_readiness: cannot derive host/port from mcp_url={mcp_url!r}")
 
-    pytest.fail(f"Server at {mcp_url} did not become ready within {timeout} seconds")
+    wait_for_e2e_stack(
+        ports=e2e_ports(mcp=int(parsed.port), postgres=int(postgres_port)),
+        compose_files=DEFAULT_E2E_COMPOSE_FILES,
+        host=parsed.hostname,
+        timeout_s=float(timeout),
+    )
 
 
 def force_approve_media_buy_in_db(live_server: dict, media_buy_id: str):
@@ -231,13 +240,12 @@ except Exception as e:
             print(f"Direct DB update failed: {ex}")
             raise prior_exc if prior_exc else ex
 
-    # Host path: pytest runs on the host and cannot reach the container DB
-    # directly, so exec the update inside the adcp-server container. In-network
-    # there is no docker-compose binary and the runner CAN reach the server DB by
-    # service name — go straight to the direct update (mirrors the conftest seed).
-    if shutil.which("docker-compose"):
+    # Host path: prefer compose exec into adcp-server (topology via
+    # use_container_exec / e2e_host). In-network runners reach the DB by
+    # service name — go straight to the direct update (mirrors conftest seed).
+    if use_container_exec(e2e_host_default()) and compose_available():
         try:
-            cmd = ["docker-compose", "exec", "-T", "adcp-server", "python", "-c", update_script]
+            cmd = compose_exec_argv("adcp-server", "python", "-c", update_script)
             result = subprocess.run(cmd, capture_output=True, text=True, check=True)
             print(result.stdout)
         except subprocess.CalledProcessError as e:

--- a/tests/unit/_architecture_helpers.py
+++ b/tests/unit/_architecture_helpers.py
@@ -132,6 +132,53 @@ def parse_module(path: Path) -> ast.Module:
     return _parse_cached(str(path), path.stat().st_mtime)
 
 
+def function_def(tree: ast.Module, name: str) -> ast.FunctionDef | ast.AsyncFunctionDef:
+    """Return the top-level function/async-function named ``name``."""
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == name:
+            return node
+    raise AssertionError(f"Function {name!r} not found at module top level")
+
+
+def assign_tuple_strs(tree: ast.Module, name: str) -> tuple[str, ...]:
+    """Return string elts from a top-level ``name = (...)`` / AnnAssign sequence."""
+    for node in tree.body:
+        if not isinstance(node, (ast.Assign, ast.AnnAssign)):
+            continue
+        targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+        if not any(isinstance(t, ast.Name) and t.id == name for t in targets):
+            continue
+        value = node.value
+        if isinstance(value, (ast.Tuple, ast.List)):
+            out: list[str] = []
+            for elt in value.elts:
+                if isinstance(elt, ast.Constant) and isinstance(elt.value, str):
+                    out.append(elt.value)
+            return tuple(out)
+    raise AssertionError(f"Constant sequence {name!r} not found")
+
+
+def call_names(tree: ast.AST) -> set[str]:
+    """Collect bare-name and attribute call targets under ``tree``."""
+    names: set[str] = set()
+    for node in iter_call_expressions(tree):
+        func = node.func
+        if isinstance(func, ast.Name):
+            names.add(func.id)
+        elif isinstance(func, ast.Attribute):
+            names.add(func.attr)
+    return names
+
+
+def imports_name_from(tree: ast.Module, module: str, name: str) -> bool:
+    """True when ``tree`` has ``from <module> import … <name> …``."""
+    for node in tree.body:
+        if isinstance(node, ast.ImportFrom) and node.module == module:
+            if any(alias.name == name for alias in node.names):
+                return True
+    return False
+
+
 def _base_expr_is_tenant(node: ast.expr) -> bool:
     """True when *node* is a tenant reference (``tenant``, ``self.tenant``, ``ctx.tenant``, …)."""
     if isinstance(node, ast.Name) and node.id == "tenant":
@@ -978,6 +1025,54 @@ def runtime_user_directives(lines: Iterable[str]) -> list[str]:
 # ---------------------------------------------------------------------------
 
 _PRE_COMMIT_CONFIG_PATH = Path(".pre-commit-config.yaml")
+
+
+def load_yaml_mapping(path: Path) -> dict[str, Any]:
+    """Read a YAML file and require a top-level mapping (shared guard preamble)."""
+    assert path.is_file(), f"missing {path}"
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert isinstance(data, dict), f"{path} must parse to a mapping"
+    return data
+
+
+def job_run_text(job: dict[str, Any]) -> str:
+    """Flatten all ``run:`` step bodies from a workflow job into one string."""
+    chunks: list[str] = []
+    for step in job.get("steps") or []:
+        if isinstance(step, dict) and isinstance(step.get("run"), str):
+            chunks.append(step["run"])
+    return "\n".join(chunks)
+
+
+def find_step(
+    steps: list[dict[str, Any]],
+    *,
+    name_contains: str | None = None,
+    uses_contains: str | None = None,
+) -> dict[str, Any] | None:
+    """Locate the first workflow step matching name/uses substring predicates.
+
+    Returns the matched step mapping, or ``None``. At least one of
+    ``name_contains`` / ``uses_contains`` must be provided; when both are set,
+    both must match. Callers that need the index should enumerate ``steps``
+    themselves (see ``_find_free_disk_step``).
+    """
+    if name_contains is None and uses_contains is None:
+        raise ValueError("at least one of name_contains, uses_contains is required")
+    for step in steps:
+        if not isinstance(step, dict):
+            continue
+        if name_contains is not None and name_contains not in str(step.get("name", "")):
+            continue
+        if uses_contains is not None and uses_contains not in str(step.get("uses", "")):
+            continue
+        return step
+    return None
+
+
+def ipr_agreement_workflow_path(repo: Path | None = None) -> Path:
+    """Canonical path to ``.github/workflows/ipr-agreement.yml``."""
+    return (repo or repo_root()) / ".github" / "workflows" / "ipr-agreement.yml"
 
 
 def load_pre_commit_config(path: Path | None = None, repo: Path | None = None) -> dict[str, Any]:

--- a/tests/unit/test_architecture_e2e_compose_tls_origins.py
+++ b/tests/unit/test_architecture_e2e_compose_tls_origins.py
@@ -1,11 +1,11 @@
 """Structural guard: one TLS terminator, every dialed origin https, one set of TLS material.
 
-salesagent-40qh gave the creative-agent origin in ``docker-compose.e2e.yml``
+GH #1802 gave the creative-agent origin in ``docker-compose.e2e.yml``
 a real TLS front specifically so ``ADCP_OUTBOUND_ALLOW_INSECURE`` could
-eventually close for it (salesagent-e6h0). salesagent-amht.2/.3/.4 then
+eventually close for it (GH #1802). GH #1802/.3/.4 then
 collapsed every outbound-only origin (creative-agent, webhook-capture) onto
 ONE shared ``tls-proxy`` front, one ``*.adcp.test`` alias per origin, one
-generated CA/leaf. salesagent-amht.5 generalizes what had been two
+generated CA/leaf. GH #1802 generalizes what had been two
 origin-specific checks (a CREATIVE_AGENT_URL-is-https check, and an
 ADCP_WEBHOOK_HOST-never-resurfaces check) into the structural invariant that
 made those checks correct in the first place, so a FUTURE origin (not just
@@ -45,7 +45,7 @@ def find_multiple_tls_terminators(compose: dict) -> list[str]:
 
     Exactly one service may mount ``nginx-tls-test.conf.template`` — the
     template that runs an ``ssl_certificate`` server block. A second service
-    mounting it is the tls-proxy-creative disease salesagent-amht.2 removed,
+    mounting it is the tls-proxy-creative disease GH #1802 removed,
     reappearing under a different name.
     """
     terminators = [
@@ -86,7 +86,7 @@ def find_non_https_adcp_test_origins(compose: dict) -> list[str]:
 def find_dead_webhook_env_var(compose: dict) -> list[str]:
     """Return one message per service that resurrects the deleted ``ADCP_WEBHOOK_HOST`` mechanism.
 
-    salesagent-amht.3 deleted this var entirely — the webhook-capture service
+    GH #1802 deleted this var entirely — the webhook-capture service
     is reachable at the fixed ``webhooks.adcp.test`` alias, never an
     env-configurable hostname. Its reappearance means a future change
     resurrected the per-launcher host-configuration disease this ticket removed.
@@ -108,7 +108,7 @@ def find_tls_material_outside_test_tls(compose: dict) -> list[str]:
     generator (``scripts/dev/gen_test_tls.py``), which writes under
     ``.test-tls/``. A ``.pem``/``.key`` path that does not mention
     ``.test-tls`` is a second, parallel TLS mechanism — exactly the disease
-    the in-process webhook-capture front was before salesagent-amht.3.
+    the in-process webhook-capture front was before GH #1802.
     """
     violations: list[str] = []
     for service_name, service in compose.get("services", {}).items():
@@ -136,7 +136,7 @@ def find_resurrected_allow_insecure_in_compose(compose: dict) -> list[str]:
 def find_resurrected_allow_insecure_in_src(src_root: Path) -> list[str]:
     """Return one message per ``src/`` file referencing the deleted ``ADCP_OUTBOUND_ALLOW_INSECURE`` hatch.
 
-    salesagent-e6h0 deleted this flag from ``src/`` entirely once every
+    GH #1802 deleted this flag from ``src/`` entirely once every
     outbound origin the server dials became TLS-fronted. Its reappearance —
     even as a bare string, since the only legitimate use was ``os.getenv``/
     ``os.environ`` lookups — means the escape hatch came back.

--- a/tests/unit/test_architecture_e2e_stack_readiness.py
+++ b/tests/unit/test_architecture_e2e_stack_readiness.py
@@ -1,0 +1,543 @@
+"""Architecture guard: E2E shared readiness helper contract.
+
+Pins that ``wait_for_e2e_stack`` is the SSOT for ordered E2E probes
+(postgres → creative-agent → adcp_health), that both ``docker_services_e2e``
+wait paths call it (via ``_export_and_wait``), that public callers cannot
+narrow the hard gate, and that ``wait_for_server_readiness`` delegates to
+``wait_for_e2e_stack``.
+
+The inline HTTP poll-loop detector only flags ``.get(...)`` URL arguments that
+literally embed ``/health`` (JoinedStr / Constant / BinOp *operands*). Variable-
+hoisted URLs are out of scope; delegation is pinned via the call-name check.
+
+CI pre-start / ``compose up --wait`` contracts live in
+``test_architecture_ci_suite_coverage.py`` — this module pins the **Python**
+helper contract only.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from tests.e2e.stack_readiness import REQUIRED_E2E_PROBES
+from tests.unit._architecture_helpers import (
+    assign_tuple_strs,
+    call_names,
+    function_def,
+    imports_name_from,
+    iter_call_expressions,
+    iter_git_tracked_files,
+    parse_module,
+    rel,
+    repo_root,
+)
+
+_HELPER_REL = "tests/e2e/stack_readiness.py"
+_CONFTEST_REL = "tests/e2e/conftest.py"
+_UTILS_REL = "tests/e2e/utils.py"
+_REQUIRED_ORDER = ("postgres", "creative-agent", "adcp_health")
+_COMPOSE_FILES = ("docker-compose.e2e.yml", "docker-compose.e2e.ports.yml")
+_FLOOR_RELS = frozenset({_HELPER_REL, _CONFTEST_REL, _UTILS_REL})
+
+
+def _tracked_rel_paths(repo: Path) -> set[str]:
+    return {str(path.relative_to(repo)) for path in iter_git_tracked_files(repo)}
+
+
+def _parse_tracked(repo: Path, file_path: str) -> ast.Module:
+    path = repo / file_path
+    assert path.is_file(), f"Expected tracked module missing on disk: {file_path}"
+    assert rel(path) == file_path, f"Expected repo-relative path {file_path!r}, got {rel(path)!r}"
+    return parse_module(path)
+
+
+def _e2e_py_rels(repo: Path) -> list[str]:
+    """Git-tracked ``tests/e2e/**/*.py`` paths (repo-relative), sorted."""
+    out: list[str] = []
+    for path in iter_git_tracked_files(repo):
+        try:
+            file_rel = path.relative_to(repo).as_posix()
+        except ValueError:
+            continue
+        if file_rel.startswith("tests/e2e/") and file_rel.endswith(".py"):
+            out.append(file_rel)
+    return sorted(out)
+
+
+def _binop_operand_contains_health(node: ast.AST) -> bool:
+    """True when a BinOp tree has ``/health`` in a string Constant operand."""
+    if isinstance(node, ast.Constant) and isinstance(node.value, str) and "/health" in node.value:
+        return True
+    if isinstance(node, ast.BinOp):
+        return _binop_operand_contains_health(node.left) or _binop_operand_contains_health(node.right)
+    return False
+
+
+def _http_poll_loop_in_function(func: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+    """True if the function body still owns an HTTP health poll loop (dedupe breach).
+
+    Detects sleep + ``.get(...)`` whose URL arg literally embeds ``/health``
+    (f-string JoinedStr, string Constant, or BinOp with ``/health`` in an
+    operand). Does not follow variable-hoisted URLs.
+    """
+    has_sleep = False
+    has_health_get = False
+    for node in iter_call_expressions(func):
+        # time.sleep(...) / sleep(...)
+        if isinstance(node.func, ast.Attribute) and node.func.attr == "sleep":
+            has_sleep = True
+        if isinstance(node.func, ast.Name) and node.func.id == "sleep":
+            has_sleep = True
+        # client.get(.../health) or requests.get(.../health)
+        if isinstance(node.func, ast.Attribute) and node.func.attr == "get":
+            for arg in node.args:
+                if isinstance(arg, ast.JoinedStr):
+                    if any(
+                        isinstance(v, ast.Constant) and isinstance(v.value, str) and "/health" in v.value
+                        for v in arg.values
+                    ):
+                        has_health_get = True
+                if isinstance(arg, ast.Constant) and isinstance(arg.value, str) and "/health" in arg.value:
+                    has_health_get = True
+                if isinstance(arg, ast.BinOp) and _binop_operand_contains_health(arg):
+                    has_health_get = True
+    return has_sleep and has_health_get
+
+
+def _string_constant_present(tree: ast.Module, value: str) -> bool:
+    """True when any string ``Constant`` node in ``tree`` equals ``value``."""
+    return any(isinstance(node, ast.Constant) and node.value == value for node in ast.walk(tree))
+
+
+def _calls_named_in(stmts: list[ast.stmt], name: str) -> list[ast.Call]:
+    out: list[ast.Call] = []
+    for stmt in stmts:
+        out.extend(iter_call_expressions(stmt, name=name))
+    return out
+
+
+def _use_existing_if(func: ast.FunctionDef | ast.AsyncFunctionDef) -> ast.If:
+    """Return the top-level ``if use_existing_services`` split in ``docker_services_e2e``."""
+    for stmt in func.body:
+        if isinstance(stmt, ast.If):
+            return stmt
+    raise AssertionError("docker_services_e2e must have a top-level if/else for verify-only vs standalone")
+
+
+def _wait_calls_by_branch(tree: ast.Module) -> tuple[list[ast.Call], list[ast.Call]]:
+    """Return ``_export_and_wait`` calls in verify-only (then) and standalone (else)."""
+    func = function_def(tree, "docker_services_e2e")
+    split = _use_existing_if(func)
+    then_calls = _calls_named_in(split.body, "_export_and_wait")
+    else_calls = _calls_named_in(split.orelse, "_export_and_wait")
+    return then_calls, else_calls
+
+
+def _call_passes_required_kw(call: ast.Call) -> bool:
+    """True when a ``wait_for_e2e_stack`` / ``_wait_for_probes`` call passes ``required=``."""
+    return any(kw.arg == "required" for kw in call.keywords)
+
+
+def _compose_argv_star_followed_by_verb(node: ast.AST, verb: str) -> bool:
+    """True for ``[*compose_argv(...), "<verb>", ...]`` list/tuple displays.
+
+    Catches re-inlined ``exec`` / ``down`` tails that bypass ``compose_exec_argv`` /
+    ``compose_down_argv``.
+    """
+    if not isinstance(node, (ast.List, ast.Tuple)):
+        return False
+    elts = node.elts
+    if len(elts) < 2:
+        return False
+    first = elts[0]
+    if not isinstance(first, ast.Starred):
+        return False
+    starred = first.value
+    if not isinstance(starred, ast.Call):
+        return False
+    func = starred.func
+    if isinstance(func, ast.Name) and func.id != "compose_argv":
+        return False
+    if isinstance(func, ast.Attribute) and func.attr != "compose_argv":
+        return False
+    if not (isinstance(func, (ast.Name, ast.Attribute))):
+        return False
+    second = elts[1]
+    return isinstance(second, ast.Constant) and second.value == verb
+
+
+def _has_reinlined_compose_verb(tree: ast.Module, verb: str) -> bool:
+    return any(_compose_argv_star_followed_by_verb(node, verb) for node in ast.walk(tree))
+
+
+# Shared predicates — production tests and self-tests call the same checkers.
+def _assert_required_probe_order(order: tuple[str, ...]) -> None:
+    assert order == _REQUIRED_ORDER, (
+        f"REQUIRED_E2E_PROBES must be {_REQUIRED_ORDER}, got {order} — creative-agent hard gate cannot silently drop"
+    )
+
+
+def _assert_both_wait_branches(then_calls: list[ast.Call], else_calls: list[ast.Call]) -> None:
+    assert len(then_calls) >= 1, "docker_services_e2e verify-only branch (if body) must call _export_and_wait"
+    assert len(else_calls) >= 1, "docker_services_e2e standalone branch (else) must call _export_and_wait"
+
+
+def _assert_no_inline_health_poll(func: ast.FunctionDef | ast.AsyncFunctionDef, *, where: str) -> None:
+    assert not _http_poll_loop_in_function(func), (
+        f"{where} must not keep an inline HTTP /health poll loop; use wait_for_e2e_stack only"
+    )
+
+
+def _helper_references_log_dump_for_creative_agent(tree: ast.Module) -> bool:
+    dump = function_def(tree, "_dump_e2e_compose_logs")
+    # Prefer the service tuple constant when present.
+    try:
+        services = assign_tuple_strs(tree, "_LOG_DUMP_SERVICES")
+        if "creative-agent" in services:
+            return True
+    except AssertionError:
+        pass
+    source = ast.unparse(dump)
+    return "creative-agent" in source and "logs" in source
+
+
+def _assert_no_public_required_kw(tree: ast.Module, *, where: str) -> None:
+    """Public ``wait_for_e2e_stack`` must not accept ``required=``."""
+    func = function_def(tree, "wait_for_e2e_stack")
+    arg_names = {a.arg for a in func.args.args} | {a.arg for a in func.args.kwonlyargs}
+    assert "required" not in arg_names, (
+        f"{where}: wait_for_e2e_stack must not expose public required= (always REQUIRED_E2E_PROBES)"
+    )
+
+
+@pytest.mark.arch_guard
+class TestE2EStackReadinessHelperContract:
+    """Pin the shared readiness helper contract (non-vacuous)."""
+
+    def test_tracked_modules_exist(self):
+        repo = repo_root()
+        tracked = _tracked_rel_paths(repo)
+        assert tracked, "git ls-files returned no files — scan would be vacuous"
+        for file_rel in _FLOOR_RELS:
+            assert file_rel in tracked, f"{file_rel} must be git-tracked for the readiness contract guard"
+
+    def test_helper_exports_wait_for_e2e_stack_and_probe_order(self):
+        repo = repo_root()
+        tree = _parse_tracked(repo, _HELPER_REL)
+        function_def(tree, "wait_for_e2e_stack")
+        function_def(tree, "_wait_for_probes")
+        order = assign_tuple_strs(tree, "REQUIRED_E2E_PROBES")
+        _assert_required_probe_order(order)
+        _assert_no_public_required_kw(tree, where=_HELPER_REL)
+        wait_fn = function_def(tree, "wait_for_e2e_stack")
+        assert "REQUIRED_E2E_PROBES" in ast.unparse(wait_fn), (
+            "wait_for_e2e_stack must always pass REQUIRED_E2E_PROBES into _wait_for_probes"
+        )
+
+    def test_required_probe_order_matches_runtime(self):
+        # Probe-registry coverage is asserted once at module import in stack_readiness
+        # (single home). This guard only pins the ordered tuple identity.
+        assert tuple(REQUIRED_E2E_PROBES) == _REQUIRED_ORDER
+
+    def test_compose_files_ssot_exported_and_imported(self):
+        repo = repo_root()
+        helper = _parse_tracked(repo, _HELPER_REL)
+        conftest = _parse_tracked(repo, _CONFTEST_REL)
+        utils = _parse_tracked(repo, _UTILS_REL)
+        files = assign_tuple_strs(helper, "DEFAULT_E2E_COMPOSE_FILES")
+        assert files == _COMPOSE_FILES, f"DEFAULT_E2E_COMPOSE_FILES must be {_COMPOSE_FILES}, got {files}"
+        assert imports_name_from(conftest, "tests.e2e.stack_readiness", "DEFAULT_E2E_COMPOSE_FILES"), (
+            "conftest must import DEFAULT_E2E_COMPOSE_FILES from stack_readiness (no duplicate tuple)"
+        )
+        assert imports_name_from(conftest, "tests.e2e.stack_readiness", "compose_argv"), (
+            "conftest must import public compose_argv (not underscore-private)"
+        )
+        assert imports_name_from(conftest, "tests.e2e.stack_readiness", "compose_available"), (
+            "conftest must import public compose_available (not underscore-private)"
+        )
+        assert imports_name_from(conftest, "tests.e2e.stack_readiness", "use_container_exec"), (
+            "conftest must import use_container_exec (topology seam for seed exec)"
+        )
+        assert imports_name_from(conftest, "tests.e2e.stack_readiness", "e2e_ports"), (
+            "conftest must import e2e_ports (ports constructor SSOT)"
+        )
+        assert imports_name_from(utils, "tests.e2e.stack_readiness", "DEFAULT_E2E_COMPOSE_FILES"), (
+            "utils must import DEFAULT_E2E_COMPOSE_FILES from stack_readiness"
+        )
+        assert imports_name_from(utils, "tests.e2e.stack_readiness", "use_container_exec"), (
+            "utils must import use_container_exec (topology seam for media_buy update)"
+        )
+        assert imports_name_from(utils, "tests.e2e.stack_readiness", "e2e_ports"), (
+            "utils must import e2e_ports (ports constructor SSOT)"
+        )
+        assert imports_name_from(conftest, "tests.e2e.stack_readiness", "e2e_host_default"), (
+            "conftest must import e2e_host_default from stack_readiness (host SSOT)"
+        )
+        assert imports_name_from(conftest, "tests.e2e.stack_readiness", "e2e_db_url_default"), (
+            "conftest must import e2e_db_url_default from stack_readiness (DB URL SSOT)"
+        )
+        assert imports_name_from(conftest, "tests.e2e.stack_readiness", "e2e_db_url_build"), (
+            "conftest must import e2e_db_url_build for setdefault seed DSN (no second literal)"
+        )
+        function_def(helper, "e2e_host_default")
+        function_def(helper, "resolve_e2e_db_endpoint")
+        function_def(helper, "e2e_db_url_default")
+        function_def(helper, "e2e_db_url_build")
+        function_def(helper, "_e2e_db_env_url")
+        function_def(helper, "in_network")
+        function_def(helper, "use_container_exec")
+        function_def(helper, "e2e_ports")
+        function_def(helper, "health_of")
+        endpoint_fn = function_def(helper, "resolve_e2e_db_endpoint")
+        url_fn = function_def(helper, "e2e_db_url_default")
+        assert "_e2e_db_env_url" in call_names(endpoint_fn), (
+            "resolve_e2e_db_endpoint must call _e2e_db_env_url (DB env-chain SSOT)"
+        )
+        assert "_e2e_db_env_url" in call_names(url_fn), (
+            "e2e_db_url_default must call _e2e_db_env_url (DB env-chain SSOT)"
+        )
+        # No private duplicate constant in conftest.
+        with pytest.raises(AssertionError):
+            assign_tuple_strs(conftest, "_E2E_COMPOSE_FILES")
+
+    def test_compose_exec_and_down_argv_ssot(self):
+        """compose_exec_argv/compose_down_argv own the exec/down verb+service+gate unit.
+
+        Guards the Should-fix regression where ``force_approve`` and the two
+        ``down -v`` teardown sites each hand-rolled ``"exec", "-T", "adcp-server"``
+        / ``"down", "-v"`` on top of ``compose_argv`` instead of sharing one seam.
+        """
+        repo = repo_root()
+        helper = _parse_tracked(repo, _HELPER_REL)
+        conftest = _parse_tracked(repo, _CONFTEST_REL)
+        utils = _parse_tracked(repo, _UTILS_REL)
+        function_def(helper, "compose_exec_argv")
+        function_def(helper, "compose_down_argv")
+
+        assert imports_name_from(conftest, "tests.e2e.stack_readiness", "compose_exec_argv"), (
+            f"{_CONFTEST_REL} must import compose_exec_argv from stack_readiness (exec SSOT)"
+        )
+        assert imports_name_from(conftest, "tests.e2e.stack_readiness", "compose_down_argv"), (
+            f"{_CONFTEST_REL} must import compose_down_argv from stack_readiness (down SSOT)"
+        )
+        assert imports_name_from(utils, "tests.e2e.stack_readiness", "compose_exec_argv"), (
+            f"{_UTILS_REL} must import compose_exec_argv from stack_readiness (exec SSOT)"
+        )
+
+        for tree, where in ((conftest, _CONFTEST_REL), (utils, _UTILS_REL)):
+            assert not _string_constant_present(tree, "-T"), (
+                f'{where} must route compose exec through compose_exec_argv (SSOT), not re-inline the "-T" exec flag'
+            )
+            assert not _has_reinlined_compose_verb(tree, "exec"), (
+                f"{where} must not re-inline [*compose_argv(...), 'exec', ...] — use compose_exec_argv"
+            )
+            assert not _has_reinlined_compose_verb(tree, "down"), (
+                f"{where} must not re-inline [*compose_argv(...), 'down', ...] — use compose_down_argv"
+            )
+
+    def test_docker_services_e2e_calls_helper_on_both_wait_paths(self):
+        repo = repo_root()
+        tree = _parse_tracked(repo, _CONFTEST_REL)
+        then_calls, else_calls = _wait_calls_by_branch(tree)
+        _assert_both_wait_branches(then_calls, else_calls)
+        export_fn = function_def(tree, "_export_and_wait")
+        assert "wait_for_e2e_stack" in call_names(export_fn), "_export_and_wait must delegate to wait_for_e2e_stack"
+        # No residual inline /health-only poll loops inside the fixture.
+        func = function_def(tree, "docker_services_e2e")
+        _assert_no_inline_health_poll(func, where="docker_services_e2e")
+
+    def test_e2e_tree_has_no_divergent_wait_or_public_required(self):
+        """Scan all tracked tests/e2e/**/*.py — floor of three SSOT modules, then full tree."""
+        repo = repo_root()
+        e2e_rels = _e2e_py_rels(repo)
+        assert _FLOOR_RELS <= set(e2e_rels), (
+            f"e2e scan floor {_FLOOR_RELS} must be present in tracked tests/e2e/**/*.py, got {e2e_rels[:20]}..."
+        )
+        assert len(e2e_rels) >= 3, "e2e scan would be vacuous with fewer than three tracked modules"
+
+        for file_rel in e2e_rels:
+            tree = _parse_tracked(repo, file_rel)
+            for call in iter_call_expressions(tree, name="wait_for_e2e_stack"):
+                assert not _call_passes_required_kw(call), (
+                    f"{file_rel}: wait_for_e2e_stack must not pass required= (hard gate is always REQUIRED_E2E_PROBES)"
+                )
+            # Divergent inline /health poll loops are forbidden outside the helper's
+            # own probe implementations (those use httpx without sleep+get shape).
+            if file_rel == _HELPER_REL:
+                continue
+            for node in tree.body:
+                if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    _assert_no_inline_health_poll(node, where=f"{file_rel}:{node.name}")
+
+    def test_wait_for_server_readiness_delegates_to_helper(self):
+        repo = repo_root()
+        tree = _parse_tracked(repo, _UTILS_REL)
+        func = function_def(tree, "wait_for_server_readiness")
+        assert "wait_for_e2e_stack" in call_names(func), (
+            "wait_for_server_readiness must call wait_for_e2e_stack (delegation, not a second oracle)"
+        )
+        assert "e2e_ports" in call_names(func), "wait_for_server_readiness must build ports via e2e_ports"
+        arg_names = {a.arg for a in func.args.args} | {a.arg for a in func.args.kwonlyargs}
+        assert "postgres_port" in arg_names, (
+            "wait_for_server_readiness must take explicit postgres_port (no POSTGRES_PORT env side-channel)"
+        )
+        _assert_no_inline_health_poll(func, where="wait_for_server_readiness")
+
+    def test_failure_path_dumps_creative_agent_logs(self):
+        repo = repo_root()
+        tree = _parse_tracked(repo, _HELPER_REL)
+        assert _helper_references_log_dump_for_creative_agent(tree), (
+            "readiness failure path must dump creative-agent compose logs"
+        )
+        wait_fn = function_def(tree, "_wait_for_probes")
+        assert "_dump_e2e_compose_logs" in call_names(wait_fn), (
+            "_wait_for_probes must call _dump_e2e_compose_logs on timeout"
+        )
+
+
+@pytest.mark.arch_guard
+class TestE2EStackReadinessGuardSelfTest:
+    """Mutation-style self-tests so a detector blind spot fails this module."""
+
+    def test_probe_order_detector_rejects_missing_creative_agent(self):
+        bad = ast.parse('REQUIRED_E2E_PROBES = ("postgres", "adcp_health")\n')
+        order = assign_tuple_strs(bad, "REQUIRED_E2E_PROBES")
+        with pytest.raises(AssertionError):
+            _assert_required_probe_order(order)
+
+    def test_both_branches_detector_rejects_double_call_in_then_only(self):
+        src = (
+            "def docker_services_e2e(request):\n"
+            "    if True:\n"
+            "        _export_and_wait(ports={}, timeout_s=60)\n"
+            "        _export_and_wait(ports={}, timeout_s=60)\n"
+            "    else:\n"
+            "        pass\n"
+        )
+        then_calls, else_calls = _wait_calls_by_branch(ast.parse(src))
+        assert len(then_calls) == 2
+        assert len(else_calls) == 0
+        with pytest.raises(AssertionError):
+            _assert_both_wait_branches(then_calls, else_calls)
+
+    def test_public_required_detector_rejects_kwonly_required(self):
+        src = (
+            "REQUIRED_E2E_PROBES = ('postgres', 'creative-agent', 'adcp_health')\n"
+            "def wait_for_e2e_stack(*, ports, required=REQUIRED_E2E_PROBES):\n"
+            "    pass\n"
+        )
+        with pytest.raises(AssertionError):
+            _assert_no_public_required_kw(ast.parse(src), where="known-bad")
+
+    def test_required_kw_call_detector_flags_required_pass(self):
+        src = 'wait_for_e2e_stack(ports={}, required=("adcp_health",))\n'
+        call = next(iter_call_expressions(ast.parse(src), name="wait_for_e2e_stack"))
+        assert _call_passes_required_kw(call)
+
+    def test_required_kw_call_detector_accepts_omitted(self):
+        src = "wait_for_e2e_stack(ports={})\n"
+        call = next(iter_call_expressions(ast.parse(src), name="wait_for_e2e_stack"))
+        assert not _call_passes_required_kw(call)
+
+    def test_inline_health_loop_detector_flags_binop_with_health(self):
+        src = (
+            "import time\n"
+            "import requests\n"
+            "def docker_services_e2e():\n"
+            "    for _ in range(30):\n"
+            "        requests.get('http://localhost:8000' + '/health')\n"
+            "        time.sleep(2)\n"
+        )
+        func = function_def(ast.parse(src), "docker_services_e2e")
+        assert _http_poll_loop_in_function(func)
+
+    def test_inline_health_loop_detector_flags_fstring_health(self):
+        src = (
+            "import time\n"
+            "import requests\n"
+            "def docker_services_e2e():\n"
+            "    u = 'http://localhost:8000'\n"
+            "    for _ in range(30):\n"
+            '        requests.get(f"{u}/health")\n'
+            "        time.sleep(2)\n"
+        )
+        func = function_def(ast.parse(src), "docker_services_e2e")
+        assert _http_poll_loop_in_function(func)
+
+    def test_inline_health_loop_detector_flags_constant_health(self):
+        src = (
+            "import time\n"
+            "import requests\n"
+            "def docker_services_e2e():\n"
+            "    for _ in range(30):\n"
+            "        requests.get('http://localhost:8000/health')\n"
+            "        time.sleep(2)\n"
+        )
+        func = function_def(ast.parse(src), "docker_services_e2e")
+        assert _http_poll_loop_in_function(func)
+
+    def test_inline_health_loop_detector_flags_bare_name_sleep(self):
+        # Bare ``sleep(...)`` from ``from time import sleep`` — Name arm twin of Attribute.
+        src = (
+            "from time import sleep\n"
+            "import requests\n"
+            "def docker_services_e2e():\n"
+            "    for _ in range(30):\n"
+            "        requests.get('http://localhost:8000/health')\n"
+            "        sleep(2)\n"
+        )
+        func = function_def(ast.parse(src), "docker_services_e2e")
+        assert _http_poll_loop_in_function(func)
+
+    def test_inline_health_loop_detector_ignores_binop_without_health(self):
+        # sleep + .get(BinOp) must not flag when no operand contains /health.
+        src = (
+            "import time\n"
+            "def docker_services_e2e():\n"
+            "    a, b = 'x', 'y'\n"
+            "    for _ in range(30):\n"
+            "        d.get(a + b)\n"
+            "        time.sleep(2)\n"
+        )
+        func = function_def(ast.parse(src), "docker_services_e2e")
+        assert not _http_poll_loop_in_function(func)
+
+    def test_inline_exec_flag_detector_flags_reinlined_dash_t(self):
+        src = 'cmd = [*compose_argv(files), "exec", "-T", "adcp-server", "python"]\n'
+        tree = ast.parse(src)
+        assert _string_constant_present(tree, "-T")
+        assert _has_reinlined_compose_verb(tree, "exec")
+
+    def test_inline_exec_flag_detector_ignores_seam_only_module(self):
+        src = 'cmd = compose_exec_argv("adcp-server", "python")\n'
+        tree = ast.parse(src)
+        assert not _string_constant_present(tree, "-T")
+        assert not _has_reinlined_compose_verb(tree, "exec")
+
+    def test_inline_down_detector_flags_reinlined_down_v(self):
+        src = 'cmd = [*compose_argv((BASE_E2E_COMPOSE_FILE,)), "down", "-v"]\n'
+        tree = ast.parse(src)
+        assert _has_reinlined_compose_verb(tree, "down")
+
+    def test_inline_down_detector_ignores_seam_only_module(self):
+        src = "cmd = compose_down_argv()\n"
+        assert not _has_reinlined_compose_verb(ast.parse(src), "down")
+
+    def test_delegate_detector_rejects_poll_only_wrapper(self):
+        src = (
+            "import time\n"
+            "import httpx\n"
+            "def wait_for_server_readiness(mcp_url, timeout=60):\n"
+            "    for _ in range(timeout):\n"
+            "        with httpx.Client() as client:\n"
+            "            client.get(mcp_url + '/health')\n"
+            "        time.sleep(1)\n"
+        )
+        func = function_def(ast.parse(src), "wait_for_server_readiness")
+        assert _http_poll_loop_in_function(func)
+        assert "wait_for_e2e_stack" not in call_names(func)
+        with pytest.raises(AssertionError):
+            _assert_no_inline_health_poll(func, where="known-bad-wrapper")

--- a/tests/unit/test_architecture_helpers_contract.py
+++ b/tests/unit/test_architecture_helpers_contract.py
@@ -131,12 +131,60 @@ def test_assert_anchor_consistency_flags_intra_file_drift() -> None:
 
 
 # ---------------------------------------------------------------------------
-# iter_git_tracked_files fallback (PR #1567 round-3): the filesystem-walk
-# fallback must be LOUD (RuntimeWarning) and hermetic w.r.t. untracked local
-# dirs (.claude/ notes were producing spurious version-anchor guard failures
-# in the in-network container, where the bind-mounted worktree's .git
-# back-reference is unreachable and the fallback engages).
+# Accessors promoted into _architecture_helpers (PR #1699): positive + negative
+# contracts so a stubbed ``return True`` / wrong-name miss cannot stay green.
 # ---------------------------------------------------------------------------
+
+
+@pytest.mark.arch_guard
+def test_function_def_positive_and_negative() -> None:
+    from tests.unit._architecture_helpers import function_def
+
+    tree = ast.parse("def alpha():\n    pass\nasync def beta():\n    pass\n")
+    assert function_def(tree, "alpha").name == "alpha"
+    assert function_def(tree, "beta").name == "beta"
+    with pytest.raises(AssertionError, match="Function 'missing'"):
+        function_def(tree, "missing")
+
+
+@pytest.mark.arch_guard
+def test_assign_tuple_strs_positive_and_negative() -> None:
+    from tests.unit._architecture_helpers import assign_tuple_strs
+
+    tree = ast.parse('NAMES = ("a", "b")\nOTHER = 1\n')
+    assert assign_tuple_strs(tree, "NAMES") == ("a", "b")
+    with pytest.raises(AssertionError, match="Constant sequence 'OTHER'"):
+        assign_tuple_strs(tree, "OTHER")
+    with pytest.raises(AssertionError, match="Constant sequence 'missing'"):
+        assign_tuple_strs(tree, "missing")
+
+
+@pytest.mark.arch_guard
+def test_call_names_positive_and_negative() -> None:
+    from tests.unit._architecture_helpers import call_names
+
+    tree = ast.parse("f()\nx.g()\n")
+    names = call_names(tree)
+    assert "f" in names
+    assert "g" in names
+    assert "missing" not in names
+    assert call_names(ast.parse("x = 1\n")) == set()
+
+
+@pytest.mark.arch_guard
+def test_imports_name_from_positive_and_negative() -> None:
+    from tests.unit._architecture_helpers import imports_name_from
+
+    tree = ast.parse("from tests.e2e.stack_readiness import compose_argv, e2e_ports\nimport os\n")
+    assert imports_name_from(tree, "tests.e2e.stack_readiness", "compose_argv") is True
+    assert imports_name_from(tree, "tests.e2e.stack_readiness", "e2e_ports") is True
+    # Wrong name on the right module.
+    assert imports_name_from(tree, "tests.e2e.stack_readiness", "missing") is False
+    # Wrong module.
+    assert imports_name_from(tree, "tests.e2e.other", "compose_argv") is False
+    # Plain ``import os`` is not ImportFrom — must not count as importing ``os``.
+    assert imports_name_from(tree, "os", "path") is False
+    assert imports_name_from(ast.parse("import os\n"), "os", "os") is False
 
 
 @pytest.mark.arch_guard

--- a/tests/unit/test_bdd_e2e_stack_probe.py
+++ b/tests/unit/test_bdd_e2e_stack_probe.py
@@ -1,6 +1,6 @@
 """The bdd_e2e stack probe must tell "no stack" apart from "broken TLS".
 
-salesagent-tgzb design step 7, promoted into scope by the disease scan.
+GH #1802 design step 7, promoted into scope by the disease scan.
 
 ``tests/bdd/conftest.py``'s ``e2e_stack`` fixture health-checks the stack and,
 today, ends in ``except Exception: return None``. Returning ``None`` means "the
@@ -9,7 +9,7 @@ against the PLAINTEXT config. So a certificate-verification failure — a broken
 test rig — is indistinguishable from a stack that was never started, and an
 https scenario grades the http branch while reporting green.
 
-That is precisely the vacuity salesagent-tgzb exists to remove, reintroduced by
+That is precisely the vacuity GH #1802 exists to remove, reintroduced by
 its own plumbing, which is why the fix is graded here rather than assumed.
 
 The network is the ONLY thing stubbed: ``httpx.get`` is replaced with a raiser
@@ -123,7 +123,7 @@ def test_a_tls_verification_failure_is_raised_and_never_reported_as_an_absent_st
 
     If this returns ``None``, the fixture hands back the plaintext config and an
     https scenario grades the http branch while reporting green — the single
-    failure mode salesagent-tgzb was opened to eliminate.
+    failure mode GH #1802 was opened to eliminate.
     """
     _configured_env(monkeypatch)
     failure = failure_factory()

--- a/tests/unit/test_e2e_stack_readiness_behavior.py
+++ b/tests/unit/test_e2e_stack_readiness_behavior.py
@@ -1,0 +1,642 @@
+"""Behavioral oracles for E2E compose health readiness (host-path contract).
+
+Complements the AST guard in ``test_architecture_e2e_stack_readiness``: that
+module pins wiring; this module proves the success predicate and wait failure
+naming so a dead ``"running"`` fallback cannot silently pass probes.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from collections.abc import Iterator
+from contextlib import contextmanager
+from unittest.mock import MagicMock, call, patch
+
+import httpx
+import pytest
+
+from tests.e2e.stack_readiness import (
+    _PROBE_FUNCS,
+    BASE_E2E_COMPOSE_FILE,
+    REQUIRED_E2E_PROBES,
+    ServiceHealth,
+    _compose_reports_ready,
+    _compose_service_health,
+    _http_authority,
+    _Probe,
+    _probe_adcp_health,
+    _probe_creative_agent,
+    _probe_postgres,
+    _wait_for_probes,
+    compose_argv,
+    compose_available,
+    compose_down_argv,
+    compose_exec_argv,
+    e2e_db_url_build,
+    e2e_db_url_default,
+    e2e_host_default,
+    e2e_ports,
+    health_of,
+    in_network,
+    use_container_exec,
+    wait_for_e2e_stack,
+)
+from tests.e2e.utils import wait_for_server_readiness
+
+
+def _ps_completed(stdout: str, *, returncode: int = 0) -> MagicMock:
+    result = MagicMock()
+    result.returncode = returncode
+    result.stdout = stdout
+    result.stderr = ""
+    return result
+
+
+@contextmanager
+def _compose_ps_patches(payload: str, *, returncode: int = 0) -> Iterator[None]:
+    """Shared compose-available + subprocess.run patch seam for health oracles."""
+    with (
+        patch("tests.e2e.stack_readiness.compose_available", return_value=True),
+        patch(
+            "tests.e2e.stack_readiness.subprocess.run",
+            return_value=_ps_completed(payload, returncode=returncode),
+        ),
+    ):
+        yield
+
+
+def _health_for(payload: str, *, returncode: int = 0) -> tuple[ServiceHealth | None, str | None]:
+    """Patch compose ps and return ``_compose_service_health`` for creative-agent."""
+    with _compose_ps_patches(payload, returncode=returncode):
+        return _compose_service_health("creative-agent", ("docker-compose.e2e.yml",))
+
+
+def _stub_probes(
+    *,
+    postgres: bool = True,
+    creative_agent: bool = True,
+    adcp_health: bool = True,
+) -> dict[str, _Probe]:
+    """Build a stub ``_PROBE_FUNCS`` overlay keyed from ``REQUIRED_E2E_PROBES``."""
+    outcomes = {
+        "postgres": postgres,
+        "creative-agent": creative_agent,
+        "adcp_health": adcp_health,
+    }
+    assert frozenset(outcomes) == frozenset(REQUIRED_E2E_PROBES), (
+        f"_stub_probes keys {sorted(outcomes)} must match REQUIRED_E2E_PROBES {list(REQUIRED_E2E_PROBES)}"
+    )
+
+    def _make(ok: bool) -> _Probe:
+        def _probe(**_kw: object) -> bool:
+            return ok
+
+        return _probe
+
+    return {name: _make(outcomes[name]) for name in REQUIRED_E2E_PROBES}
+
+
+class TestHealthOfContract:
+    """Pure ``health_of`` table — no mocks; ``unhealthy`` must not grant ready."""
+
+    @pytest.mark.parametrize(
+        ("record", "expected"),
+        [
+            ({"Health": "healthy", "State": "running"}, ServiceHealth.HEALTHY),
+            ({"Health": "unhealthy", "State": "running"}, ServiceHealth.UNHEALTHY),
+            ({"Health": "starting", "State": "running"}, ServiceHealth.STARTING),
+            ({"Health": "weird", "State": "running"}, ServiceHealth.UNKNOWN),
+            ({"Health": "", "State": "running"}, ServiceHealth.UNKNOWN),
+            ({"Health": "", "State": "running (healthy)"}, ServiceHealth.HEALTHY),
+            ({"Health": "", "State": "running (unhealthy)"}, ServiceHealth.UNHEALTHY),
+            ({"Health": "", "State": "running (starting)"}, ServiceHealth.STARTING),
+            ({"Health": "", "Status": "Up 5 seconds (healthy)"}, ServiceHealth.HEALTHY),
+            ({"Health": "", "Status": "Up"}, ServiceHealth.UNKNOWN),
+            ({"Health": "", "State": "running", "Status": "Up"}, ServiceHealth.UNKNOWN),
+        ],
+    )
+    def test_health_of_table(self, record, expected):
+        assert health_of(record) is expected
+        assert _compose_reports_ready(health_of(record)) is (expected is ServiceHealth.HEALTHY)
+
+    def test_only_healthy_enum_counts_as_ready(self):
+        assert _compose_reports_ready(ServiceHealth.HEALTHY) is True
+        assert _compose_reports_ready(ServiceHealth.UNHEALTHY) is False
+        assert _compose_reports_ready(ServiceHealth.STARTING) is False
+        assert _compose_reports_ready(ServiceHealth.UNKNOWN) is False
+        assert _compose_reports_ready(None) is False
+
+    def test_empty_health_running_state_is_not_ready(self):
+        payload = json.dumps({"Health": "", "State": "running", "Name": "creative-agent"})
+        health, err = _health_for(payload)
+        assert health is ServiceHealth.UNKNOWN
+        assert err is None
+        assert _compose_reports_ready(health) is False
+
+    def test_empty_health_unhealthy_state_is_not_ready_at_parser(self):
+        payload = json.dumps({"Health": "", "State": "running (unhealthy)", "Name": "creative-agent"})
+        health, err = _health_for(payload)
+        assert health is ServiceHealth.UNHEALTHY
+        assert err is None
+        assert _compose_reports_ready(health) is False
+
+    def test_empty_health_state_containing_healthy_is_ready(self):
+        payload = json.dumps({"Health": "", "State": "running (healthy)", "Name": "creative-agent"})
+        health, err = _health_for(payload)
+        assert health is ServiceHealth.HEALTHY
+        assert err is None
+        assert _compose_reports_ready(health) is True
+
+    def test_json_array_payload_parses_first_record(self):
+        payload = json.dumps([{"Health": "healthy", "Name": "creative-agent"}, {"Health": "unhealthy"}])
+        health, err = _health_for(payload)
+        assert health is ServiceHealth.HEALTHY
+        assert err is None
+
+    def test_ndjson_payload_parses_via_line_fallback(self):
+        ndjson = (
+            json.dumps({"Health": "healthy", "Name": "creative-agent"})
+            + "\n"
+            + json.dumps({"Health": "unhealthy", "Name": "other"})
+        )
+        health, err = _health_for(ndjson)
+        assert health is ServiceHealth.HEALTHY
+        assert err is None
+
+    def test_rc_nonzero_returns_none_health_with_diagnostic(self):
+        health, err = _health_for("", returncode=1)
+        assert health is None
+        assert err is not None
+        assert "failed" in err
+
+    def test_host_creative_agent_probe_rejects_running_only(self):
+        payload = json.dumps({"Health": "", "Status": "Up", "Name": "creative-agent"})
+        with _compose_ps_patches(payload):
+            assert (
+                _probe_creative_agent(
+                    ports=e2e_ports(mcp=8000, postgres=5432),
+                    host="localhost",
+                    compose_files=("docker-compose.e2e.yml",),
+                )
+                is False
+            )
+
+    def test_host_creative_agent_probe_rejects_unhealthy_state(self):
+        payload = json.dumps({"Health": "", "State": "running (unhealthy)", "Name": "creative-agent"})
+        with _compose_ps_patches(payload):
+            assert (
+                _probe_creative_agent(
+                    ports=e2e_ports(mcp=8000, postgres=5432),
+                    host="localhost",
+                    compose_files=("docker-compose.e2e.yml",),
+                )
+                is False
+            )
+
+    def test_probe_creative_agent_host_uses_compose_ready(self):
+        with patch("tests.e2e.stack_readiness._compose_service_ready", return_value=True) as ready:
+            assert (
+                _probe_creative_agent(
+                    ports=e2e_ports(mcp=8000, postgres=5432),
+                    host="localhost",
+                    compose_files=("docker-compose.e2e.yml",),
+                )
+                is True
+            )
+        ready.assert_called_once_with("creative-agent", ("docker-compose.e2e.yml",))
+
+
+def _which_docker_and_compose(name: str) -> str | None:
+    """Shared ``shutil.which`` side-effect for compose argv-selection oracles."""
+    return f"/usr/bin/{name}" if name in {"docker", "docker-compose"} else None
+
+
+class TestComposeArgvSelection:
+    """Compose V2 plugin must win over a legacy docker-compose V1 binary."""
+
+    def test_prefers_docker_compose_plugin_when_version_ok(self):
+        version_ok = _ps_completed("Docker Compose version v2.24.0", returncode=0)
+
+        with (
+            patch("tests.e2e.stack_readiness.shutil.which", side_effect=_which_docker_and_compose),
+            patch("tests.e2e.stack_readiness.subprocess.run", return_value=version_ok) as run,
+        ):
+            argv = compose_argv(("docker-compose.e2e.yml",))
+        assert argv[:2] == ["docker", "compose"]
+        run.assert_called_once_with(
+            ["docker", "compose", "version"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+
+    def test_falls_back_to_docker_compose_v1_when_plugin_probe_fails(self):
+        version_fail = _ps_completed("", returncode=1)
+
+        with (
+            patch("tests.e2e.stack_readiness.shutil.which", side_effect=_which_docker_and_compose),
+            patch("tests.e2e.stack_readiness.subprocess.run", return_value=version_fail),
+        ):
+            argv = compose_argv(("docker-compose.e2e.yml",))
+        assert argv[0] == "docker-compose"
+        assert argv[1:3] == ["-f", "docker-compose.e2e.yml"]
+
+    @pytest.mark.parametrize("exc", [OSError("boom"), subprocess.TimeoutExpired(cmd="docker", timeout=5)])
+    def test_falls_back_to_docker_compose_v1_when_plugin_probe_crashes(self, exc):
+        with (
+            patch("tests.e2e.stack_readiness.shutil.which", side_effect=_which_docker_and_compose),
+            patch("tests.e2e.stack_readiness.subprocess.run", side_effect=exc),
+        ):
+            argv = compose_argv(("docker-compose.e2e.yml",))
+        assert argv[0] == "docker-compose"
+        assert argv[1:3] == ["-f", "docker-compose.e2e.yml"]
+
+    def test_falls_back_to_docker_compose_v1_when_docker_absent(self):
+        which = {"docker-compose": "/usr/bin/docker-compose"}.get
+
+        with patch("tests.e2e.stack_readiness.shutil.which", side_effect=which):
+            argv = compose_argv(("docker-compose.e2e.yml",))
+        assert argv[0] == "docker-compose"
+        assert argv[1:3] == ["-f", "docker-compose.e2e.yml"]
+
+    def test_falls_back_to_docker_compose_plugin_name_when_neither_binary_found(self):
+        with patch("tests.e2e.stack_readiness.shutil.which", return_value=None):
+            argv = compose_argv(("docker-compose.e2e.yml",))
+        assert argv[:2] == ["docker", "compose"]
+        assert argv[2:4] == ["-f", "docker-compose.e2e.yml"]
+
+
+class TestComposeAvailableAndTopology:
+    """compose_available is CLI presence; in_network/use_container_exec is topology."""
+
+    def test_compose_available_true_when_docker_on_path(self):
+        with patch(
+            "tests.e2e.stack_readiness.shutil.which", side_effect=lambda n: "/bin/docker" if n == "docker" else None
+        ):
+            assert compose_available() is True
+
+    def test_compose_available_false_when_neither_binary(self):
+        with patch("tests.e2e.stack_readiness.shutil.which", return_value=None):
+            assert compose_available() is False
+
+    def test_in_network_loopback_hosts(self):
+        assert in_network("localhost") is False
+        assert in_network("127.0.0.1") is False
+        assert in_network("::1") is False
+        assert in_network("postgres") is True
+        assert in_network("adcp-server") is True
+
+    def test_use_container_exec_is_host_path_topology(self):
+        assert use_container_exec("localhost") is True
+        assert use_container_exec("postgres") is False
+
+
+class TestComposeExecAndDownArgv:
+    """Behavioral oracles for compose exec/down SSOT helpers (``-T`` / ``-v``)."""
+
+    def test_compose_exec_argv_emits_exec_dash_t_service_cmd(self):
+        version_ok = _ps_completed("Docker Compose version v2.24.0", returncode=0)
+
+        with (
+            patch("tests.e2e.stack_readiness.shutil.which", side_effect=_which_docker_and_compose),
+            patch("tests.e2e.stack_readiness.subprocess.run", return_value=version_ok),
+        ):
+            argv = compose_exec_argv("adcp-server", "python", "-c", "x")
+
+        assert argv[-6:] == ["exec", "-T", "adcp-server", "python", "-c", "x"]
+        assert "-f" in argv
+        assert argv[argv.index("-f") + 1] == BASE_E2E_COMPOSE_FILE
+
+    def test_compose_down_argv_emits_down_dash_v(self):
+        version_ok = _ps_completed("Docker Compose version v2.24.0", returncode=0)
+
+        with (
+            patch("tests.e2e.stack_readiness.shutil.which", side_effect=_which_docker_and_compose),
+            patch("tests.e2e.stack_readiness.subprocess.run", return_value=version_ok),
+        ):
+            argv = compose_down_argv()
+
+        assert argv[-2:] == ["down", "-v"]
+        assert "-f" in argv
+        assert argv[argv.index("-f") + 1] == BASE_E2E_COMPOSE_FILE
+
+
+class TestHostAndDbEnvDefaults:
+    def test_e2e_host_default_reads_adcp_test_host(self):
+        with patch.dict("os.environ", {"ADCP_TEST_HOST": "proxy"}, clear=False):
+            assert e2e_host_default() == "proxy"
+
+    def test_e2e_host_default_falls_back_to_localhost(self):
+        import os
+
+        cleaned = {k: v for k, v in os.environ.items() if k != "ADCP_TEST_HOST"}
+        with patch.dict("os.environ", cleaned, clear=True):
+            assert e2e_host_default() == "localhost"
+
+    def test_e2e_db_url_default_prefers_e2e_database_url(self):
+        with patch.dict(
+            "os.environ",
+            {
+                "E2E_DATABASE_URL": "postgresql://u:p@e2ehost:1111/adcp",
+                "DATABASE_URL": "postgresql://u:p@other:2222/adcp",
+            },
+            clear=False,
+        ):
+            assert e2e_db_url_default() == "postgresql://u:p@e2ehost:1111/adcp"
+
+    def test_e2e_db_url_build_ignores_env(self):
+        with patch.dict(
+            "os.environ",
+            {"E2E_DATABASE_URL": "postgresql://u:p@e2ehost:1111/adcp"},
+            clear=False,
+        ):
+            assert e2e_db_url_build(host="localhost", port=5435).endswith("@localhost:5435/adcp")
+
+
+class TestProbeWiring:
+    """Direct probe tests — host + in-network branches, real registry mapping."""
+
+    def test_probe_postgres_host_uses_published_port(self):
+        with patch("tests.e2e.stack_readiness._tcp_open", return_value=True) as tcp:
+            assert (
+                _probe_postgres(
+                    ports=e2e_ports(mcp=8000, postgres=55432),
+                    host="localhost",
+                    compose_files=("docker-compose.e2e.yml",),
+                )
+                is True
+            )
+        tcp.assert_called_once_with("localhost", 55432)
+
+    def test_probe_postgres_host_without_port_fails_closed(self):
+        # Absent postgres key must not silently degrade to compose health.
+        with patch("tests.e2e.stack_readiness._compose_service_ready", return_value=True) as ready:
+            assert (
+                _probe_postgres(
+                    ports={"mcp": 8000},  # type: ignore[typeddict-item]
+                    host="localhost",
+                    compose_files=("docker-compose.e2e.yml",),
+                )
+                is False
+            )
+        ready.assert_not_called()
+
+    def test_probe_postgres_in_network_default_host(self):
+        with (
+            patch.dict("os.environ", {"E2E_DATABASE_URL": "", "DATABASE_URL": ""}, clear=False),
+            patch("tests.e2e.stack_readiness._tcp_open", return_value=True) as tcp,
+        ):
+            assert (
+                _probe_postgres(
+                    ports=e2e_ports(mcp=8000, postgres=5432),
+                    host="postgres",
+                    compose_files=("docker-compose.e2e.yml",),
+                )
+                is True
+            )
+        tcp.assert_called_once_with("postgres", 5432)
+
+    def test_probe_postgres_in_network_from_database_url(self):
+        with (
+            patch.dict(
+                "os.environ",
+                {"E2E_DATABASE_URL": "postgresql://u:p@dbhost:6543/adcp"},
+                clear=False,
+            ),
+            patch("tests.e2e.stack_readiness._tcp_open", return_value=True) as tcp,
+        ):
+            assert (
+                _probe_postgres(
+                    ports=e2e_ports(mcp=8000, postgres=5432),
+                    host="adcp-server",
+                    compose_files=("docker-compose.e2e.yml",),
+                )
+                is True
+            )
+        tcp.assert_called_once_with("dbhost", 6543)
+
+    def test_probe_adcp_health_host_hits_mcp_port(self):
+        with patch("tests.e2e.stack_readiness._http_ok", return_value=True) as http:
+            assert (
+                _probe_adcp_health(
+                    ports=e2e_ports(mcp=18000, postgres=5432),
+                    host="localhost",
+                    compose_files=("docker-compose.e2e.yml",),
+                )
+                is True
+            )
+        http.assert_called_once_with("http://localhost:18000/health")
+
+    def test_probe_adcp_health_fail_closed_when_no_port(self):
+        with patch("tests.e2e.stack_readiness._http_ok", return_value=True) as http:
+            assert (
+                _probe_adcp_health(
+                    ports={"postgres": 5432},  # type: ignore[typeddict-item]
+                    host="localhost",
+                    compose_files=("docker-compose.e2e.yml",),
+                )
+                is False
+            )
+        http.assert_not_called()
+
+    def test_probe_adcp_health_in_network(self):
+        with patch("tests.e2e.stack_readiness._http_ok", return_value=True) as http:
+            assert (
+                _probe_adcp_health(
+                    ports=e2e_ports(mcp=8000, postgres=5432),
+                    host="adcp-server",
+                    compose_files=("docker-compose.e2e.yml",),
+                )
+                is True
+            )
+        http.assert_called_once_with("http://adcp-server:8000/health")
+
+    def test_probe_adcp_health_ipv6_host_returns_bool_never_raises(self):
+        # ::1 must be bracketed; InvalidURL must not escape the probe.
+        assert _probe_adcp_health(
+            ports=e2e_ports(mcp=8092, postgres=5432),
+            host="::1",
+            compose_files=("docker-compose.e2e.yml",),
+        ) in (True, False)
+
+    def test_http_authority_brackets_ipv6(self):
+        assert _http_authority("::1", 8092) == "[::1]:8092"
+        assert _http_authority("localhost", 8092) == "localhost:8092"
+
+    def test_http_ok_catches_invalid_url(self):
+        from tests.e2e.stack_readiness import _http_ok
+
+        with patch("tests.e2e.stack_readiness.httpx.Client") as client_cls:
+            client = MagicMock()
+            client_cls.return_value.__enter__.return_value = client
+            client.get.side_effect = httpx.InvalidURL("bad")
+            assert _http_ok("http://::1:8092/health") is False
+
+    def test_probe_creative_agent_in_network_hits_service_url(self):
+        with patch("tests.e2e.stack_readiness._http_ok", return_value=True) as http:
+            assert (
+                _probe_creative_agent(
+                    ports=e2e_ports(mcp=8000, postgres=5432),
+                    host="adcp-server",
+                    compose_files=("docker-compose.e2e.yml",),
+                )
+                is True
+            )
+        http.assert_called_once_with("http://creative-agent:8080/api/creative-agent/health")
+
+    def test_real_probe_funcs_postgres_key_wires_tcp(self):
+        with patch("tests.e2e.stack_readiness._tcp_open", return_value=True) as tcp:
+            assert _PROBE_FUNCS["postgres"](
+                ports=e2e_ports(mcp=8000, postgres=54321),
+                host="localhost",
+                compose_files=("docker-compose.e2e.yml",),
+            )
+        tcp.assert_called_once_with("localhost", 54321)
+
+    def test_real_probe_funcs_adcp_key_wires_http(self):
+        with patch("tests.e2e.stack_readiness._http_ok", return_value=True) as http:
+            assert _PROBE_FUNCS["adcp_health"](
+                ports=e2e_ports(mcp=9000, postgres=5432),
+                host="localhost",
+                compose_files=("docker-compose.e2e.yml",),
+            )
+        http.assert_called_once_with("http://localhost:9000/health")
+
+
+class TestWaitForE2EStackCreativeAgentOracle:
+    """Creative-agent miss must fail the wait naming that probe."""
+
+    def test_creative_agent_false_fails_naming_probe_with_compose_diag(self):
+        probes = _stub_probes(creative_agent=False)
+        with (
+            patch.dict("tests.e2e.stack_readiness._PROBE_FUNCS", probes, clear=False),
+            patch("tests.e2e.stack_readiness._dump_e2e_compose_logs"),
+            patch(
+                "tests.e2e.stack_readiness._compose_service_health",
+                return_value=(None, "diag"),
+            ),
+            pytest.raises(pytest.fail.Exception, match="failed probe: creative-agent") as exc_info,
+        ):
+            wait_for_e2e_stack(
+                ports=e2e_ports(mcp=8000, postgres=5432),
+                compose_files=("docker-compose.e2e.yml",),
+                host="localhost",
+                timeout_s=0.01,
+                poll_interval_s=0.001,
+            )
+        msg = str(exc_info.value)
+        assert "creative-agent" in msg
+        assert "compose_ps_diag=diag" in msg
+
+    def test_creative_agent_false_reports_compose_health_when_no_err(self):
+        probes = _stub_probes(creative_agent=False)
+        with (
+            patch.dict("tests.e2e.stack_readiness._PROBE_FUNCS", probes, clear=False),
+            patch("tests.e2e.stack_readiness._dump_e2e_compose_logs"),
+            patch(
+                "tests.e2e.stack_readiness._compose_service_health",
+                return_value=(ServiceHealth.UNHEALTHY, None),
+            ),
+            pytest.raises(pytest.fail.Exception) as exc_info,
+        ):
+            wait_for_e2e_stack(
+                ports=e2e_ports(mcp=8000, postgres=5432),
+                compose_files=("docker-compose.e2e.yml",),
+                host="localhost",
+                timeout_s=0.01,
+                poll_interval_s=0.001,
+            )
+        assert "compose_health=" in str(exc_info.value)
+
+    def test_probe_order_names_postgres_first_on_double_false(self):
+        probes = _stub_probes(postgres=False, adcp_health=False)
+        with (
+            patch.dict("tests.e2e.stack_readiness._PROBE_FUNCS", probes, clear=False),
+            patch("tests.e2e.stack_readiness._dump_e2e_compose_logs"),
+            pytest.raises(pytest.fail.Exception, match="failed probe: postgres"),
+        ):
+            wait_for_e2e_stack(
+                ports=e2e_ports(mcp=8000, postgres=5432),
+                compose_files=("docker-compose.e2e.yml",),
+                host="localhost",
+                timeout_s=0.01,
+                poll_interval_s=0.001,
+            )
+
+    def test_all_probes_ready_returns_without_log_dump(self):
+        probes = _stub_probes()
+        with (
+            patch.dict("tests.e2e.stack_readiness._PROBE_FUNCS", probes, clear=False),
+            patch("tests.e2e.stack_readiness._dump_e2e_compose_logs") as dump,
+        ):
+            wait_for_e2e_stack(
+                ports=e2e_ports(mcp=8000, postgres=5432),
+                compose_files=("docker-compose.e2e.yml",),
+                host="localhost",
+                timeout_s=1.0,
+                poll_interval_s=0.001,
+            )
+        dump.assert_not_called()
+
+    def test_empty_names_raises_value_error_via_private_helper(self):
+        with (
+            patch("tests.e2e.stack_readiness._dump_e2e_compose_logs") as dump,
+            pytest.raises(ValueError, match="non-empty required"),
+        ):
+            _wait_for_probes(
+                (),
+                ports=e2e_ports(mcp=8000, postgres=5432),
+                compose_files=("docker-compose.e2e.yml",),
+                host="localhost",
+                timeout_s=1.0,
+            )
+        dump.assert_not_called()
+
+    def test_unknown_probe_raises_value_error_via_private_helper(self):
+        with (
+            patch("tests.e2e.stack_readiness._dump_e2e_compose_logs") as dump,
+            pytest.raises(ValueError, match="Unknown E2E readiness probes"),
+        ):
+            _wait_for_probes(
+                ("nope",),
+                ports=e2e_ports(mcp=8000, postgres=5432),
+                compose_files=("docker-compose.e2e.yml",),
+                host="localhost",
+                timeout_s=1.0,
+            )
+        dump.assert_not_called()
+
+    def test_wait_uses_real_registry_with_patched_low_level(self):
+        with (
+            patch("tests.e2e.stack_readiness._tcp_open", return_value=True),
+            patch("tests.e2e.stack_readiness._compose_service_ready", return_value=True),
+            patch("tests.e2e.stack_readiness._http_ok", return_value=True) as http,
+            patch("tests.e2e.stack_readiness._dump_e2e_compose_logs") as dump,
+        ):
+            wait_for_e2e_stack(
+                ports=e2e_ports(mcp=8000, postgres=5432),
+                compose_files=("docker-compose.e2e.yml",),
+                host="localhost",
+                timeout_s=1.0,
+                poll_interval_s=0.001,
+            )
+        dump.assert_not_called()
+        assert call("http://localhost:8000/health") in http.call_args_list
+
+
+class TestWaitForServerReadinessWrapper:
+    def test_fail_closed_when_mcp_url_missing_port(self):
+        with pytest.raises(pytest.fail.Exception, match="cannot derive host/port"):
+            wait_for_server_readiness("http://localhost", postgres_port=5432)
+
+    def test_forwards_to_wait_for_e2e_stack(self):
+        with patch("tests.e2e.utils.wait_for_e2e_stack") as wait:
+            wait_for_server_readiness("http://localhost:18000", postgres_port=55432, timeout=12.5)
+        wait.assert_called_once_with(
+            ports=e2e_ports(mcp=18000, postgres=55432),
+            compose_files=("docker-compose.e2e.yml", "docker-compose.e2e.ports.yml"),
+            host="localhost",
+            timeout_s=12.5,
+        )


### PR DESCRIPTION
## Summary
- Extract shared `tests.e2e.stack_readiness.wait_for_e2e_stack` with ordered hard gate **postgres → creative-agent → adcp `/health`** and a single structured compose log dump.
- Wire both `docker_services_e2e` paths (verify-only when `ADCP_TESTING=true` / `--skip-docker`, and standalone after self-`up`) through that helper; dedupe `wait_for_server_readiness` as a thin delegate.
- Add architecture guard `tests/unit/test_architecture_e2e_stack_readiness.py` plus behavioral coverage in `tests/unit/test_e2e_stack_readiness_behavior.py` (mutation self-tests, oracles, compose argv SSOT).

Closes #1668

## Scope
**#1668 only** — rebased onto latest `main` (2026-09-02). IPR / CI pre-start / free-disk work stays on **#1669** and is **not** in this diff.

## Spec-Grounding
N/A — test infrastructure only (no AdCP protocol behavior change).

## Test plan
- [x] `uv run pytest tests/unit/test_architecture_e2e_stack_readiness.py tests/unit/test_e2e_stack_readiness_behavior.py`
- [x] Mutation proofs via guard self-tests (probe registry, call sites, no divergent wait loops)
- [ ] CI on this tip

## Out of scope
- #1669 IPR verify/sign, `.github/workflows` pre-start E2E, `_free-disk`, zizmor/actionlint
- Parent epic #1666 closure