### PR TITLE
fix: identity-scope A2A in-memory tasks/get (and cancel) (#1702)

### DIFF
--- a/docs/test-obligations/bdd-traceability.yaml
+++ b/docs/test-obligations/bdd-traceability.yaml
@@ -48,49 +48,101 @@ mappings:
       status: new
   # Locally-added, no upstream storyboard: the adcp-req storyboards never drive
   # the A2A protocol methods tasks/get / tasks/cancel against another
-  # principal's task. Retire these entries with the local feature once upstream
-  # grows the equivalent scenarios. See tests/bdd/features/local-a2a-task-ownership.feature.
+  # principal's task. Spec-grounded in A2A Protocol §3.3.2 + §13.1; this
+  # altitude is upstream-ungraded by design (AdCP task-lifecycle places
+  # transport-native tasks/* outside AdCP polling). AdCP analogue:
+  # get_products_async wrong-account steps → REFERENCE_NOT_FOUND.
+  # Retire these entries with the local feature once upstream grows equivalents.
+  # See tests/bdd/features/local-a2a-task-ownership.feature.
   A2A-TASK-OWNERSHIP:
     - adcp_scenario_id: "T-A2A-TASK-OWNERSHIP-owner-get"
       adcp_feature: "local-a2a-task-ownership.feature"
       obligation_id: null
-      upstream_refs: []
+      upstream_refs:
+        - "a2a-spec:3.3.2"
+        - "a2a-spec:13.1"
+        - "adcp:get_products_async/get_products_task_status_wrong_account"
+        - "adcp:get_products_async/list_products_task_wrong_account"
       business_rules: []
       status: new
     - adcp_scenario_id: "T-A2A-TASK-OWNERSHIP-sibling-get"
       adcp_feature: "local-a2a-task-ownership.feature"
       obligation_id: null
-      upstream_refs: []
+      upstream_refs:
+        - "a2a-spec:3.3.2"
+        - "a2a-spec:13.1"
+        - "adcp:get_products_async/get_products_task_status_wrong_account"
+        - "adcp:get_products_async/list_products_task_wrong_account"
       business_rules: []
       status: new
     - adcp_scenario_id: "T-A2A-TASK-OWNERSHIP-other-tenant-get"
       adcp_feature: "local-a2a-task-ownership.feature"
       obligation_id: null
-      upstream_refs: []
+      upstream_refs:
+        - "a2a-spec:3.3.2"
+        - "a2a-spec:13.1"
+        - "adcp:get_products_async/get_products_task_status_wrong_account"
+        - "adcp:get_products_async/list_products_task_wrong_account"
       business_rules: []
       status: new
     - adcp_scenario_id: "T-A2A-TASK-OWNERSHIP-unknown-get"
       adcp_feature: "local-a2a-task-ownership.feature"
       obligation_id: null
-      upstream_refs: []
+      upstream_refs:
+        - "a2a-spec:3.3.2"
+        - "a2a-spec:13.1"
+        - "adcp:get_products_async/get_products_task_status_wrong_account"
+        - "adcp:get_products_async/list_products_task_wrong_account"
       business_rules: []
       status: new
     - adcp_scenario_id: "T-A2A-TASK-OWNERSHIP-sibling-cancel"
       adcp_feature: "local-a2a-task-ownership.feature"
       obligation_id: null
-      upstream_refs: []
+      upstream_refs:
+        - "a2a-spec:3.3.2"
+        - "a2a-spec:13.1"
+        - "adcp:get_products_async/get_products_task_status_wrong_account"
+        - "adcp:get_products_async/list_products_task_wrong_account"
       business_rules: []
       status: new
     - adcp_scenario_id: "T-A2A-TASK-OWNERSHIP-other-tenant-cancel"
       adcp_feature: "local-a2a-task-ownership.feature"
       obligation_id: null
-      upstream_refs: []
+      upstream_refs:
+        - "a2a-spec:3.3.2"
+        - "a2a-spec:13.1"
+        - "adcp:get_products_async/get_products_task_status_wrong_account"
+        - "adcp:get_products_async/list_products_task_wrong_account"
       business_rules: []
       status: new
     - adcp_scenario_id: "T-A2A-TASK-OWNERSHIP-owner-cancel"
       adcp_feature: "local-a2a-task-ownership.feature"
       obligation_id: null
-      upstream_refs: []
+      upstream_refs:
+        - "a2a-spec:3.3.2"
+        - "a2a-spec:13.1"
+        - "adcp:get_products_async/get_products_task_status_wrong_account"
+        - "adcp:get_products_async/list_products_task_wrong_account"
+      business_rules: []
+      status: new
+    - adcp_scenario_id: "T-A2A-TASK-OWNERSHIP-no-owner-get"
+      adcp_feature: "local-a2a-task-ownership.feature"
+      obligation_id: null
+      upstream_refs:
+        - "a2a-spec:3.3.2"
+        - "a2a-spec:13.1"
+        - "adcp:get_products_async/get_products_task_status_wrong_account"
+        - "adcp:get_products_async/list_products_task_wrong_account"
+      business_rules: []
+      status: new
+    - adcp_scenario_id: "T-A2A-TASK-OWNERSHIP-unauth-get"
+      adcp_feature: "local-a2a-task-ownership.feature"
+      obligation_id: null
+      upstream_refs:
+        - "a2a-spec:3.3.2"
+        - "a2a-spec:13.1"
+        - "adcp:get_products_async/get_products_task_status_wrong_account"
+        - "adcp:get_products_async/list_products_task_wrong_account"
       business_rules: []
       status: new
   UC-001:

--- a/docs/test-obligations/bdd-traceability.yaml
+++ b/docs/test-obligations/bdd-traceability.yaml
@@ -46,6 +46,53 @@ mappings:
       upstream_refs: ["BR-COMPAT-001"]
       business_rules: []
       status: new
+  # Locally-added, no upstream storyboard: the adcp-req storyboards never drive
+  # the A2A protocol methods tasks/get / tasks/cancel against another
+  # principal's task. Retire these entries with the local feature once upstream
+  # grows the equivalent scenarios. See tests/bdd/features/local-a2a-task-ownership.feature.
+  A2A-TASK-OWNERSHIP:
+    - adcp_scenario_id: "T-A2A-TASK-OWNERSHIP-owner-get"
+      adcp_feature: "local-a2a-task-ownership.feature"
+      obligation_id: null
+      upstream_refs: []
+      business_rules: []
+      status: new
+    - adcp_scenario_id: "T-A2A-TASK-OWNERSHIP-sibling-get"
+      adcp_feature: "local-a2a-task-ownership.feature"
+      obligation_id: null
+      upstream_refs: []
+      business_rules: []
+      status: new
+    - adcp_scenario_id: "T-A2A-TASK-OWNERSHIP-other-tenant-get"
+      adcp_feature: "local-a2a-task-ownership.feature"
+      obligation_id: null
+      upstream_refs: []
+      business_rules: []
+      status: new
+    - adcp_scenario_id: "T-A2A-TASK-OWNERSHIP-unknown-get"
+      adcp_feature: "local-a2a-task-ownership.feature"
+      obligation_id: null
+      upstream_refs: []
+      business_rules: []
+      status: new
+    - adcp_scenario_id: "T-A2A-TASK-OWNERSHIP-sibling-cancel"
+      adcp_feature: "local-a2a-task-ownership.feature"
+      obligation_id: null
+      upstream_refs: []
+      business_rules: []
+      status: new
+    - adcp_scenario_id: "T-A2A-TASK-OWNERSHIP-other-tenant-cancel"
+      adcp_feature: "local-a2a-task-ownership.feature"
+      obligation_id: null
+      upstream_refs: []
+      business_rules: []
+      status: new
+    - adcp_scenario_id: "T-A2A-TASK-OWNERSHIP-owner-cancel"
+      adcp_feature: "local-a2a-task-ownership.feature"
+      obligation_id: null
+      upstream_refs: []
+      business_rules: []
+      status: new
   UC-001:
     - adcp_scenario_id: "T-UC-001-main"
       adcp_feature: "BR-UC-001-discover-available-inventory.feature"

--- a/src/a2a_server/adcp_a2a_server.py
+++ b/src/a2a_server/adcp_a2a_server.py
@@ -7,6 +7,7 @@ Supports both standard A2A message format and JSON-RPC 2.0.
 import copy
 import json
 import logging
+import re
 import uuid
 from collections.abc import AsyncGenerator, Awaitable, Callable
 
@@ -222,16 +223,24 @@ DISCOVERY_SKILLS = frozenset(
 
 
 def _task_not_found_message(task_id: str) -> str:
-    """Buyer-facing not-found message shared by wire raise and deny telemetry."""
+    """Buyer-facing not-found message (wire raise + deny telemetry when ids match).
+
+    Callers that sanitize for logs (``_safe_task_id_for_log``) may pass a different
+    id than the raw wire raise — both still use this formatter.
+    """
     return f"Task not found: {task_id}"
 
 
 def _safe_task_id_for_log(task_id: str) -> str:
-    """Truncate / neutralize attacker-controlled task ids before file/audit logs."""
-    return task_id.replace("\r", "\\r").replace("\n", "\\n")[:100]
+    """Neutralize attacker-controlled task ids before logs / buyer-facing messages.
+
+    Allowlist keeps ``task_<hex>``-shaped ids intact; everything else becomes ``?``.
+    Truncate after substitution so a trailing escape cannot leave a lone backslash.
+    """
+    return re.sub(r"[^A-Za-z0-9_.:-]", "?", task_id)[:100]
 
 
-def _internal_error_for(operation: str, _exc: Exception) -> InternalError:
+def _internal_error_for(operation: str, exc: Exception) -> InternalError:
     """Canonical InternalError shape for non-skill A2A boundary failures.
 
     Skill handlers raise typed ``AdCPError`` (or untyped exceptions that the
@@ -242,17 +251,16 @@ def _internal_error_for(operation: str, _exc: Exception) -> InternalError:
     for semantically identical untyped failures — divergence on the buyer-
     facing wire message for the same condition.
 
-    Use this helper at non-skill ``InternalError(...)`` raise sites that are
-    not a deliberate protocol-level convention. Do **not** use it from
-    ``_authenticate``: that path deliberately bypasses
-    ``normalize_to_adcp_error`` so SQL / bound parameters never reach the
-    client-facing message or envelope.
+    Use this helper at every non-skill ``InternalError(...)`` raise site that is
+    not a deliberate protocol-level convention — including ``_authenticate``.
+    Typed and untyped inputs are both handled here; no caller may interpolate
+    ``str(exc)`` into the client-facing ``InternalError`` message or its
+    ``data`` envelope (SQLAlchemy includes SQL + bound params).
 
     Typed ``AdCPError`` keeps its intentional buyer-facing ``.message`` and
     envelope (e.g. NL ``AdCPCapabilityNotSupportedError``). Untyped exceptions
-    use a fixed ``"{operation} failed"`` phrase — never interpolate
-    ``str(exc)`` (SQLAlchemy includes SQL + bound params). Untyped detail
-    belongs in ``record_boundary_error`` at the call site only.
+    use a fixed ``"{operation} failed"`` phrase. Untyped detail belongs in
+    ``record_boundary_error`` at the call site only.
 
     The four ``on_*_task_push_notification_config`` JSON-RPC protocol methods use
     this helper too — they have no async Task to carry a DataPart, so the two-layer
@@ -263,10 +271,10 @@ def _internal_error_for(operation: str, _exc: Exception) -> InternalError:
     raising a non-``A2AError`` would hit the dispatcher's ``except Exception``
     branch and be flattened to a bare ``InternalError`` with no envelope.
     """
-    if isinstance(_exc, AdCPError):
+    if isinstance(exc, AdCPError):
         return InternalError(
-            message=_exc.message,
-            data=build_two_layer_error_envelope(_exc),
+            message=exc.message,
+            data=build_two_layer_error_envelope(exc),
         )
     # Untyped: fixed phrase only — class defaults map INTERNAL_ERROR →
     # SERVICE_UNAVAILABLE with recovery=transient on the envelope.
@@ -458,15 +466,9 @@ class AdCPRequestHandler(RequestHandler):
         except Exception as e:
             record_boundary_error("a2a", operation, e)
             # Underscore→space is the wire phrase; keep op ids underscore-replaceable.
-            wire_op = operation.replace("_", " ")
-            # Fixed message + typed envelope — do NOT route through
-            # ``normalize_to_adcp_error(e)`` (re-copies ``str(exc)`` / SQL).
-            # AdCPError class defaults: INTERNAL_ERROR → wire SERVICE_UNAVAILABLE,
-            # recovery=transient (do not hand-write error_code=/recovery=).
-            raise InternalError(
-                message=f"{wire_op} failed",
-                data=build_two_layer_error_envelope(AdCPError(message=f"{wire_op} failed")),
-            ) from e
+            # Delegate to ``_internal_error_for`` (typed + untyped); never interpolate
+            # ``str(exc)`` / SQL (do not hand-write error_code=/recovery=).
+            raise _internal_error_for(operation.replace("_", " "), e) from e
 
     def _log_a2a_operation(
         self,
@@ -502,6 +504,8 @@ class AdCPRequestHandler(RequestHandler):
         status: str,
         result: dict[str, Any] | None = None,
         error: str | None = None,
+        *,
+        config: TaskPushNotificationConfig | None = None,
     ):
         """Send protocol-level push notification if configured.
 
@@ -513,8 +517,7 @@ class AdCPRequestHandler(RequestHandler):
         TaskStatusUpdateEvent for intermediate ones.
         """
         try:
-            # Check if task has push notification config stored
-            webhook_config = self._task_push_configs.get(task.id)
+            webhook_config = config or self._task_push_configs.get(task.id)
             if not webhook_config:
                 return
 
@@ -734,6 +737,8 @@ class AdCPRequestHandler(RequestHandler):
             # resolution succeeds. Auth failure above must leave no orphan
             # entries in self.tasks / _task_push_configs / _task_owners. #1702
             # Push config lives outside protobuf metadata (not JSON-serializable).
+            # Failure webhooks before this point thread ``config=`` into
+            # ``_send_protocol_webhook`` rather than writing the map early.
             if push_notification_config:
                 self._task_push_configs[task_id] = push_notification_config
             self.tasks[task_id] = task
@@ -1095,24 +1100,20 @@ class AdCPRequestHandler(RequestHandler):
                 principal_id=err_principal_id,
             )
 
-            # Send protocol-level webhook notification for failure if configured
+            # Failure webhook before create+own: thread config explicitly so we
+            # never orphan ``_task_push_configs`` on a resolve failure (R5-A1).
             task.status.CopyFrom(TaskStatus(state=TaskState.TASK_STATE_FAILED))
-            # Attach error to task artifacts as a spec-compliant two-layer
-            # envelope (same shape as failed-skill DataParts) so storyboard
-            # runners can ``JSON.parse`` the artifact uniformly regardless of
-            # which failure path produced it.
             del task.artifacts[:]
-            task.artifacts.append(
-                Artifact(
-                    artifact_id="error_1",
-                    name="processing_error",
-                    parts=[Part(data=_dict_to_value(self._build_error_envelope(e)))],
-                )
+
+            await self._send_protocol_webhook(
+                task,
+                status="failed",
+                config=push_notification_config,
             )
 
-            await self._send_protocol_webhook(task, status="failed")
-
-            # Raise A2A error instead of creating failed task
+            # Raise A2A error — ``_internal_error_for`` keeps SQL out of the
+            # client-facing InternalError message/envelope (do not attach a
+            # normalize_to_adcp_error artifact on this raising path).
             raise _internal_error_for("message processing", e)
 
         self.tasks[task_id] = task
@@ -1163,14 +1164,20 @@ class AdCPRequestHandler(RequestHandler):
         will surface ``-32001`` the moment that gap closes; the xfail'd
         live-server test pins the current reality.
 
-        The requested id is put on both the message and structured ``data``.
-        Only the message reaches a client today: the same compat adapter that
-        flattens the code to ``-32603`` rebuilds the error as
-        ``CoreInternalError(message=str(e))``, which drops ``data`` — driving
-        the real route returns ``data: null``. Populating it is still correct
-        and becomes readable when #1670 closes, the same as the code.
+        The requested id is put on both the message and structured ``data``
+        (sanitized via ``_safe_task_id_for_log`` so control characters cannot
+        forge log lines one frame away in the compat adapter). Only the message
+        reaches a client today: the same compat adapter that flattens the code
+        to ``-32603`` rebuilds the error as ``CoreInternalError(message=str(e))``,
+        which drops ``data`` — driving the real route returns ``data: null``.
+        Populating it is still correct and becomes readable when #1670 closes,
+        the same as the code.
         """
-        return TaskNotFoundError(message=_task_not_found_message(task_id), data={"task_id": task_id})
+        safe_id = _safe_task_id_for_log(task_id)
+        adcp_err = AdCPTaskNotFoundError(message=_task_not_found_message(safe_id))
+        data = build_two_layer_error_envelope(adcp_err)
+        data["task_id"] = safe_id
+        return TaskNotFoundError(message=adcp_err.message, data=data)
 
     def _get_owned_in_memory_task_or_raise(
         self, task_id: str, context: ServerCallContext | None, *, operation: str
@@ -1193,40 +1200,30 @@ class AdCPRequestHandler(RequestHandler):
 
         task = self.tasks.get(task_id)
         expected_owner = _TaskOwner(tenant_id=identity.tenant_id, principal_id=identity.principal_id)
-        if task is None or self._task_owners.get(task_id) != expected_owner:
-            # Wire must stay indistinguishable (existence oracle); log may branch.
+        # Fail closed on null principal (must not match a null-owner row) and
+        # evaluate ownership unconditionally (error-handling.mdx § Side effects).
+        if task is None or not identity.principal_id or self._task_owners.get(task_id) != expected_owner:
+            # Wire must stay indistinguishable (existence oracle). Stdlib log may
+            # branch for operators; side-effect sinks MUST stay symmetric
+            # (error-handling.mdx:206-207) — both omit tenant/principal so feeds
+            # self-skip (no asymmetric audit flood).
             log_task_id = _safe_task_id_for_log(task_id)
-            ownership_miss = task is not None
-            if ownership_miss:
-                logger.warning(
-                    "Ownership denial for task %s: caller tenant_id=%s principal_id=%s",
-                    log_task_id,
-                    identity.tenant_id,
-                    identity.principal_id,
-                )
-            else:
-                logger.warning(
-                    "Unknown task id on %s: task_id=%s caller tenant_id=%s principal_id=%s",
-                    operation,
-                    log_task_id,
-                    identity.tenant_id,
-                    identity.principal_id,
-                )
-            # Telemetry uses typed AdCPError (WARNING branch). ``TaskNotFoundError``
-            # is an A2AError, not AdCPError — passing it took the untyped
-            # ``exc_info=True`` path with no active exception (NoneType: None)
-            # and logged ordinary stale-handle polls at ERROR.
-            # Unknown-id / stale-handle: omit tenant_id/principal_id so sinks
-            # self-skip (no feed/audit flood). Ownership miss keeps full sinks.
-            telem_kwargs: dict[str, Any] = {}
-            if ownership_miss:
-                telem_kwargs["tenant_id"] = identity.tenant_id
-                telem_kwargs["principal_id"] = identity.principal_id
+            ownership_miss = task is not None and bool(identity.principal_id)
+            # Structurally identical traces on both branches (error-handling.mdx:207).
+            logger.warning(
+                "Task access denied on %s: task_id=%s ownership_miss=%s caller tenant_id=%s principal_id=%s",
+                operation,
+                log_task_id,
+                ownership_miss,
+                identity.tenant_id,
+                identity.principal_id,
+            )
+            # Telemetry uses typed AdCPError (WARNING branch). Identical kwargs on
+            # both branches — omit tenant_id/principal_id so sinks self-skip.
             record_boundary_error(
                 "a2a",
                 operation,
                 AdCPTaskNotFoundError(message=_task_not_found_message(log_task_id)),
-                **telem_kwargs,
             )
             raise self._task_not_found(task_id)
         return task

--- a/src/a2a_server/adcp_a2a_server.py
+++ b/src/a2a_server/adcp_a2a_server.py
@@ -248,10 +248,11 @@ def _internal_error_for(operation: str, _exc: Exception) -> InternalError:
     ``normalize_to_adcp_error`` so SQL / bound parameters never reach the
     client-facing message or envelope.
 
-    Client-facing message is a fixed ``"{operation} failed"`` phrase — never
-    interpolate ``str(exc)`` (SQLAlchemy includes SQL + bound params). Exception
-    detail belongs in ``record_boundary_error`` at the call site only
-    (``_exc`` is retained for call-site clarity / future typed mapping).
+    Typed ``AdCPError`` keeps its intentional buyer-facing ``.message`` and
+    envelope (e.g. NL ``AdCPCapabilityNotSupportedError``). Untyped exceptions
+    use a fixed ``"{operation} failed"`` phrase — never interpolate
+    ``str(exc)`` (SQLAlchemy includes SQL + bound params). Untyped detail
+    belongs in ``record_boundary_error`` at the call site only.
 
     The four ``on_*_task_push_notification_config`` JSON-RPC protocol methods use
     this helper too — they have no async Task to carry a DataPart, so the two-layer
@@ -262,8 +263,13 @@ def _internal_error_for(operation: str, _exc: Exception) -> InternalError:
     raising a non-``A2AError`` would hit the dispatcher's ``except Exception``
     branch and be flattened to a bare ``InternalError`` with no envelope.
     """
-    # Fixed phrase only — class defaults map INTERNAL_ERROR → SERVICE_UNAVAILABLE
-    # with recovery=transient on the envelope.
+    if isinstance(_exc, AdCPError):
+        return InternalError(
+            message=_exc.message,
+            data=build_two_layer_error_envelope(_exc),
+        )
+    # Untyped: fixed phrase only — class defaults map INTERNAL_ERROR →
+    # SERVICE_UNAVAILABLE with recovery=transient on the envelope.
     fixed = f"{operation} failed"
     return InternalError(
         message=fixed,

--- a/src/a2a_server/adcp_a2a_server.py
+++ b/src/a2a_server/adcp_a2a_server.py
@@ -12,7 +12,7 @@ from collections.abc import AsyncGenerator, Awaitable, Callable
 
 # Import core functions for direct calls (raw functions without FastMCP decorators)
 from datetime import UTC, datetime
-from typing import Any
+from typing import Any, NamedTuple
 
 from a2a.server.context import ServerCallContext
 from a2a.server.events.event_queue import Event
@@ -251,10 +251,17 @@ def _internal_error_for(operation: str, exc: Exception) -> InternalError:
     )
 
 
+class _TaskOwner(NamedTuple):
+    """Owner identity recorded at in-memory task create for get/cancel authorization."""
+
+    tenant_id: str | None
+    principal_id: str | None
+
+
 class AdCPRequestHandler(RequestHandler):
     """Request handler for AdCP A2A operations supporting JSON-RPC 2.0."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Initialize the AdCP A2A request handler."""
         self.tasks: dict[str, Task] = {}  # In-memory task storage
         # The VALUE, not the raw protobuf: what is stashed here is handed straight
@@ -311,6 +318,7 @@ class AdCPRequestHandler(RequestHandler):
     def _resolve_a2a_identity(
         self,
         auth_token: str | None,
+        *,
         require_valid_token: bool = True,
         context: ServerCallContext | None = None,
     ) -> ResolvedIdentity:
@@ -405,6 +413,22 @@ class AdCPRequestHandler(RequestHandler):
             metadata={"source": "a2a_server", "protocol": "a2a_jsonrpc"},
             testing_context=identity.testing_context,
         )
+
+    def _authenticate(self, context: ServerCallContext | None, *, operation: str) -> ResolvedIdentity:
+        """Resolve a valid principal identity for authenticated A2A operations.
+
+        Auth failures (``A2AError`` / ``InvalidRequestError``) propagate unchanged.
+        Unexpected failures become ``InternalError`` with a fixed message — never
+        interpolate ``str(exc)`` into the client-facing message.
+        """
+        auth_token = self._get_auth_token(context)
+        try:
+            return self._resolve_a2a_identity(auth_token, require_valid_token=True, context=context)
+        except A2AError:
+            raise
+        except Exception as e:
+            record_boundary_error("a2a", operation, e)
+            raise InternalError(message=f"{operation} failed") from e
 
     def _log_a2a_operation(
         self,
@@ -600,7 +624,6 @@ class AdCPRequestHandler(RequestHandler):
             status=TaskStatus(state=TaskState.TASK_STATE_WORKING),
             metadata=_dict_to_struct(task_metadata),
         )
-        self.tasks[task_id] = task
 
         # Bound BEFORE the try because the handler below reads it: identity is
         # resolved partway through, so any earlier failure — the push-config gate
@@ -665,19 +688,19 @@ class AdCPRequestHandler(RequestHandler):
             # unbound; it now sits before the `try` so every arm can read it.
             if auth_token:
                 identity = self._resolve_a2a_identity(auth_token, require_valid_token=requires_auth, context=context)
-            elif not requires_auth:
-                # Unauthenticated discovery request — resolve tenant from headers only
+            else:
+                # Unauthenticated discovery — requires_auth already gated above
                 identity = self._resolve_a2a_identity(None, require_valid_token=False, context=context)
 
-            # Record the owner now, before any skill dispatch can raise — get/cancel
-            # authorize an in-memory hit against this. An identity resolved without
-            # require_valid_token can carry a None principal_id, which can never match
-            # a later poll authenticated with require_valid_token=True (that path
-            # always has a non-None principal_id — see _resolve_a2a_identity), so an
-            # anonymously-created task simply becomes unpollable via the in-memory
-            # path rather than owned by nobody-in-particular. #1702
-            self._task_owners[task_id] = (
-                (identity.tenant_id, identity.principal_id) if identity is not None else (None, None)
+            # Store task + push config + owner together only after identity
+            # resolution succeeds. Auth failure above must leave no orphan
+            # entries in self.tasks / _task_push_configs / _task_owners. #1702
+            if push_notification_config:
+                self._task_push_configs[task_id] = push_notification_config
+            self.tasks[task_id] = task
+            self._task_owners[task_id] = _TaskOwner(
+                tenant_id=identity.tenant_id,
+                principal_id=identity.principal_id,
             )
 
             # Route: Handle explicit skill invocations first, then natural language fallback
@@ -1080,12 +1103,15 @@ class AdCPRequestHandler(RequestHandler):
 
     @staticmethod
     def _task_not_found(task_id: str) -> TaskNotFoundError:
-        """Build the shared not-found shape for get/cancel (no existence oracle).
+        """Build the TaskNotFoundError raised for unknown or unauthorized task ids.
 
-        A bare ``None`` return makes the SDK synthesize a generic internal error;
-        the A2A spec defines ``TaskNotFoundError`` for an unknown task id, so
-        raising it is the correct thing to do here and is what an A2A client
-        should be able to react to precisely.
+        Called via ``_get_owned_in_memory_task_or_raise`` for get/cancel when the
+        id is missing from ``self.tasks`` or the caller's identity does not match
+        the recorded owner — both collapse to this same shape (no existence
+        oracle). The A2A spec defines ``TaskNotFoundError`` for an unknown task
+        id; raising it is what an A2A client should be able to react to precisely.
+
+        A bare ``None`` return makes the SDK synthesize a generic internal error.
 
         What a client sees TODAY is still ``-32603``, not the spec's ``-32001``:
         this app builds its A2A routes with ``enable_v0_3_compat=True``
@@ -1107,7 +1133,9 @@ class AdCPRequestHandler(RequestHandler):
         """
         return TaskNotFoundError(message=f"Task not found: {task_id}", data={"task_id": task_id})
 
-    def _get_owned_in_memory_task_or_raise(self, task_id: str, context: ServerCallContext | None) -> Task:
+    def _get_owned_in_memory_task_or_raise(
+        self, task_id: str, context: ServerCallContext | None, *, operation: str
+    ) -> Task:
         """Auth-first owned in-memory lookup shared by ``on_get_task`` and ``on_cancel_task``.
 
         Authenticates the caller and checks OWNERSHIP before returning anything.
@@ -1115,26 +1143,33 @@ class AdCPRequestHandler(RequestHandler):
         logs, shared support channels); serving/mutating an in-memory hit
         unconditionally let any caller who learned it read or cancel a sibling
         principal's task with no authentication. Ownership is checked against
-        ``self._task_owners`` (the (tenant_id, principal_id) recorded at create).
+        ``self._task_owners`` (the ``_TaskOwner`` recorded at create).
 
-        Failed auth, wrong principal, or unknown id all raise the same
-        ``TaskNotFoundError`` — identical to an unknown task_id, so this cannot
-        be used as an existence oracle. #1702
+        Auth failures (``InvalidRequestError`` / ``A2AError``) propagate — they
+        must not collapse to ``TaskNotFoundError``. Only ownership miss or
+        unknown id raises ``TaskNotFoundError`` via ``_task_not_found`` (identical
+        shape, so this cannot be used as an existence oracle). #1702
         """
-        try:
-            auth_token = self._get_auth_token(context)
-            identity = self._resolve_a2a_identity(auth_token, require_valid_token=True, context=context)
-        except Exception as e:
-            logger.warning(
-                "Denying task access for %s — identity resolution failed: %s",
-                task_id,
-                e,
-            )
-            raise self._task_not_found(task_id) from e
+        identity = self._authenticate(context, operation=operation)
 
         task = self.tasks.get(task_id)
-        if task is None or self._task_owners.get(task_id) != (identity.tenant_id, identity.principal_id):
-            raise self._task_not_found(task_id)
+        expected_owner = _TaskOwner(tenant_id=identity.tenant_id, principal_id=identity.principal_id)
+        if task is None or self._task_owners.get(task_id) != expected_owner:
+            logger.warning(
+                "Failed to authorize task access for %s: tenant_id=%s principal_id=%s",
+                task_id,
+                identity.tenant_id,
+                identity.principal_id,
+            )
+            not_found = self._task_not_found(task_id)
+            record_boundary_error(
+                "a2a",
+                operation,
+                not_found,
+                tenant_id=identity.tenant_id,
+                principal_id=identity.principal_id,
+            )
+            raise not_found
         return task
 
     async def on_get_task(
@@ -1145,10 +1180,11 @@ class AdCPRequestHandler(RequestHandler):
         """Handle 'tasks/get' method to retrieve task status.
 
         Authenticates the poller and checks ownership before serving an
-        in-memory hit — see ``_get_owned_in_memory_task_or_raise`` (#1702;
-        and #1670 for why the wire code is still -32603).
+        in-memory hit — see ``_get_owned_in_memory_task_or_raise`` (#1702).
+        Wire error code for unknown/unauthorized ids is built by
+        ``_task_not_found`` (#1670 for why the wire code is still -32603).
         """
-        return self._get_owned_in_memory_task_or_raise(params.id, context)
+        return self._get_owned_in_memory_task_or_raise(params.id, context, operation="get_task")
 
     async def on_cancel_task(
         self,
@@ -1159,10 +1195,11 @@ class AdCPRequestHandler(RequestHandler):
 
         Same auth-first ownership gate as get — cancelling another principal's
         in-memory task is the same not-found condition as an unknown id, not a
-        silent no-op. See ``_get_owned_in_memory_task_or_raise`` (#1702; and
-        #1670 for why the wire code is still -32603).
+        silent no-op. See ``_get_owned_in_memory_task_or_raise`` (#1702).
+        Wire error code for unknown/unauthorized ids is built by
+        ``_task_not_found`` (#1670 for why the wire code is still -32603).
         """
-        task = self._get_owned_in_memory_task_or_raise(params.id, context)
+        task = self._get_owned_in_memory_task_or_raise(params.id, context, operation="cancel_task")
         # CopyFrom mutates the stored Task in place — self.tasks already holds
         # this exact reference, so re-storing it would rebind the same object.
         task.status.CopyFrom(TaskStatus(state=TaskState.TASK_STATE_CANCELED))

--- a/src/a2a_server/adcp_a2a_server.py
+++ b/src/a2a_server/adcp_a2a_server.py
@@ -221,7 +221,17 @@ DISCOVERY_SKILLS = frozenset(
 )
 
 
-def _internal_error_for(operation: str, exc: Exception) -> InternalError:
+def _task_not_found_message(task_id: str) -> str:
+    """Buyer-facing not-found message shared by wire raise and deny telemetry."""
+    return f"Task not found: {task_id}"
+
+
+def _safe_task_id_for_log(task_id: str) -> str:
+    """Truncate / neutralize attacker-controlled task ids before file/audit logs."""
+    return task_id.replace("\r", "\\r").replace("\n", "\\n")[:100]
+
+
+def _internal_error_for(operation: str, _exc: Exception) -> InternalError:
     """Canonical InternalError shape for non-skill A2A boundary failures.
 
     Skill handlers raise typed ``AdCPError`` (or untyped exceptions that the
@@ -232,23 +242,32 @@ def _internal_error_for(operation: str, exc: Exception) -> InternalError:
     for semantically identical untyped failures — divergence on the buyer-
     facing wire message for the same condition.
 
-    Use this helper at every non-skill ``InternalError(...)`` raise site that
-    is NOT a deliberate protocol-level convention (see push-notif handlers
-    below). The canonical prefix is ``"{operation} failed: {exc}"`` so
-    storyboard runners can parse the failure uniformly.
+    Use this helper at non-skill ``InternalError(...)`` raise sites that are
+    not a deliberate protocol-level convention. Do **not** use it from
+    ``_authenticate``: that path deliberately bypasses
+    ``normalize_to_adcp_error`` so SQL / bound parameters never reach the
+    client-facing message or envelope.
+
+    Client-facing message is a fixed ``"{operation} failed"`` phrase — never
+    interpolate ``str(exc)`` (SQLAlchemy includes SQL + bound params). Exception
+    detail belongs in ``record_boundary_error`` at the call site only
+    (``_exc`` is retained for call-site clarity / future typed mapping).
 
     The four ``on_*_task_push_notification_config`` JSON-RPC protocol methods use
     this helper too — they have no async Task to carry a DataPart, so the two-layer
-    envelope rides in the error's ``data`` field (``error.data["errors"][0]["code"]``
-    / ``error.data["adcp_error"]``). ``InternalError`` stays an ``A2AError`` so the
-    SDK's ``JsonRpcDispatcher`` serializes it as a structured JSON-RPC error; raising
-    a non-``A2AError`` (e.g. ``AdCPAdapterError``) would hit the dispatcher's
-    ``except Exception`` branch and be flattened to a bare ``InternalError`` with no
-    envelope.
+    envelope is attached on ``InternalError.data``. Under v0.3 compat that
+    ``data`` is flattened to null on the wire (#1670); attaching it is still
+    correct for when flattening lifts. ``InternalError`` stays an ``A2AError`` so
+    the SDK's ``JsonRpcDispatcher`` serializes it as a structured JSON-RPC error;
+    raising a non-``A2AError`` would hit the dispatcher's ``except Exception``
+    branch and be flattened to a bare ``InternalError`` with no envelope.
     """
+    # Fixed phrase only — class defaults map INTERNAL_ERROR → SERVICE_UNAVAILABLE
+    # with recovery=transient on the envelope.
+    fixed = f"{operation} failed"
     return InternalError(
-        message=f"{operation} failed: {exc}",
-        data=build_two_layer_error_envelope(normalize_to_adcp_error(exc)),
+        message=fixed,
+        data=build_two_layer_error_envelope(AdCPError(message=fixed)),
     )
 
 
@@ -436,15 +455,11 @@ class AdCPRequestHandler(RequestHandler):
             wire_op = operation.replace("_", " ")
             # Fixed message + typed envelope — do NOT route through
             # ``normalize_to_adcp_error(e)`` (re-copies ``str(exc)`` / SQL).
+            # AdCPError class defaults: INTERNAL_ERROR → wire SERVICE_UNAVAILABLE,
+            # recovery=transient (do not hand-write error_code=/recovery=).
             raise InternalError(
                 message=f"{wire_op} failed",
-                data=build_two_layer_error_envelope(
-                    AdCPError(
-                        message=f"{wire_op} failed",
-                        error_code="INTERNAL_ERROR",
-                        recovery="transient",
-                    )
-                ),
+                data=build_two_layer_error_envelope(AdCPError(message=f"{wire_op} failed")),
             ) from e
 
     def _log_a2a_operation(
@@ -712,6 +727,7 @@ class AdCPRequestHandler(RequestHandler):
             # Store task + push config + owner together only after identity
             # resolution succeeds. Auth failure above must leave no orphan
             # entries in self.tasks / _task_push_configs / _task_owners. #1702
+            # Push config lives outside protobuf metadata (not JSON-serializable).
             if push_notification_config:
                 self._task_push_configs[task_id] = push_notification_config
             self.tasks[task_id] = task
@@ -1148,7 +1164,7 @@ class AdCPRequestHandler(RequestHandler):
         the real route returns ``data: null``. Populating it is still correct
         and becomes readable when #1670 closes, the same as the code.
         """
-        return TaskNotFoundError(message=f"Task not found: {task_id}", data={"task_id": task_id})
+        return TaskNotFoundError(message=_task_not_found_message(task_id), data={"task_id": task_id})
 
     def _get_owned_in_memory_task_or_raise(
         self, task_id: str, context: ServerCallContext | None, *, operation: str
@@ -1173,10 +1189,12 @@ class AdCPRequestHandler(RequestHandler):
         expected_owner = _TaskOwner(tenant_id=identity.tenant_id, principal_id=identity.principal_id)
         if task is None or self._task_owners.get(task_id) != expected_owner:
             # Wire must stay indistinguishable (existence oracle); log may branch.
-            if task is not None:
+            log_task_id = _safe_task_id_for_log(task_id)
+            ownership_miss = task is not None
+            if ownership_miss:
                 logger.warning(
                     "Ownership denial for task %s: caller tenant_id=%s principal_id=%s",
-                    task_id,
+                    log_task_id,
                     identity.tenant_id,
                     identity.principal_id,
                 )
@@ -1184,7 +1202,7 @@ class AdCPRequestHandler(RequestHandler):
                 logger.warning(
                     "Unknown task id on %s: task_id=%s caller tenant_id=%s principal_id=%s",
                     operation,
-                    task_id,
+                    log_task_id,
                     identity.tenant_id,
                     identity.principal_id,
                 )
@@ -1192,12 +1210,17 @@ class AdCPRequestHandler(RequestHandler):
             # is an A2AError, not AdCPError — passing it took the untyped
             # ``exc_info=True`` path with no active exception (NoneType: None)
             # and logged ordinary stale-handle polls at ERROR.
+            # Unknown-id / stale-handle: omit tenant_id/principal_id so sinks
+            # self-skip (no feed/audit flood). Ownership miss keeps full sinks.
+            telem_kwargs: dict[str, Any] = {}
+            if ownership_miss:
+                telem_kwargs["tenant_id"] = identity.tenant_id
+                telem_kwargs["principal_id"] = identity.principal_id
             record_boundary_error(
                 "a2a",
                 operation,
-                AdCPTaskNotFoundError(message=f"Task not found: {task_id}"),
-                tenant_id=identity.tenant_id,
-                principal_id=identity.principal_id,
+                AdCPTaskNotFoundError(message=_task_not_found_message(log_task_id)),
+                **telem_kwargs,
             )
             raise self._task_not_found(task_id)
         return task

--- a/src/a2a_server/adcp_a2a_server.py
+++ b/src/a2a_server/adcp_a2a_server.py
@@ -414,12 +414,23 @@ class AdCPRequestHandler(RequestHandler):
             testing_context=identity.testing_context,
         )
 
+    # Snake_case op ids for record_boundary_error → buyer-facing wire phrases.
+    _AUTH_OPERATION_WIRE_PHRASES: dict[str, str] = {
+        "get_task": "get task",
+        "cancel_task": "cancel task",
+        "get_push_notification_config": "get push notification config",
+        "create_push_notification_config": "create push notification config",
+        "list_push_notification_configs": "list push notification configs",
+        "delete_push_notification_config": "delete push notification config",
+    }
+
     def _authenticate(self, context: ServerCallContext | None, *, operation: str) -> ResolvedIdentity:
         """Resolve a valid principal identity for authenticated A2A operations.
 
         Auth failures (``A2AError`` / ``InvalidRequestError``) propagate unchanged.
-        Unexpected failures become ``InternalError`` with a fixed message — never
-        interpolate ``str(exc)`` into the client-facing message.
+        Unexpected failures become ``InternalError`` with a fixed human-phrase
+        message — never interpolate ``str(exc)`` or raw snake_case op ids into
+        the client-facing message (e.g. ``get_task`` → ``"get task failed"``).
         """
         auth_token = self._get_auth_token(context)
         try:
@@ -428,7 +439,8 @@ class AdCPRequestHandler(RequestHandler):
             raise
         except Exception as e:
             record_boundary_error("a2a", operation, e)
-            raise InternalError(message=f"{operation} failed") from e
+            wire_op = self._AUTH_OPERATION_WIRE_PHRASES.get(operation, operation.replace("_", " "))
+            raise InternalError(message=f"{wire_op} failed") from e
 
     def _log_a2a_operation(
         self,
@@ -1233,10 +1245,7 @@ class AdCPRequestHandler(RequestHandler):
         """
         tool_context = None
         try:
-            auth_token = self._get_auth_token(context)
-            if not auth_token:
-                raise InvalidRequestError(message="Missing authentication token")
-            identity = self._resolve_a2a_identity(auth_token, context=context)
+            identity = self._authenticate(context, operation="get_push_notification_config")
             tool_context = self._make_tool_context(identity, "get_push_notification_config")
 
             config_id = params.get("id") if isinstance(params, dict) else getattr(params, "id", None)
@@ -1302,10 +1311,7 @@ class AdCPRequestHandler(RequestHandler):
         """
         tool_context = None
         try:
-            auth_token = self._get_auth_token(context)
-            if not auth_token:
-                raise InvalidRequestError(message="Missing authentication token")
-            identity = self._resolve_a2a_identity(auth_token, context=context)
+            identity = self._authenticate(context, operation="create_push_notification_config")
             tool_context = self._make_tool_context(identity, "set_push_notification_config")
 
             # In a2a-sdk 1.0, TaskPushNotificationConfig is a flat protobuf message
@@ -1383,10 +1389,7 @@ class AdCPRequestHandler(RequestHandler):
         """
         tool_context = None
         try:
-            auth_token = self._get_auth_token(context)
-            if not auth_token:
-                raise InvalidRequestError(message="Missing authentication token")
-            identity = self._resolve_a2a_identity(auth_token, context=context)
+            identity = self._authenticate(context, operation="list_push_notification_configs")
             tool_context = self._make_tool_context(identity, "list_push_notification_configs")
 
             with PushNotificationConfigUoW(tool_context.tenant_id) as uow:
@@ -1441,10 +1444,7 @@ class AdCPRequestHandler(RequestHandler):
         """
         tool_context = None
         try:
-            auth_token = self._get_auth_token(context)
-            if not auth_token:
-                raise InvalidRequestError(message="Missing authentication token")
-            identity = self._resolve_a2a_identity(auth_token, context=context)
+            identity = self._authenticate(context, operation="delete_push_notification_config")
             tool_context = self._make_tool_context(identity, "delete_push_notification_config")
 
             config_id = params.id

--- a/src/a2a_server/adcp_a2a_server.py
+++ b/src/a2a_server/adcp_a2a_server.py
@@ -669,6 +669,17 @@ class AdCPRequestHandler(RequestHandler):
                 # Unauthenticated discovery request — resolve tenant from headers only
                 identity = self._resolve_a2a_identity(None, require_valid_token=False, context=context)
 
+            # Record the owner now, before any skill dispatch can raise — get/cancel
+            # authorize an in-memory hit against this. An identity resolved without
+            # require_valid_token can carry a None principal_id, which can never match
+            # a later poll authenticated with require_valid_token=True (that path
+            # always has a non-None principal_id — see _resolve_a2a_identity), so an
+            # anonymously-created task simply becomes unpollable via the in-memory
+            # path rather than owned by nobody-in-particular. #1702
+            self._task_owners[task_id] = (
+                (identity.tenant_id, identity.principal_id) if identity is not None else (None, None)
+            )
+
             # Route: Handle explicit skill invocations first, then natural language fallback
             if skill_invocations:
                 # Process explicit skill invocations
@@ -1067,8 +1078,9 @@ class AdCPRequestHandler(RequestHandler):
         # result is already Task | Message — yield it directly
         yield result
 
-    def _get_task_or_raise(self, task_id: str) -> Task:
-        """Return the in-memory task, or raise ``TaskNotFoundError``.
+    @staticmethod
+    def _task_not_found(task_id: str) -> TaskNotFoundError:
+        """Build the shared not-found shape for get/cancel (no existence oracle).
 
         A bare ``None`` return makes the SDK synthesize a generic internal error;
         the A2A spec defines ``TaskNotFoundError`` for an unknown task id, so
@@ -1092,13 +1104,37 @@ class AdCPRequestHandler(RequestHandler):
         ``CoreInternalError(message=str(e))``, which drops ``data`` — driving
         the real route returns ``data: null``. Populating it is still correct
         and becomes readable when #1670 closes, the same as the code.
-
-        Shared by ``on_get_task`` and ``on_cancel_task`` so both surface the
-        same error.
         """
+        return TaskNotFoundError(message=f"Task not found: {task_id}", data={"task_id": task_id})
+
+    def _get_owned_in_memory_task_or_raise(self, task_id: str, context: ServerCallContext | None) -> Task:
+        """Auth-first owned in-memory lookup shared by ``on_get_task`` and ``on_cancel_task``.
+
+        Authenticates the caller and checks OWNERSHIP before returning anything.
+        A task_id is unguessable but not secret once known (webhook payloads,
+        logs, shared support channels); serving/mutating an in-memory hit
+        unconditionally let any caller who learned it read or cancel a sibling
+        principal's task with no authentication. Ownership is checked against
+        ``self._task_owners`` (the (tenant_id, principal_id) recorded at create).
+
+        Failed auth, wrong principal, or unknown id all raise the same
+        ``TaskNotFoundError`` — identical to an unknown task_id, so this cannot
+        be used as an existence oracle. #1702
+        """
+        try:
+            auth_token = self._get_auth_token(context)
+            identity = self._resolve_a2a_identity(auth_token, require_valid_token=True, context=context)
+        except Exception as e:
+            logger.warning(
+                "Denying task access for %s — identity resolution failed: %s",
+                task_id,
+                e,
+            )
+            raise self._task_not_found(task_id) from e
+
         task = self.tasks.get(task_id)
-        if task is None:
-            raise TaskNotFoundError(message=f"Task not found: {task_id}", data={"task_id": task_id})
+        if task is None or self._task_owners.get(task_id) != (identity.tenant_id, identity.principal_id):
+            raise self._task_not_found(task_id)
         return task
 
     async def on_get_task(
@@ -1108,10 +1144,11 @@ class AdCPRequestHandler(RequestHandler):
     ) -> Task:
         """Handle 'tasks/get' method to retrieve task status.
 
-        Raises ``TaskNotFoundError`` for an unknown task id — see
-        ``_get_task_or_raise`` (and #1670 for why the wire code is still -32603).
+        Authenticates the poller and checks ownership before serving an
+        in-memory hit — see ``_get_owned_in_memory_task_or_raise`` (#1702;
+        and #1670 for why the wire code is still -32603).
         """
-        return self._get_task_or_raise(params.id)
+        return self._get_owned_in_memory_task_or_raise(params.id, context)
 
     async def on_cancel_task(
         self,
@@ -1120,12 +1157,12 @@ class AdCPRequestHandler(RequestHandler):
     ) -> Task:
         """Handle 'tasks/cancel' method to cancel a task.
 
-        Raises ``TaskNotFoundError`` for an unknown task id — cancelling a task
-        that does not exist is the same not-found condition as get, not a silent
-        no-op. See ``_get_task_or_raise`` (and #1670 for why the wire code is
-        still -32603).
+        Same auth-first ownership gate as get — cancelling another principal's
+        in-memory task is the same not-found condition as an unknown id, not a
+        silent no-op. See ``_get_owned_in_memory_task_or_raise`` (#1702; and
+        #1670 for why the wire code is still -32603).
         """
-        task = self._get_task_or_raise(params.id)
+        task = self._get_owned_in_memory_task_or_raise(params.id, context)
         # CopyFrom mutates the stored Task in place — self.tasks already holds
         # this exact reference, so re-storing it would rebind the same object.
         task.status.CopyFrom(TaskStatus(state=TaskState.TASK_STATE_CANCELED))

--- a/src/a2a_server/adcp_a2a_server.py
+++ b/src/a2a_server/adcp_a2a_server.py
@@ -13,7 +13,7 @@ from collections.abc import AsyncGenerator, Awaitable, Callable
 
 # Import core functions for direct calls (raw functions without FastMCP decorators)
 from datetime import UTC, datetime
-from typing import Any, NamedTuple
+from typing import Any, NamedTuple, NoReturn
 
 from a2a.server.context import ServerCallContext
 from a2a.server.events.event_queue import Event
@@ -63,6 +63,7 @@ from src.core.exceptions import (
     AdCPAuthRequiredError,
     AdCPCapabilityNotSupportedError,
     AdCPError,
+    AdCPServiceUnavailableError,
     AdCPTaskNotFoundError,
     AdCPValidationError,
     build_two_layer_error_envelope,
@@ -278,12 +279,11 @@ def _internal_error_for(operation: str, exc: Exception) -> InternalError:
             message=exc.message,
             data=build_two_layer_error_envelope(exc),
         )
-    # Untyped: fixed phrase only — class defaults map INTERNAL_ERROR →
-    # SERVICE_UNAVAILABLE with recovery=transient on the envelope.
+    # Untyped: fixed phrase via typed SERVICE_UNAVAILABLE (not base AdCPError).
     fixed = f"{operation} failed"
     return InternalError(
         message=fixed,
-        data=build_two_layer_error_envelope(AdCPError(message=fixed)),
+        data=build_two_layer_error_envelope(AdCPServiceUnavailableError(message=fixed)),
     )
 
 
@@ -382,7 +382,15 @@ class AdCPRequestHandler(RequestHandler):
         headers = auth_ctx.headers if auth_ctx else {}
 
         if require_valid_token and not auth_token:
-            raise InvalidRequestError(message="Missing authentication token")
+            raise InvalidRequestError(
+                message="Missing authentication token",
+                data=build_two_layer_error_envelope(
+                    AdCPAuthRequiredError(
+                        "Missing authentication token",
+                        suggestion=AUTH_REQUIRED_SUGGESTION,
+                    )
+                ),
+            )
 
         # Extract testing context from A2A request headers (same as MCP does)
         testing_context = AdCPTestContext.from_headers(headers)
@@ -470,7 +478,7 @@ class AdCPRequestHandler(RequestHandler):
             # Underscore→space is the wire phrase; keep op ids underscore-replaceable.
             # Delegate to ``_internal_error_for`` (typed + untyped); never interpolate
             # ``str(exc)`` / SQL (do not hand-write error_code=/recovery=).
-            raise _internal_error_for(operation.replace("_", " "), e) from e
+            raise _internal_error_for(_wire_phrase(operation), e) from e
 
     def _log_a2a_operation(
         self,
@@ -1116,7 +1124,7 @@ class AdCPRequestHandler(RequestHandler):
             # Raise A2A error — ``_internal_error_for`` keeps SQL out of the
             # client-facing InternalError message/envelope (do not attach a
             # normalize_to_adcp_error artifact on this raising path).
-            raise _internal_error_for("message processing", e)
+            raise _internal_error_for("message processing", e) from e
 
         self.tasks[task_id] = task
         return task
@@ -1181,6 +1189,31 @@ class AdCPRequestHandler(RequestHandler):
         data["task_id"] = safe_id
         return TaskNotFoundError(message=adcp_err.message, data=data)
 
+    def _deny_task_access(
+        self,
+        task_id: str,
+        operation: str,
+        identity: ResolvedIdentity,
+    ) -> NoReturn:
+        """Single denial path for unknown id and ownership miss (#1702).
+
+        Receives no branch discriminator — the wire, telemetry, and log must stay
+        symmetric (error-handling.mdx observability MUST).
+        """
+        safe_id = _safe_task_id_for_log(task_id)
+        adcp_err = AdCPTaskNotFoundError(message=_task_not_found_message(safe_id))
+        logger.warning(
+            "Task access denied on %s: task_id=%s caller tenant_id=%s principal_id=%s",
+            operation,
+            safe_id,
+            identity.tenant_id,
+            identity.principal_id,
+        )
+        record_boundary_error("a2a", operation, adcp_err)
+        data = build_two_layer_error_envelope(adcp_err)
+        data["task_id"] = safe_id
+        raise TaskNotFoundError(message=adcp_err.message, data=data)
+
     def _get_owned_in_memory_task_or_raise(
         self, task_id: str, context: ServerCallContext | None, *, operation: str
     ) -> Task:
@@ -1195,39 +1228,19 @@ class AdCPRequestHandler(RequestHandler):
 
         Auth failures (``InvalidRequestError`` / ``A2AError``) propagate — they
         must not collapse to ``TaskNotFoundError``. Only ownership miss or
-        unknown id raises ``TaskNotFoundError`` via ``_task_not_found`` (identical
+        unknown id raises ``TaskNotFoundError`` via ``_deny_task_access`` (identical
         shape, so this cannot be used as an existence oracle). #1702
         """
         identity = self._authenticate(context, operation=operation)
 
         task = self.tasks.get(task_id)
+        stored_owner = self._task_owners.get(task_id)
         expected_owner = _TaskOwner(tenant_id=identity.tenant_id, principal_id=identity.principal_id)
-        # Fail closed on null principal (must not match a null-owner row) and
-        # evaluate ownership unconditionally (error-handling.mdx § Side effects).
-        if task is None or not identity.principal_id or self._task_owners.get(task_id) != expected_owner:
-            # Wire must stay indistinguishable (existence oracle). Stdlib log may
-            # branch for operators; side-effect sinks MUST stay symmetric
-            # (error-handling.mdx:206-207) — both omit tenant/principal so feeds
-            # self-skip (no asymmetric audit flood).
-            log_task_id = _safe_task_id_for_log(task_id)
-            ownership_miss = task is not None and bool(identity.principal_id)
-            # Structurally identical traces on both branches (error-handling.mdx:207).
-            logger.warning(
-                "Task access denied on %s: task_id=%s ownership_miss=%s caller tenant_id=%s principal_id=%s",
-                operation,
-                log_task_id,
-                ownership_miss,
-                identity.tenant_id,
-                identity.principal_id,
-            )
-            # Telemetry uses typed AdCPError (WARNING branch). Identical kwargs on
-            # both branches — omit tenant_id/principal_id so sinks self-skip.
-            record_boundary_error(
-                "a2a",
-                operation,
-                AdCPTaskNotFoundError(message=_task_not_found_message(log_task_id)),
-            )
-            raise self._task_not_found(task_id)
+        # Resolve-then-authorize: evaluate owner compare even on true-miss
+        # (error-handling.mdx:209 — no short-circuit on unknown id).
+        authorized = task is not None and identity.principal_id and stored_owner == expected_owner
+        if not authorized:
+            self._deny_task_access(task_id, operation, identity)
         return task
 
     async def on_get_task(
@@ -1290,9 +1303,10 @@ class AdCPRequestHandler(RequestHandler):
         Retrieves the push notification configuration for a specific config ID.
         """
         tool_context = None
+        operation = "get_push_notification_config"
         try:
-            identity = self._authenticate(context, operation="get_push_notification_config")
-            tool_context = self._make_tool_context(identity, "get_push_notification_config")
+            identity = self._authenticate(context, operation=operation)
+            tool_context = self._make_tool_context(identity, operation)
 
             config_id = params.get("id") if isinstance(params, dict) else getattr(params, "id", None)
             if not config_id:
@@ -1338,12 +1352,12 @@ class AdCPRequestHandler(RequestHandler):
         except Exception as e:
             record_boundary_error(
                 "a2a",
-                "get_push_notification_config",
+                operation,
                 e,
                 tenant_id=tool_context.tenant_id if tool_context else None,
                 principal_id=tool_context.principal_id if tool_context else None,
             )
-            raise _internal_error_for("get push notification config", e) from e
+            raise _internal_error_for(_wire_phrase(operation), e) from e
 
     async def on_create_task_push_notification_config(
         self,
@@ -1356,11 +1370,10 @@ class AdCPRequestHandler(RequestHandler):
         Buyers use this to register webhook URLs where they want to receive status updates.
         """
         tool_context = None
+        operation = "set_push_notification_config"
         try:
-            # Op id must match tool_context + body error path ("set …") so auth
-            # failures join the same method vocabulary.
-            identity = self._authenticate(context, operation="set_push_notification_config")
-            tool_context = self._make_tool_context(identity, "set_push_notification_config")
+            identity = self._authenticate(context, operation=operation)
+            tool_context = self._make_tool_context(identity, operation)
 
             # In a2a-sdk 1.0, TaskPushNotificationConfig is a flat protobuf message
             # with fields: tenant, id, task_id, url, token, authentication
@@ -1419,12 +1432,12 @@ class AdCPRequestHandler(RequestHandler):
         except Exception as e:
             record_boundary_error(
                 "a2a",
-                "set_push_notification_config",
+                operation,
                 e,
                 tenant_id=tool_context.tenant_id if tool_context else None,
                 principal_id=tool_context.principal_id if tool_context else None,
             )
-            raise _internal_error_for("set push notification config", e) from e
+            raise _internal_error_for(_wire_phrase(operation), e) from e
 
     async def on_list_task_push_notification_configs(
         self,
@@ -1436,9 +1449,10 @@ class AdCPRequestHandler(RequestHandler):
         Returns all active push notification configurations for the authenticated principal.
         """
         tool_context = None
+        operation = "list_push_notification_configs"
         try:
-            identity = self._authenticate(context, operation="list_push_notification_configs")
-            tool_context = self._make_tool_context(identity, "list_push_notification_configs")
+            identity = self._authenticate(context, operation=operation)
+            tool_context = self._make_tool_context(identity, operation)
 
             with PushNotificationConfigUoW(tool_context.tenant_id) as uow:
                 assert uow.push_notification_configs is not None
@@ -1474,12 +1488,12 @@ class AdCPRequestHandler(RequestHandler):
         except Exception as e:
             record_boundary_error(
                 "a2a",
-                "list_push_notification_configs",
+                operation,
                 e,
                 tenant_id=tool_context.tenant_id if tool_context else None,
                 principal_id=tool_context.principal_id if tool_context else None,
             )
-            raise _internal_error_for("list push notification configs", e) from e
+            raise _internal_error_for(_wire_phrase(operation), e) from e
 
     async def on_delete_task_push_notification_config(
         self,
@@ -1491,9 +1505,10 @@ class AdCPRequestHandler(RequestHandler):
         Marks a push notification configuration as inactive (soft delete).
         """
         tool_context = None
+        operation = "delete_push_notification_config"
         try:
-            identity = self._authenticate(context, operation="delete_push_notification_config")
-            tool_context = self._make_tool_context(identity, "delete_push_notification_config")
+            identity = self._authenticate(context, operation=operation)
+            tool_context = self._make_tool_context(identity, operation)
 
             config_id = params.id
             if not config_id:
@@ -1516,12 +1531,12 @@ class AdCPRequestHandler(RequestHandler):
         except Exception as e:
             record_boundary_error(
                 "a2a",
-                "delete_push_notification_config",
+                operation,
                 e,
                 tenant_id=tool_context.tenant_id if tool_context else None,
                 principal_id=tool_context.principal_id if tool_context else None,
             )
-            raise _internal_error_for("delete push notification config", e) from e
+            raise _internal_error_for(_wire_phrase(operation), e) from e
 
     async def on_get_extended_agent_card(
         self,

--- a/src/a2a_server/adcp_a2a_server.py
+++ b/src/a2a_server/adcp_a2a_server.py
@@ -226,13 +226,13 @@ DISCOVERY_SKILLS = frozenset(
 def _task_not_found_message(task_id: str) -> str:
     """Buyer-facing not-found message (wire raise + deny telemetry when ids match).
 
-    Callers that sanitize for logs (``_safe_task_id_for_log``) may pass a different
+    Callers that sanitize for logs (``_safe_id_for_log``) may pass a different
     id than the raw wire raise — both still use this formatter.
     """
     return f"Task not found: {task_id}"
 
 
-def _safe_task_id_for_log(task_id: str) -> str:
+def _safe_id_for_log(task_id: str) -> str:
     """Neutralize attacker-controlled task ids before logs / buyer-facing messages.
 
     Allowlist keeps ``task_<hex>``-shaped ids intact; everything else becomes ``?``.
@@ -303,6 +303,7 @@ class AdCPRequestHandler(RequestHandler):
         # The VALUE, not the raw protobuf: what is stashed here is handed straight
         # to the sender, so it must carry the gate's receipt.
         self._task_push_configs: dict[str, ValidatedWebhookRegistration] = {}
+        self._task_owners: dict[str, _TaskOwner] = {}
         logger.info("AdCP Request Handler initialized for direct function calls")
 
     @staticmethod
@@ -478,7 +479,7 @@ class AdCPRequestHandler(RequestHandler):
             # Underscore→space is the wire phrase; keep op ids underscore-replaceable.
             # Delegate to ``_internal_error_for`` (typed + untyped); never interpolate
             # ``str(exc)`` / SQL (do not hand-write error_code=/recovery=).
-            raise _internal_error_for(_wire_phrase(operation), e) from e
+            raise _internal_error_for(operation.replace("_", " "), e) from e
 
     def _log_a2a_operation(
         self,
@@ -571,7 +572,7 @@ class AdCPRequestHandler(RequestHandler):
             # row is expected and the registration this sender holds
             # (ValidatedWebhookRegistration) carries no scope ids to give it.
             # Stating them as None is what makes that visible -- the dict this
-            # replaced simply had no such keys (salesagent-pldmk.39).
+            # replaced simply had no such keys (GH #1802).
             webhook_task = WebhookTaskContext(
                 task_id=task.id,
                 task_type=skills[0] if skills else "unknown",
@@ -749,8 +750,6 @@ class AdCPRequestHandler(RequestHandler):
             # Push config lives outside protobuf metadata (not JSON-serializable).
             # Failure webhooks before this point thread ``config=`` into
             # ``_send_protocol_webhook`` rather than writing the map early.
-            if push_notification_config:
-                self._task_push_configs[task_id] = push_notification_config
             self.tasks[task_id] = task
             self._task_owners[task_id] = _TaskOwner(
                 tenant_id=identity.tenant_id,
@@ -1175,7 +1174,7 @@ class AdCPRequestHandler(RequestHandler):
         live-server test pins the current reality.
 
         The requested id is put on both the message and structured ``data``
-        (sanitized via ``_safe_task_id_for_log`` so control characters cannot
+        (sanitized via ``_safe_id_for_log`` so control characters cannot
         forge log lines one frame away in the compat adapter). Only the message
         reaches a client today: the same compat adapter that flattens the code
         to ``-32603`` rebuilds the error as ``CoreInternalError(message=str(e))``,
@@ -1183,7 +1182,7 @@ class AdCPRequestHandler(RequestHandler):
         Populating it is still correct and becomes readable when #1670 closes,
         the same as the code.
         """
-        safe_id = _safe_task_id_for_log(task_id)
+        safe_id = _safe_id_for_log(task_id)
         adcp_err = AdCPTaskNotFoundError(message=_task_not_found_message(safe_id))
         data = build_two_layer_error_envelope(adcp_err)
         data["task_id"] = safe_id
@@ -1200,7 +1199,7 @@ class AdCPRequestHandler(RequestHandler):
         Receives no branch discriminator — the wire, telemetry, and log must stay
         symmetric (error-handling.mdx observability MUST).
         """
-        safe_id = _safe_task_id_for_log(task_id)
+        safe_id = _safe_id_for_log(task_id)
         adcp_err = AdCPTaskNotFoundError(message=_task_not_found_message(safe_id))
         logger.warning(
             "Task access denied on %s: task_id=%s caller tenant_id=%s principal_id=%s",
@@ -1358,7 +1357,7 @@ class AdCPRequestHandler(RequestHandler):
                 tenant_id=tool_context.tenant_id if tool_context else None,
                 principal_id=tool_context.principal_id if tool_context else None,
             )
-            raise _internal_error_for(_wire_phrase(operation), e) from e
+            raise _internal_error_for(operation.replace("_", " "), e) from e
 
     async def on_create_task_push_notification_config(
         self,
@@ -1393,7 +1392,7 @@ class AdCPRequestHandler(RequestHandler):
             # manufactures field="push_notification_config.url" plus the https SSRF
             # wording for a non-AdCP error -- so a credential refusal raised from
             # inside the repository would reach the buyer as "fix your URL" about a
-            # URL that is fine (salesagent-47n9.20).
+            # URL that is fine (GH #1802).
             registration = _accept_a2a_push_config(url, auth_type, auth_token_value)
 
             # No ValueError funnel around upsert any more: the repository no longer
@@ -1438,7 +1437,7 @@ class AdCPRequestHandler(RequestHandler):
                 tenant_id=tool_context.tenant_id if tool_context else None,
                 principal_id=tool_context.principal_id if tool_context else None,
             )
-            raise _internal_error_for(_wire_phrase(operation), e) from e
+            raise _internal_error_for(operation.replace("_", " "), e) from e
 
     async def on_list_task_push_notification_configs(
         self,
@@ -1494,7 +1493,7 @@ class AdCPRequestHandler(RequestHandler):
                 tenant_id=tool_context.tenant_id if tool_context else None,
                 principal_id=tool_context.principal_id if tool_context else None,
             )
-            raise _internal_error_for(_wire_phrase(operation), e) from e
+            raise _internal_error_for(operation.replace("_", " "), e) from e
 
     async def on_delete_task_push_notification_config(
         self,
@@ -1537,7 +1536,7 @@ class AdCPRequestHandler(RequestHandler):
                 tenant_id=tool_context.tenant_id if tool_context else None,
                 principal_id=tool_context.principal_id if tool_context else None,
             )
-            raise _internal_error_for(_wire_phrase(operation), e) from e
+            raise _internal_error_for(operation.replace("_", " "), e) from e
 
     async def on_get_extended_agent_card(
         self,
@@ -1672,7 +1671,7 @@ class AdCPRequestHandler(RequestHandler):
         # order (``error.data.adcp_error``). Without it the A2A wire carried a
         # bare JSON-RPC error and the buyer-facing code and suggestion that REST
         # returns were simply absent, which the test harness was papering over by
-        # synthesizing an envelope production never sent (salesagent-pldmk.26).
+        # synthesizing an envelope production never sent (GH #1802).
         #
         # AUTH_REQUIRED is the correct code at the 3.1.1 pin, not merely the
         # consistent one. The pin's enum marks it deprecated in favour of
@@ -1683,7 +1682,7 @@ class AdCPRequestHandler(RequestHandler):
         # attached". The generated features grade AUTH_REQUIRED accordingly,
         # including for the invalid-token case (BR-UC-011:256). The pin
         # contradicts itself here -- transport-errors.mdx separately reserves
-        # -32028 for AUTH_MISSING -- and salesagent-pldmk.38 tracks raising that
+        # -32028 for AUTH_MISSING -- and GH #1802 tracks raising that
         # upstream and migrating when the pin actually performs the split.
         if skill_name not in DISCOVERY_SKILLS and (identity is None or not identity.principal_id):
             raise InvalidRequestError(

--- a/src/a2a_server/adcp_a2a_server.py
+++ b/src/a2a_server/adcp_a2a_server.py
@@ -62,6 +62,7 @@ from src.core.exceptions import (
     AdCPAuthRequiredError,
     AdCPCapabilityNotSupportedError,
     AdCPError,
+    AdCPTaskNotFoundError,
     AdCPValidationError,
     build_two_layer_error_envelope,
     normalize_to_adcp_error,
@@ -414,23 +415,15 @@ class AdCPRequestHandler(RequestHandler):
             testing_context=identity.testing_context,
         )
 
-    # Snake_case op ids for record_boundary_error → buyer-facing wire phrases.
-    _AUTH_OPERATION_WIRE_PHRASES: dict[str, str] = {
-        "get_task": "get task",
-        "cancel_task": "cancel task",
-        "get_push_notification_config": "get push notification config",
-        "create_push_notification_config": "create push notification config",
-        "list_push_notification_configs": "list push notification configs",
-        "delete_push_notification_config": "delete push notification config",
-    }
-
     def _authenticate(self, context: ServerCallContext | None, *, operation: str) -> ResolvedIdentity:
         """Resolve a valid principal identity for authenticated A2A operations.
 
         Auth failures (``A2AError`` / ``InvalidRequestError``) propagate unchanged.
         Unexpected failures become ``InternalError`` with a fixed human-phrase
-        message — never interpolate ``str(exc)`` or raw snake_case op ids into
-        the client-facing message (e.g. ``get_task`` → ``"get task failed"``).
+        message and a two-layer recovery envelope — never interpolate ``str(exc)``
+        or raw snake_case op ids into the client-facing message
+        (e.g. ``get_task`` → ``"get task failed"``). Op ids are chosen so
+        ``operation.replace("_", " ")`` is the wire phrase (no hand-maintained map).
         """
         auth_token = self._get_auth_token(context)
         try:
@@ -439,8 +432,20 @@ class AdCPRequestHandler(RequestHandler):
             raise
         except Exception as e:
             record_boundary_error("a2a", operation, e)
-            wire_op = self._AUTH_OPERATION_WIRE_PHRASES.get(operation, operation.replace("_", " "))
-            raise InternalError(message=f"{wire_op} failed") from e
+            # Underscore→space is the wire phrase; keep op ids underscore-replaceable.
+            wire_op = operation.replace("_", " ")
+            # Fixed message + typed envelope — do NOT route through
+            # ``normalize_to_adcp_error(e)`` (re-copies ``str(exc)`` / SQL).
+            raise InternalError(
+                message=f"{wire_op} failed",
+                data=build_two_layer_error_envelope(
+                    AdCPError(
+                        message=f"{wire_op} failed",
+                        error_code="INTERNAL_ERROR",
+                        recovery="transient",
+                    )
+                ),
+            ) from e
 
     def _log_a2a_operation(
         self,
@@ -1167,21 +1172,34 @@ class AdCPRequestHandler(RequestHandler):
         task = self.tasks.get(task_id)
         expected_owner = _TaskOwner(tenant_id=identity.tenant_id, principal_id=identity.principal_id)
         if task is None or self._task_owners.get(task_id) != expected_owner:
-            logger.warning(
-                "Failed to authorize task access for %s: tenant_id=%s principal_id=%s",
-                task_id,
-                identity.tenant_id,
-                identity.principal_id,
-            )
-            not_found = self._task_not_found(task_id)
+            # Wire must stay indistinguishable (existence oracle); log may branch.
+            if task is not None:
+                logger.warning(
+                    "Ownership denial for task %s: caller tenant_id=%s principal_id=%s",
+                    task_id,
+                    identity.tenant_id,
+                    identity.principal_id,
+                )
+            else:
+                logger.warning(
+                    "Unknown task id on %s: task_id=%s caller tenant_id=%s principal_id=%s",
+                    operation,
+                    task_id,
+                    identity.tenant_id,
+                    identity.principal_id,
+                )
+            # Telemetry uses typed AdCPError (WARNING branch). ``TaskNotFoundError``
+            # is an A2AError, not AdCPError — passing it took the untyped
+            # ``exc_info=True`` path with no active exception (NoneType: None)
+            # and logged ordinary stale-handle polls at ERROR.
             record_boundary_error(
                 "a2a",
                 operation,
-                not_found,
+                AdCPTaskNotFoundError(message=f"Task not found: {task_id}"),
                 tenant_id=identity.tenant_id,
                 principal_id=identity.principal_id,
             )
-            raise not_found
+            raise self._task_not_found(task_id)
         return task
 
     async def on_get_task(
@@ -1311,7 +1329,9 @@ class AdCPRequestHandler(RequestHandler):
         """
         tool_context = None
         try:
-            identity = self._authenticate(context, operation="create_push_notification_config")
+            # Op id must match tool_context + body error path ("set …") so auth
+            # failures join the same method vocabulary.
+            identity = self._authenticate(context, operation="set_push_notification_config")
             tool_context = self._make_tool_context(identity, "set_push_notification_config")
 
             # In a2a-sdk 1.0, TaskPushNotificationConfig is a flat protobuf message
@@ -1371,7 +1391,7 @@ class AdCPRequestHandler(RequestHandler):
         except Exception as e:
             record_boundary_error(
                 "a2a",
-                "create_push_notification_config",
+                "set_push_notification_config",
                 e,
                 tenant_id=tool_context.tenant_id if tool_context else None,
                 principal_id=tool_context.principal_id if tool_context else None,

--- a/src/a2a_server/adcp_a2a_server.py
+++ b/src/a2a_server/adcp_a2a_server.py
@@ -235,7 +235,9 @@ def _safe_task_id_for_log(task_id: str) -> str:
     """Neutralize attacker-controlled task ids before logs / buyer-facing messages.
 
     Allowlist keeps ``task_<hex>``-shaped ids intact; everything else becomes ``?``.
-    Truncate after substitution so a trailing escape cannot leave a lone backslash.
+    Truncate after substitution so a control char near the limit cannot expand
+    past the cap (replacement is one ``?`` per char today; order still matters
+    if the substitute ever grows).
     """
     return re.sub(r"[^A-Za-z0-9_.:-]", "?", task_id)[:100]
 

--- a/src/a2a_server/adcp_a2a_server.py
+++ b/src/a2a_server/adcp_a2a_server.py
@@ -1241,6 +1241,7 @@ class AdCPRequestHandler(RequestHandler):
         authorized = task is not None and identity.principal_id and stored_owner == expected_owner
         if not authorized:
             self._deny_task_access(task_id, operation, identity)
+        assert task is not None
         return task
 
     async def on_get_task(

--- a/src/a2a_server/adcp_a2a_server.py
+++ b/src/a2a_server/adcp_a2a_server.py
@@ -243,6 +243,10 @@ def _safe_id_for_log(task_id: str) -> str:
     return re.sub(r"[^A-Za-z0-9_.:-]", "?", task_id)[:100]
 
 
+# Tests and helpers still import the pre-rename symbol from #1720 review rounds.
+_safe_task_id_for_log = _safe_id_for_log
+
+
 def _internal_error_for(operation: str, exc: Exception) -> InternalError:
     """Canonical InternalError shape for non-skill A2A boundary failures.
 
@@ -716,12 +720,10 @@ class AdCPRequestHandler(RequestHandler):
 
             # SSRF-reject unsafe push URLs after the auth-required gate so callers
             # that need credentials see AUTH_REQUIRED before scheme/blocked-host checks.
-            # ONE branch: stash iff a registration was built. Previously the gate ran
-            # under `config and config.url` while the stash ran under `config` alone,
-            # so a blank-url config was stashed ungated (the reader then early-returned
-            # on it). Observably equivalent, minus the ungated stash.
+            # Validate here; stash only after identity resolves (R5-A1 — no orphan map).
+            push_registration: ValidatedWebhookRegistration | None = None
             if push_notification_config and push_notification_config.url:
-                registration = _accept_a2a_push_config(
+                push_registration = _accept_a2a_push_config(
                     push_notification_config.url,
                     *_a2a_push_config_auth(push_notification_config),
                 )
@@ -730,7 +732,6 @@ class AdCPRequestHandler(RequestHandler):
                     task_id,
                     webhook_url_for_log(push_notification_config.url),
                 )
-                self._task_push_configs[task_id] = registration
 
             # ── Transport boundary: resolve identity ONCE ──
             # Like REST's _resolve_auth(), identity is resolved here and passed
@@ -750,6 +751,8 @@ class AdCPRequestHandler(RequestHandler):
             # Push config lives outside protobuf metadata (not JSON-serializable).
             # Failure webhooks before this point thread ``config=`` into
             # ``_send_protocol_webhook`` rather than writing the map early.
+            if push_registration is not None:
+                self._task_push_configs[task_id] = push_registration
             self.tasks[task_id] = task
             self._task_owners[task_id] = _TaskOwner(
                 tenant_id=identity.tenant_id,

--- a/src/core/exceptions.py
+++ b/src/core/exceptions.py
@@ -122,7 +122,7 @@ RECOVERY_BY_WIRE_CODE: dict[str, RecoveryHint] = _load_pinned_recovery()
 # here — this is a set of code NAMES; RECOVERY_BY_WIRE_CODE answers what they
 # mean. The remaining demoted spec code (BILLING_NOT_SUPPORTED) is tracked for
 # the same treatment in #1602.
-_SPEC_SUPPLEMENT_CODES: frozenset[str] = frozenset({"CREATIVE_NOT_FOUND", "CONFIGURATION_ERROR"})
+_SPEC_SUPPLEMENT_CODES: frozenset[str] = frozenset({"CREATIVE_NOT_FOUND", "CONFIGURATION_ERROR", "REFERENCE_NOT_FOUND"})
 
 # Codes the SDK helper ships that the PINNED spec does not define. The pin is the
 # authority and the helper is a cross-check (CLAUDE.md spec-grounding gate), so a

--- a/src/core/exceptions.py
+++ b/src/core/exceptions.py
@@ -177,10 +177,13 @@ ERROR_CODE_MAPPING: dict[str, str] = {
     # Entity-specific not-found codes the pinned spec enum does NOT define
     # (unlike CREATIVE_NOT_FOUND, which the enum defines and therefore passes
     # through untranslated). The typed subclasses exist for
-    # recovery=correctable + guard-enforceability; the buyer-visible wire code
-    # is INVALID_REQUEST.
+    # recovery=correctable + guard-enforceability; FORMAT_NOT_FOUND maps to
+    # INVALID_REQUEST, while TASK_NOT_FOUND maps to REFERENCE_NOT_FOUND
+    # (3.1.1 generic inaccessible-reference code).
     "FORMAT_NOT_FOUND": "INVALID_REQUEST",
-    "TASK_NOT_FOUND": "INVALID_REQUEST",
+    # AdCP 3.1.1: unknown / inaccessible task ids → REFERENCE_NOT_FOUND
+    # (not INVALID_REQUEST — that is for malformed requests).
+    "TASK_NOT_FOUND": "REFERENCE_NOT_FOUND",
     "INTERNAL_ERROR": "SERVICE_UNAVAILABLE",
     # Authentication / authorisation
     "AUTHORIZATION_ERROR": "AUTH_REQUIRED",
@@ -238,7 +241,7 @@ INTERNAL_CODES: frozenset[str] = frozenset(
         "INTERNAL_ERROR",  # Base-class default; never instantiated for wire
         "NOT_FOUND",  # Base-class for entity-specific NotFound subclasses
         "FORMAT_NOT_FOUND",  # AdCPFormatNotFoundError; wire → INVALID_REQUEST
-        "TASK_NOT_FOUND",  # AdCPTaskNotFoundError; wire → INVALID_REQUEST
+        "TASK_NOT_FOUND",  # AdCPTaskNotFoundError; wire → REFERENCE_NOT_FOUND
         "API_ERROR",  # Raw adapter API failure detail
         "WORKFLOW_CREATION_FAILED",  # GAM workflow orchestration detail
         "LINE_ITEM_CREATION_FAILED",  # GAM line-item creation detail
@@ -1037,10 +1040,12 @@ class AdCPFormatNotFoundError(AdCPNotFoundError):
 
 
 class AdCPTaskNotFoundError(AdCPNotFoundError):
-    """Requested workflow task/step does not exist (404, wire → INVALID_REQUEST).
+    """Requested workflow task/step does not exist (404, wire → REFERENCE_NOT_FOUND).
 
     No standard ``TASK_NOT_FOUND`` SDK code exists, so the raw code is internal
-    and translated to ``INVALID_REQUEST`` at the wire boundary. The gain over the
+    and translated to ``REFERENCE_NOT_FOUND`` at the wire boundary (AdCP 3.1.1
+    ``error-code.json``: referenced identifier that does not exist or is not
+    accessible — MUST not mint a custom ``*_NOT_FOUND``). The gain over the
     bare ``AdCPNotFoundError`` is recovery=correctable + a typed identity.
 
     Recovery=correctable: the buyer can correct by supplying a valid task_id

--- a/src/core/exceptions.py
+++ b/src/core/exceptions.py
@@ -177,12 +177,12 @@ ERROR_CODE_MAPPING: dict[str, str] = {
     # Entity-specific not-found codes the pinned spec enum does NOT define
     # (unlike CREATIVE_NOT_FOUND, which the enum defines and therefore passes
     # through untranslated). The typed subclasses exist for
-    # recovery=correctable + guard-enforceability; FORMAT_NOT_FOUND maps to
-    # INVALID_REQUEST, while TASK_NOT_FOUND maps to REFERENCE_NOT_FOUND
-    # (3.1.1 generic inaccessible-reference code).
-    "FORMAT_NOT_FOUND": "INVALID_REQUEST",
-    # AdCP 3.1.1: unknown / inaccessible task ids → REFERENCE_NOT_FOUND
-    # (not INVALID_REQUEST — that is for malformed requests).
+    # recovery=correctable + guard-enforceability; both FORMAT_NOT_FOUND and
+    # TASK_NOT_FOUND map to REFERENCE_NOT_FOUND — a missing referenced id is
+    # AdCP 3.1.1's generic inaccessible-reference code, and MUST NOT mint a
+    # custom `*_NOT_FOUND` (not INVALID_REQUEST — that is for malformed
+    # requests).
+    "FORMAT_NOT_FOUND": "REFERENCE_NOT_FOUND",
     "TASK_NOT_FOUND": "REFERENCE_NOT_FOUND",
     "INTERNAL_ERROR": "SERVICE_UNAVAILABLE",
     # Authentication / authorisation
@@ -240,7 +240,7 @@ INTERNAL_CODES: frozenset[str] = frozenset(
     {
         "INTERNAL_ERROR",  # Base-class default; never instantiated for wire
         "NOT_FOUND",  # Base-class for entity-specific NotFound subclasses
-        "FORMAT_NOT_FOUND",  # AdCPFormatNotFoundError; wire → INVALID_REQUEST
+        "FORMAT_NOT_FOUND",  # AdCPFormatNotFoundError; wire → REFERENCE_NOT_FOUND
         "TASK_NOT_FOUND",  # AdCPTaskNotFoundError; wire → REFERENCE_NOT_FOUND
         "API_ERROR",  # Raw adapter API failure detail
         "WORKFLOW_CREATION_FAILED",  # GAM workflow orchestration detail
@@ -1026,11 +1026,14 @@ class AdCPCreativeNotFoundError(AdCPNotFoundError):
 
 
 class AdCPFormatNotFoundError(AdCPNotFoundError):
-    """Requested creative format does not exist on the agent (404, wire → INVALID_REQUEST).
+    """Requested creative format does not exist on the agent (404, wire → REFERENCE_NOT_FOUND).
 
     No standard ``FORMAT_NOT_FOUND`` SDK code exists, so the raw code is internal
-    and translated to ``INVALID_REQUEST`` at the wire boundary. The gain over the
-    bare ``AdCPNotFoundError`` is recovery=correctable + a typed identity.
+    and translated to ``REFERENCE_NOT_FOUND`` at the wire boundary (AdCP 3.1.1
+    ``error-code.json``: referenced identifier that does not exist or is not
+    accessible — MUST not mint a custom ``*_NOT_FOUND``, the same rule
+    ``AdCPTaskNotFoundError`` follows below). The gain over the bare
+    ``AdCPNotFoundError`` is recovery=correctable + a typed identity.
 
     Recovery=correctable: the buyer can correct by supplying a valid format_id
     (discoverable via list_creative_formats).

--- a/tests/a2a_helpers.py
+++ b/tests/a2a_helpers.py
@@ -5,15 +5,27 @@ AdCPCallContextBuilder.build() does in production, but without needing
 a Starlette request object.
 """
 
-from collections.abc import Iterator
+from __future__ import annotations
+
+from collections.abc import Callable, Iterator, Mapping
 from contextlib import contextmanager
+from types import MappingProxyType
 from unittest.mock import patch
 
 from a2a.server.context import ServerCallContext
+from a2a.types import Task, TaskState, TaskStatus
 
-from src.a2a_server.adcp_a2a_server import AdCPRequestHandler
+from src.a2a_server.adcp_a2a_server import AdCPRequestHandler, _TaskOwner
 from src.core.auth_context import AUTH_CONTEXT_STATE_KEY, AuthContext
 from src.core.resolved_identity import ResolvedIdentity
+
+# Shared ownership fixtures for unit + in-process wire altitudes (#1702 / #1720).
+OWNED_TASK_TENANT = "tenant_a"
+OWNED_TASK_OWNER = "principal_owner"
+OWNED_TASK_SIBLING = "principal_sibling"
+OWNED_TASK_ID = "task_owned_abc"
+OWNED_TASK_OWNER_TOK = "owner-tok"
+OWNED_TASK_SIBLING_TOK = "sibling-tok"
 
 
 def make_a2a_context(
@@ -44,3 +56,34 @@ def a2a_auth_as(handler: AdCPRequestHandler, identity: ResolvedIdentity) -> Iter
         patch.object(handler, "_resolve_a2a_identity", return_value=identity),
     ):
         yield
+
+
+def seeded_owned_a2a_handler(
+    *,
+    task_id: str = OWNED_TASK_ID,
+    tenant_id: str = OWNED_TASK_TENANT,
+    principal_id: str = OWNED_TASK_OWNER,
+) -> AdCPRequestHandler:
+    """Minimal owned in-memory task handler (bypasses ``__init__`` for unit/wire)."""
+    handler = AdCPRequestHandler.__new__(AdCPRequestHandler)
+    handler.tasks = {task_id: Task(id=task_id, status=TaskStatus(state=TaskState.TASK_STATE_COMPLETED))}
+    handler._task_owners = {task_id: _TaskOwner(tenant_id=tenant_id, principal_id=principal_id)}
+    return handler
+
+
+def token_identity_resolver(
+    mapping: Mapping[str, ResolvedIdentity],
+) -> Callable[..., ResolvedIdentity]:
+    """``resolve_identity`` side_effect: Bearer token → identity (shared by unit+wire)."""
+
+    def resolve(*, auth_token: str | None, **_kwargs: object) -> ResolvedIdentity:
+        if auth_token is None or auth_token not in mapping:
+            raise AssertionError(f"unexpected token: {auth_token!r}")
+        return mapping[auth_token]
+
+    return resolve
+
+
+def auth_headers_mapping(headers: Mapping[str, str]) -> MappingProxyType[str, str]:
+    """Immutable header map for ``AuthContext`` (matches production typing)."""
+    return MappingProxyType({k.lower(): v for k, v in headers.items()})

--- a/tests/a2a_helpers.py
+++ b/tests/a2a_helpers.py
@@ -20,13 +20,26 @@ from src.a2a_server.adcp_a2a_server import AdCPRequestHandler, _safe_task_id_for
 from src.core.auth_context import AUTH_CONTEXT_STATE_KEY, AuthContext
 from src.core.resolved_identity import ResolvedIdentity
 
-# Shared ownership fixtures for unit + in-process wire altitudes (#1702 / #1720).
+# Shared ownership fixtures for unit + in-process wire altitudes (#1702 / #1720 / #1780).
 OWNED_TASK_TENANT = "tenant_a"
 OWNED_TASK_OWNER = "principal_owner"
 OWNED_TASK_SIBLING = "principal_sibling"
+# Cross-tenant isolation uses the SAME principal_id under a different tenant so
+# the tenant half of ``_TaskOwner`` is graded independently of the principal half.
+OWNED_TASK_OTHER_TENANT = "tenant_b"
+OWNED_TASK_OTHER_PRINCIPAL = OWNED_TASK_OWNER
 OWNED_TASK_ID = "task_owned_abc"
 OWNED_TASK_OWNER_TOK = "owner-tok"
 OWNED_TASK_SIBLING_TOK = "sibling-tok"
+
+# Default non-disclosure needles — every role id that appears at any altitude.
+OWNED_TASK_FORBIDDEN_SUBSTRINGS: tuple[str, ...] = (
+    OWNED_TASK_TENANT,
+    OWNED_TASK_OWNER,
+    OWNED_TASK_SIBLING,
+    OWNED_TASK_OTHER_TENANT,
+    "leaked_tenant",
+)
 
 # method_name / request_cls / JSON-RPC method — one vocabulary for unit + wire.
 TASK_METHOD_MATRIX: tuple[tuple[type, str, str], ...] = (
@@ -78,16 +91,30 @@ async def invoke_owned_task_method(
     return await getattr(handler, method_name)(request_cls(id=task_id), context=None)
 
 
+def record_a2a_task_owner(
+    handler: AdCPRequestHandler,
+    task_id: str,
+    *,
+    tenant_id: str | None,
+    principal_id: str | None,
+) -> None:
+    """Write the in-memory ownership record (shared by unit seed + harness seed)."""
+    handler._task_owners[task_id] = _TaskOwner(tenant_id=tenant_id, principal_id=principal_id)
+
+
 def seeded_owned_a2a_handler(
     *,
     task_id: str = OWNED_TASK_ID,
     tenant_id: str = OWNED_TASK_TENANT,
     principal_id: str = OWNED_TASK_OWNER,
+    record_owner: bool = True,
 ) -> AdCPRequestHandler:
     """Minimal owned in-memory task handler (bypasses ``__init__`` for unit/wire)."""
     handler = AdCPRequestHandler.__new__(AdCPRequestHandler)
     handler.tasks = {task_id: Task(id=task_id, status=TaskStatus(state=TaskState.TASK_STATE_COMPLETED))}
-    handler._task_owners = {task_id: _TaskOwner(tenant_id=tenant_id, principal_id=principal_id)}
+    handler._task_owners = {}
+    if record_owner:
+        record_a2a_task_owner(handler, task_id, tenant_id=tenant_id, principal_id=principal_id)
     return handler
 
 
@@ -114,12 +141,7 @@ def assert_task_not_found_nondisclosure(
     exc: TaskNotFoundError,
     task_id: str,
     *,
-    forbidden_substrings: tuple[str, ...] = (
-        OWNED_TASK_TENANT,
-        OWNED_TASK_OWNER,
-        OWNED_TASK_SIBLING,
-        "leaked_tenant",
-    ),
+    forbidden_substrings: tuple[str, ...] = OWNED_TASK_FORBIDDEN_SUBSTRINGS,
 ) -> None:
     """Shared non-disclosure oracle for unit-altitude TaskNotFoundError objects.
 
@@ -140,13 +162,23 @@ def assert_task_not_found_nondisclosure(
 def assert_wire_task_not_found(err: Mapping[str, object], task_id: str) -> None:
     """Exact wire-body oracle for not-found (v0.3 compat: code -32603, data null).
 
+    Both the in-process live-POST harness (#1780) and
+    ``tests/unit/test_a2a_task_identity_wire.py`` share this un-parameterized
+    oracle — do not add per-caller ``code=`` / ``message=`` knobs; a split
+    would let the harness silently drift from the buyer wire.
+
+    Expected message is a literal over the raw *task_id* (not
+    ``_task_not_found_message`` / ``_safe_task_id_for_log``) so a static identity
+    leak inside the production builder cannot move both sides together. Clean
+    task ids only — control-character sanitizer joining is graded at unit
+    altitude via ``assert_task_not_found_nondisclosure``.
+
     When #1670 removes flattening, the strict xfail sibling at
     ``tests/e2e/test_a2a_endpoints_working.py`` (TestA2AServerIntegration) XPASSes
     by design while this hard-fails — keep the pointer at the failure site.
     """
-    safe_id = _safe_task_id_for_log(task_id)
     assert err == {
         "code": -32603,
-        "message": f"Task not found: {safe_id}",
+        "message": f"Task not found: {task_id}",
         "data": None,
     }

--- a/tests/a2a_helpers.py
+++ b/tests/a2a_helpers.py
@@ -219,6 +219,10 @@ def assert_task_not_found_nondisclosure(
     assert isinstance(exc.data, dict)
     assert exc.data.get("task_id") == safe_id
     assert "adcp_error" in exc.data
+    adcp_error = exc.data["adcp_error"]
+    assert isinstance(adcp_error, dict)
+    assert adcp_error["code"] == "REFERENCE_NOT_FOUND"
+    assert adcp_error["recovery"] == "correctable"
     blob = f"{exc.message}{exc.data!s}"
     for needle in forbidden_substrings:
         assert needle not in blob
@@ -292,12 +296,20 @@ def post_a2a_task_method(
 
 
 def assert_wire_auth_failure(err: Mapping[str, object]) -> None:
-    """Exact wire-body oracle for unauthenticated A2A task calls (v0.3 compat)."""
-    assert err == {
-        "code": -32603,
-        "message": "Missing authentication token",
-        "data": None,
-    }
+    """Wire-body oracle for unauthenticated A2A task calls (v0.3 compat).
+
+    Under v0.3 compat the envelope may flatten to ``data: null`` (#1670); when
+    ``data`` is present we grade ``AUTH_REQUIRED`` / ``correctable`` on the
+    two-layer envelope attached at the raise site.
+    """
+    assert err.get("code") == -32603
+    assert err.get("message") == "Missing authentication token"
+    data = err.get("data")
+    if isinstance(data, dict) and "adcp_error" in data:
+        adcp_error = data["adcp_error"]
+        assert isinstance(adcp_error, dict)
+        assert adcp_error.get("code") == "AUTH_REQUIRED"
+        assert adcp_error.get("recovery") == "correctable"
 
 
 def assert_wire_no_identity_leak(

--- a/tests/a2a_helpers.py
+++ b/tests/a2a_helpers.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 from collections.abc import Callable, Iterator, Mapping
 from contextlib import contextmanager
 from types import MappingProxyType
-from typing import Any
 from unittest.mock import patch
 
 from a2a.server.context import ServerCallContext
@@ -19,6 +18,7 @@ from a2a.types import CancelTaskRequest, GetTaskRequest, Task, TaskNotFoundError
 from src.a2a_server.adcp_a2a_server import AdCPRequestHandler, _safe_task_id_for_log, _TaskOwner
 from src.core.auth_context import AUTH_CONTEXT_STATE_KEY, AuthContext
 from src.core.resolved_identity import ResolvedIdentity
+from tests.factories.principal import PrincipalFactory
 
 # Shared ownership fixtures for unit + in-process wire altitudes (#1702 / #1720 / #1780).
 OWNED_TASK_TENANT = "tenant_a"
@@ -32,6 +32,9 @@ OWNED_TASK_ID = "task_owned_abc"
 OWNED_TASK_OWNER_TOK = "owner-tok"
 OWNED_TASK_SIBLING_TOK = "sibling-tok"
 
+# Default host header for ServerCallContext builders (unit + wire altitudes).
+A2A_TEST_HOST_HEADERS: dict[str, str] = {"host": "test.example.com"}
+
 # Default non-disclosure needles — every role id that appears at any altitude.
 OWNED_TASK_FORBIDDEN_SUBSTRINGS: tuple[str, ...] = (
     OWNED_TASK_TENANT,
@@ -41,11 +44,48 @@ OWNED_TASK_FORBIDDEN_SUBSTRINGS: tuple[str, ...] = (
     "leaked_tenant",
 )
 
-# method_name / request_cls / JSON-RPC method — one vocabulary for unit + wire.
-TASK_METHOD_MATRIX: tuple[tuple[type, str, str], ...] = (
-    (GetTaskRequest, "on_get_task", "tasks/get"),
-    (CancelTaskRequest, "on_cancel_task", "tasks/cancel"),
+type TaskRequestCls = type[GetTaskRequest] | type[CancelTaskRequest]
+
+# request_cls / method_name / JSON-RPC method / _authenticate operation id —
+# one vocabulary for unit + wire. Wire phrase = ``op.replace("_", " ") + " failed"``
+# (same transform production ``_authenticate`` uses).
+TASK_METHOD_MATRIX: tuple[tuple[TaskRequestCls, str, str, str], ...] = (
+    (GetTaskRequest, "on_get_task", "tasks/get", "get_task"),
+    (CancelTaskRequest, "on_cancel_task", "tasks/cancel", "cancel_task"),
 )
+
+
+def auth_operation_wire_phrase(operation: str) -> str:
+    """Buyer-facing InternalError phrase for an ``_authenticate`` op id."""
+    return f"{operation.replace('_', ' ')} failed"
+
+
+def owned_task_owner_identity(*, tenant_id: str = OWNED_TASK_TENANT) -> ResolvedIdentity:
+    """Owner principal identity for the shared ownership fixtures."""
+    return PrincipalFactory.make_identity(
+        principal_id=OWNED_TASK_OWNER,
+        tenant_id=tenant_id,
+        protocol="a2a",
+    )
+
+
+def owned_task_sibling_identity(*, tenant_id: str = OWNED_TASK_TENANT) -> ResolvedIdentity:
+    """Same-tenant sibling identity for the shared ownership fixtures."""
+    return PrincipalFactory.make_identity(
+        principal_id=OWNED_TASK_SIBLING,
+        tenant_id=tenant_id,
+        protocol="a2a",
+    )
+
+
+def seeded_owner_sibling_resolver() -> Callable[..., ResolvedIdentity]:
+    """Token → owner/sibling identity map used by real-auth unit + wire altitudes."""
+    return token_identity_resolver(
+        {
+            OWNED_TASK_SIBLING_TOK: owned_task_sibling_identity(),
+            OWNED_TASK_OWNER_TOK: owned_task_owner_identity(),
+        }
+    )
 
 
 def make_a2a_context(
@@ -84,9 +124,9 @@ def a2a_auth_as(handler: AdCPRequestHandler, identity: ResolvedIdentity) -> Iter
 async def invoke_owned_task_method(
     handler: AdCPRequestHandler,
     method_name: str,
-    request_cls: type,
+    request_cls: TaskRequestCls,
     task_id: str,
-) -> Any:
+) -> Task:
     """Act half shared by ownership unit tests (auth already patched via ``a2a_auth_as``)."""
     return await getattr(handler, method_name)(request_cls(id=task_id), context=None)
 

--- a/tests/a2a_helpers.py
+++ b/tests/a2a_helpers.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from collections.abc import Callable, Iterator, Mapping
 from contextlib import contextmanager
 from types import MappingProxyType
+from typing import Any
 from unittest.mock import patch
 
 from a2a.server.context import ServerCallContext
@@ -204,7 +205,7 @@ def assert_task_not_found_nondisclosure(
         assert needle not in blob
 
 
-class _XAdcpAuthContextBuilder(ServerCallContextBuilder):
+class XAdcpAuthContextBuilder(ServerCallContextBuilder):
     """Per-request token extraction on the harness's ``x-adcp-auth`` contract.
 
     Not ``Authorization: Bearer`` — both are production-valid, but pinning the
@@ -224,21 +225,65 @@ class _XAdcpAuthContextBuilder(ServerCallContextBuilder):
         )
 
 
-def build_a2a_jsonrpc_client(handler: AdCPRequestHandler) -> TestClient:
+def build_a2a_jsonrpc_client(
+    handler: AdCPRequestHandler,
+    *,
+    context_builder: ServerCallContextBuilder | None = None,
+) -> TestClient:
     """Shared route+client build for the live v0.3-compat JSON-RPC wire grade.
 
     Drives the same ``create_jsonrpc_routes(..., enable_v0_3_compat=True)``
-    production call on one ``x-adcp-auth`` auth contract. Callers POST with an
-    ``{"x-adcp-auth": token}`` header rather than hand-rolling a new
-    route+client+auth-header build per call site.
+    production call. Default ``context_builder`` is the harness ``x-adcp-auth``
+    contract; callers that need a prepared context (BDD) pass their own.
+    Prefer ``post_a2a_task_method`` for the full POST+200+json boundary.
     """
     routes = create_jsonrpc_routes(
         request_handler=handler,
         rpc_url="/a2a",
-        context_builder=_XAdcpAuthContextBuilder(),
+        context_builder=context_builder or XAdcpAuthContextBuilder(),
         enable_v0_3_compat=True,
     )
     return TestClient(Starlette(routes=routes))
+
+
+def post_a2a_task_method(
+    handler: AdCPRequestHandler,
+    *,
+    method: str,
+    task_id: str,
+    context_builder: ServerCallContextBuilder,
+    headers: Mapping[str, str] | None = None,
+) -> dict[str, Any]:
+    """One production JSON-RPC POST for ``tasks/get`` / ``tasks/cancel``.
+
+    Shared boundary for the harness (``run_a2a_task_method``) and the
+    in-process wire unit test: both build routes with
+    ``enable_v0_3_compat=True``, open a context-managed ``TestClient``, POST the
+    same envelope, assert HTTP 200, and return the parsed JSON-RPC body.
+    """
+    routes = create_jsonrpc_routes(
+        request_handler=handler,
+        rpc_url="/a2a",
+        context_builder=context_builder,
+        enable_v0_3_compat=True,
+    )
+    with TestClient(Starlette(routes=routes)) as client:
+        response = client.post(
+            "/a2a",
+            json={"jsonrpc": "2.0", "id": 1, "method": method, "params": {"id": task_id}},
+            headers=dict(headers) if headers else {},
+        )
+        assert response.status_code == 200, f"JSON-RPC {method} returned HTTP {response.status_code}: {response.text}"
+        return response.json()
+
+
+def assert_wire_auth_failure(err: Mapping[str, object]) -> None:
+    """Exact wire-body oracle for unauthenticated A2A task calls (v0.3 compat)."""
+    assert err == {
+        "code": -32603,
+        "message": "Missing authentication token",
+        "data": None,
+    }
 
 
 def assert_wire_no_identity_leak(

--- a/tests/a2a_helpers.py
+++ b/tests/a2a_helpers.py
@@ -13,9 +13,9 @@ from types import MappingProxyType
 from unittest.mock import patch
 
 from a2a.server.context import ServerCallContext
-from a2a.types import Task, TaskState, TaskStatus
+from a2a.types import Task, TaskNotFoundError, TaskState, TaskStatus
 
-from src.a2a_server.adcp_a2a_server import AdCPRequestHandler, _TaskOwner
+from src.a2a_server.adcp_a2a_server import AdCPRequestHandler, _task_not_found_message, _TaskOwner
 from src.core.auth_context import AUTH_CONTEXT_STATE_KEY, AuthContext
 from src.core.resolved_identity import ResolvedIdentity
 
@@ -30,7 +30,7 @@ OWNED_TASK_SIBLING_TOK = "sibling-tok"
 
 def make_a2a_context(
     auth_token: str | None = None,
-    headers: dict[str, str] | None = None,
+    headers: Mapping[str, str] | None = None,
 ) -> ServerCallContext:
     """Build a ServerCallContext for A2A handler tests.
 
@@ -44,7 +44,10 @@ def make_a2a_context(
     Returns:
         ServerCallContext ready to pass to handler.on_message_send(params, context=ctx).
     """
-    auth_ctx = AuthContext(auth_token=auth_token, headers=headers or {})
+    auth_ctx = AuthContext(
+        auth_token=auth_token,
+        headers=auth_headers_mapping(headers) if headers is not None else auth_headers_mapping({}),
+    )
     return ServerCallContext(state={AUTH_CONTEXT_STATE_KEY: auth_ctx})
 
 
@@ -77,7 +80,7 @@ def token_identity_resolver(
     """``resolve_identity`` side_effect: Bearer token → identity (shared by unit+wire)."""
 
     def resolve(*, auth_token: str | None, **_kwargs: object) -> ResolvedIdentity:
-        if auth_token is None or auth_token not in mapping:
+        if auth_token not in mapping:
             raise AssertionError(f"unexpected token: {auth_token!r}")
         return mapping[auth_token]
 
@@ -87,3 +90,42 @@ def token_identity_resolver(
 def auth_headers_mapping(headers: Mapping[str, str]) -> MappingProxyType[str, str]:
     """Immutable header map for ``AuthContext`` (matches production typing)."""
     return MappingProxyType({k.lower(): v for k, v in headers.items()})
+
+
+def assert_task_not_found_nondisclosure(
+    exc: TaskNotFoundError,
+    task_id: str,
+    *,
+    forbidden_substrings: tuple[str, ...] = (
+        OWNED_TASK_TENANT,
+        OWNED_TASK_OWNER,
+        OWNED_TASK_SIBLING,
+        "leaked_tenant",
+    ),
+) -> None:
+    """Shared non-disclosure oracle for unit-altitude TaskNotFoundError objects.
+
+    Literal message/data — never call ``_task_not_found`` for the expected side
+    (both sides would move together and hide an identity leak). Message text must
+    match production ``_task_not_found_message`` so telemetry and wire stay joined.
+    """
+    assert exc.message == _task_not_found_message(task_id)
+    # Grades exception object ``data``, not the wire envelope (compat drops it).
+    assert exc.data == {"task_id": task_id}
+    blob = f"{exc.message}{exc.data!s}"
+    for needle in forbidden_substrings:
+        assert needle not in blob
+
+
+def assert_wire_task_not_found(err: Mapping[str, object], task_id: str) -> None:
+    """Exact wire-body oracle for not-found (v0.3 compat: code -32603, data null).
+
+    When #1670 removes flattening, the strict xfail sibling at
+    ``tests/e2e/test_a2a_endpoints_working.py`` (TestA2AServerIntegration) XPASSes
+    by design while this hard-fails — keep the pointer at the failure site.
+    """
+    assert err == {
+        "code": -32603,
+        "message": _task_not_found_message(task_id),
+        "data": None,
+    }

--- a/tests/a2a_helpers.py
+++ b/tests/a2a_helpers.py
@@ -5,9 +5,15 @@ AdCPCallContextBuilder.build() does in production, but without needing
 a Starlette request object.
 """
 
+from collections.abc import Iterator
+from contextlib import contextmanager
+from unittest.mock import patch
+
 from a2a.server.context import ServerCallContext
 
+from src.a2a_server.adcp_a2a_server import AdCPRequestHandler
 from src.core.auth_context import AUTH_CONTEXT_STATE_KEY, AuthContext
+from src.core.resolved_identity import ResolvedIdentity
 
 
 def make_a2a_context(
@@ -28,3 +34,13 @@ def make_a2a_context(
     """
     auth_ctx = AuthContext(auth_token=auth_token, headers=headers or {})
     return ServerCallContext(state={AUTH_CONTEXT_STATE_KEY: auth_ctx})
+
+
+@contextmanager
+def a2a_auth_as(handler: AdCPRequestHandler, identity: ResolvedIdentity) -> Iterator[None]:
+    """Patch token extract + identity resolve for a single authenticated call."""
+    with (
+        patch.object(handler, "_get_auth_token", return_value="tok"),
+        patch.object(handler, "_resolve_a2a_identity", return_value=identity),
+    ):
+        yield

--- a/tests/a2a_helpers.py
+++ b/tests/a2a_helpers.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from collections.abc import Callable, Iterator, Mapping
 from contextlib import contextmanager
 from types import MappingProxyType
-from typing import Any
+from typing import Any, NamedTuple
 from unittest.mock import patch
 
 from a2a.server.context import ServerCallContext
@@ -52,13 +52,32 @@ OWNED_TASK_FORBIDDEN_SUBSTRINGS: tuple[str, ...] = (
 
 type TaskRequestCls = type[GetTaskRequest] | type[CancelTaskRequest]
 
+
+class TaskMethodRow(NamedTuple):
+    """One A2A task method row — named columns so consumers never index positionally."""
+
+    request_cls: TaskRequestCls
+    method_name: str
+    jsonrpc_method: str
+    operation: str
+
+
 # request_cls / method_name / JSON-RPC method / _authenticate operation id —
 # one vocabulary for unit + wire. Wire phrase = ``op.replace("_", " ") + " failed"``
 # (same transform production ``_authenticate`` uses).
-TASK_METHOD_MATRIX: tuple[tuple[TaskRequestCls, str, str, str], ...] = (
-    (GetTaskRequest, "on_get_task", "tasks/get", "get_task"),
-    (CancelTaskRequest, "on_cancel_task", "tasks/cancel", "cancel_task"),
+TASK_METHOD_MATRIX: tuple[TaskMethodRow, ...] = (
+    TaskMethodRow(GetTaskRequest, "on_get_task", "tasks/get", "get_task"),
+    TaskMethodRow(CancelTaskRequest, "on_cancel_task", "tasks/cancel", "cancel_task"),
 )
+
+# Hot slices — one home so unit/wire sites do not re-project by index.
+TASK_METHOD_PAIRS: tuple[tuple[TaskRequestCls, str], ...] = tuple(
+    (row.request_cls, row.method_name) for row in TASK_METHOD_MATRIX
+)
+TASK_METHOD_WITH_OPS: tuple[tuple[TaskRequestCls, str, str], ...] = tuple(
+    (row.request_cls, row.method_name, row.operation) for row in TASK_METHOD_MATRIX
+)
+TASK_JSONRPC_METHODS: tuple[str, ...] = tuple(row.jsonrpc_method for row in TASK_METHOD_MATRIX)
 
 
 def auth_operation_wire_phrase(operation: str) -> str:

--- a/tests/a2a_helpers.py
+++ b/tests/a2a_helpers.py
@@ -10,12 +10,13 @@ from __future__ import annotations
 from collections.abc import Callable, Iterator, Mapping
 from contextlib import contextmanager
 from types import MappingProxyType
+from typing import Any
 from unittest.mock import patch
 
 from a2a.server.context import ServerCallContext
-from a2a.types import Task, TaskNotFoundError, TaskState, TaskStatus
+from a2a.types import CancelTaskRequest, GetTaskRequest, Task, TaskNotFoundError, TaskState, TaskStatus
 
-from src.a2a_server.adcp_a2a_server import AdCPRequestHandler, _task_not_found_message, _TaskOwner
+from src.a2a_server.adcp_a2a_server import AdCPRequestHandler, _safe_task_id_for_log, _TaskOwner
 from src.core.auth_context import AUTH_CONTEXT_STATE_KEY, AuthContext
 from src.core.resolved_identity import ResolvedIdentity
 
@@ -26,6 +27,12 @@ OWNED_TASK_SIBLING = "principal_sibling"
 OWNED_TASK_ID = "task_owned_abc"
 OWNED_TASK_OWNER_TOK = "owner-tok"
 OWNED_TASK_SIBLING_TOK = "sibling-tok"
+
+# method_name / request_cls / JSON-RPC method — one vocabulary for unit + wire.
+TASK_METHOD_MATRIX: tuple[tuple[type, str, str], ...] = (
+    (GetTaskRequest, "on_get_task", "tasks/get"),
+    (CancelTaskRequest, "on_cancel_task", "tasks/cancel"),
+)
 
 
 def make_a2a_context(
@@ -61,6 +68,16 @@ def a2a_auth_as(handler: AdCPRequestHandler, identity: ResolvedIdentity) -> Iter
         yield
 
 
+async def invoke_owned_task_method(
+    handler: AdCPRequestHandler,
+    method_name: str,
+    request_cls: type,
+    task_id: str,
+) -> Any:
+    """Act half shared by ownership unit tests (auth already patched via ``a2a_auth_as``)."""
+    return await getattr(handler, method_name)(request_cls(id=task_id), context=None)
+
+
 def seeded_owned_a2a_handler(
     *,
     task_id: str = OWNED_TASK_ID,
@@ -80,7 +97,8 @@ def token_identity_resolver(
     """``resolve_identity`` side_effect: Bearer token → identity (shared by unit+wire)."""
 
     def resolve(*, auth_token: str | None, **_kwargs: object) -> ResolvedIdentity:
-        if auth_token not in mapping:
+        # Explicit None check restores the narrowing mypy needs for Mapping.__getitem__.
+        if auth_token is None or auth_token not in mapping:
             raise AssertionError(f"unexpected token: {auth_token!r}")
         return mapping[auth_token]
 
@@ -105,13 +123,15 @@ def assert_task_not_found_nondisclosure(
 ) -> None:
     """Shared non-disclosure oracle for unit-altitude TaskNotFoundError objects.
 
-    Literal message/data — never call ``_task_not_found`` for the expected side
-    (both sides would move together and hide an identity leak). Message text must
-    match production ``_task_not_found_message`` so telemetry and wire stay joined.
+    Expected message is a hand-written literal (never derived from production
+    ``_task_not_found_message`` — both sides would move together). Sanitizer
+    treatment matches ``_task_not_found`` so control-character ids stay joined.
     """
-    assert exc.message == _task_not_found_message(task_id)
-    # Grades exception object ``data``, not the wire envelope (compat drops it).
-    assert exc.data == {"task_id": task_id}
+    safe_id = _safe_task_id_for_log(task_id)
+    assert exc.message == f"Task not found: {safe_id}"
+    assert isinstance(exc.data, dict)
+    assert exc.data.get("task_id") == safe_id
+    assert "adcp_error" in exc.data
     blob = f"{exc.message}{exc.data!s}"
     for needle in forbidden_substrings:
         assert needle not in blob
@@ -124,8 +144,9 @@ def assert_wire_task_not_found(err: Mapping[str, object], task_id: str) -> None:
     ``tests/e2e/test_a2a_endpoints_working.py`` (TestA2AServerIntegration) XPASSes
     by design while this hard-fails — keep the pointer at the failure site.
     """
+    safe_id = _safe_task_id_for_log(task_id)
     assert err == {
         "code": -32603,
-        "message": _task_not_found_message(task_id),
+        "message": f"Task not found: {safe_id}",
         "data": None,
     }

--- a/tests/a2a_helpers.py
+++ b/tests/a2a_helpers.py
@@ -257,17 +257,12 @@ def post_a2a_task_method(
     """One production JSON-RPC POST for ``tasks/get`` / ``tasks/cancel``.
 
     Shared boundary for the harness (``run_a2a_task_method``) and the
-    in-process wire unit test: both build routes with
-    ``enable_v0_3_compat=True``, open a context-managed ``TestClient``, POST the
-    same envelope, assert HTTP 200, and return the parsed JSON-RPC body.
+    in-process wire unit test. Route+client construction goes through
+    ``build_a2a_jsonrpc_client`` so ``enable_v0_3_compat`` (and any future
+    flag flip) has a single home — do not re-hand-roll
+    ``create_jsonrpc_routes`` here (KM Aug-05).
     """
-    routes = create_jsonrpc_routes(
-        request_handler=handler,
-        rpc_url="/a2a",
-        context_builder=context_builder,
-        enable_v0_3_compat=True,
-    )
-    with TestClient(Starlette(routes=routes)) as client:
+    with build_a2a_jsonrpc_client(handler, context_builder=context_builder) as client:
         response = client.post(
             "/a2a",
             json={"jsonrpc": "2.0", "id": 1, "method": method, "params": {"id": task_id}},

--- a/tests/a2a_helpers.py
+++ b/tests/a2a_helpers.py
@@ -13,7 +13,12 @@ from types import MappingProxyType
 from unittest.mock import patch
 
 from a2a.server.context import ServerCallContext
+from a2a.server.routes.common import ServerCallContextBuilder
+from a2a.server.routes.jsonrpc_routes import create_jsonrpc_routes
 from a2a.types import CancelTaskRequest, GetTaskRequest, Task, TaskNotFoundError, TaskState, TaskStatus
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.testclient import TestClient
 
 from src.a2a_server.adcp_a2a_server import AdCPRequestHandler, _safe_task_id_for_log, _TaskOwner
 from src.core.auth_context import AUTH_CONTEXT_STATE_KEY, AuthContext
@@ -197,6 +202,60 @@ def assert_task_not_found_nondisclosure(
     blob = f"{exc.message}{exc.data!s}"
     for needle in forbidden_substrings:
         assert needle not in blob
+
+
+class _XAdcpAuthContextBuilder(ServerCallContextBuilder):
+    """Per-request token extraction on the harness's ``x-adcp-auth`` contract.
+
+    Not ``Authorization: Bearer`` — both are production-valid, but pinning the
+    wire unit test to a second header vocabulary means the A2A auth-context
+    seam has to change in two places on a future edit (#1720 review).
+    """
+
+    def build(self, request: Request) -> ServerCallContext:
+        token = request.headers.get("x-adcp-auth") or None
+        return ServerCallContext(
+            state={
+                AUTH_CONTEXT_STATE_KEY: AuthContext(
+                    auth_token=token,
+                    headers=auth_headers_mapping(dict(request.headers.items())),
+                )
+            }
+        )
+
+
+def build_a2a_jsonrpc_client(handler: AdCPRequestHandler) -> TestClient:
+    """Shared route+client build for the live v0.3-compat JSON-RPC wire grade.
+
+    Drives the same ``create_jsonrpc_routes(..., enable_v0_3_compat=True)``
+    production call on one ``x-adcp-auth`` auth contract. Callers POST with an
+    ``{"x-adcp-auth": token}`` header rather than hand-rolling a new
+    route+client+auth-header build per call site.
+    """
+    routes = create_jsonrpc_routes(
+        request_handler=handler,
+        rpc_url="/a2a",
+        context_builder=_XAdcpAuthContextBuilder(),
+        enable_v0_3_compat=True,
+    )
+    return TestClient(Starlette(routes=routes))
+
+
+def assert_wire_no_identity_leak(
+    error: Mapping[str, object],
+    needles: tuple[str, ...] = OWNED_TASK_FORBIDDEN_SUBSTRINGS,
+) -> None:
+    """Wire-dict sibling of ``assert_task_not_found_nondisclosure`` (#1720 review).
+
+    The object-altitude oracle only grades a ``TaskNotFoundError`` instance;
+    the wire/BDD altitude captures a plain JSON-RPC error dict instead, so it
+    needs its own sweep over the *same* forbidden-substring set — the wire
+    path is the copy most likely to be missed if the non-disclosure policy
+    changes.
+    """
+    blob = f"{error.get('message', '')}{error.get('data')!s}"
+    for needle in needles:
+        assert needle not in blob, f"identity leak {needle!r} in wire error body: {error!r}"
 
 
 def assert_wire_task_not_found(err: Mapping[str, object], task_id: str) -> None:

--- a/tests/bdd/conftest.py
+++ b/tests/bdd/conftest.py
@@ -3245,13 +3245,6 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
     if any(t.startswith(_ADMIN_TAG_PREFIX) for t in marker_names):
         return
 
-    # A2A task ownership grades tasks/get|cancel on the shared handler only —
-    # no MCP/REST equivalent. Redundant with ``_TRANSPORT_SPECIFIC_TAGS`` today
-    # (all scenarios also carry ``@a2a``, which returns above); kept as
-    # belt-and-braces if a scenario drops ``@a2a`` while retaining the tag prefix.
-    if any(t.startswith(_A2A_TASK_OWNERSHIP_TAG_PREFIX) for t in marker_names):
-        return
-
     # IMPL-only scenarios: harness has no transport wrappers for this path
     for uc_prefix, required_tag in _IMPL_ONLY:
         tag_prefix = f"T-{uc_prefix}-"

--- a/tests/bdd/conftest.py
+++ b/tests/bdd/conftest.py
@@ -1370,6 +1370,24 @@ def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
                 "SPEC-PRODUCTION GAP: sync_creatives does not set sandbox=true on "
                 "response for sandbox accounts (BR-RULE-209 INV-4)"
             ),
+            # Async submitted envelope: _sync_creatives_impl returns
+            # SyncCreativesResponse, which extends the library SUCCESS shape — there
+            # is no SyncCreativesSubmitted variant anywhere on the sync_creatives
+            # path, so the buyer can never be handed a task_id to poll. Steps
+            # (including the tasks/get poll binder) are implemented and grade the
+            # wire the moment production grows the variant. #1780
+            "T-UC-006-main-async-submitted": (
+                "SPEC-PRODUCTION GAP: sync_creatives has no submitted envelope — "
+                "_sync_creatives_impl only returns the success variant, so status='submitted' "
+                "with a pollable task_id is never emitted"
+            ),
+            # Same submitted-envelope gap as main-async-submitted; sandbox INV-11
+            # (omit sandbox on submitted) cannot grade until that envelope exists.
+            "T-UC-006-sandbox-submitted-no-flag": (
+                "SPEC-PRODUCTION GAP: sync_creatives has no submitted envelope — "
+                "sandbox INV-11 (omit sandbox on submitted) cannot be graded until "
+                "status='submitted' with a pollable task_id is emitted"
+            ),
             # Sandbox: invalid format_id does not trigger validation error at _impl level
             "T-UC-006-sandbox-validation": (
                 "SPEC-PRODUCTION GAP: production does not validate format_id pattern "
@@ -3189,6 +3207,11 @@ _UC002_V31_SUCCESS_WIRED: set[str] = {
 # They must NOT be parametrized across MCP/A2A/REST/IMPL API transports.
 _ADMIN_TAG_PREFIX = "T-ADMIN-"
 
+# Locally-added A2A protocol-method scenarios (tasks/get, tasks/cancel — #1780).
+# Tagged @a2a as well, so they are never parametrized across transports: the
+# methods exist only on the A2A wire.
+_A2A_TASK_OWNERSHIP_TAG_PREFIX = "T-A2A-TASK-OWNERSHIP"
+
 # UCs whose tool has no REST route — parametrize across A2A + MCP only (a REST
 # variant would 404). get_media_buys (UC-019) is A2A/MCP-only.
 _NO_REST_UC_TAG_PREFIXES = ("T-UC-019-",)
@@ -3230,6 +3253,11 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
 
     # Admin scenarios use Flask test_client, not API transports
     if any(t.startswith(_ADMIN_TAG_PREFIX) for t in marker_names):
+        return
+
+    # A2A task ownership grades tasks/get|cancel on the shared handler only —
+    # no MCP/REST equivalent. Skip multiply even if a scenario drops @a2a.
+    if any(t.startswith(_A2A_TASK_OWNERSHIP_TAG_PREFIX) for t in marker_names):
         return
 
     # IMPL-only scenarios: harness has no transport wrappers for this path

--- a/tests/bdd/conftest.py
+++ b/tests/bdd/conftest.py
@@ -82,6 +82,7 @@ pytest_plugins = [
     "tests.bdd.steps.domain.uc_brand_shorthand",
     "tests.bdd.steps.domain.compat_normalization",
     "tests.bdd.steps.domain.local_constraint_relaxations",
+    "tests.bdd.steps.domain.a2a_task_ownership",
 ]
 
 # ---------------------------------------------------------------------------
@@ -3806,6 +3807,20 @@ def _run_env_route(
         yield
 
 
+def _build_a2a_task_ownership_env(e2e_config: object | None) -> AbstractContextManager:
+    """In-memory A2A tasks/get + tasks/cancel ownership gate (#1702 / #1959)."""
+    from tests.harness.a2a_task_ownership import A2ATaskOwnershipEnv
+
+    return A2ATaskOwnershipEnv(e2e_config=e2e_config)
+
+
+def _seed_a2a_task_ownership(ctx: dict, env: object) -> None:
+    """Seed owner + sibling + cross-tenant principals for ownership grading."""
+    tenant, principal = env.setup_principals()
+    ctx["tenant"] = tenant
+    ctx["principal"] = principal
+
+
 _UC_BUCKET_ROUTES: dict[str, EnvRoute] = {
     "T-UC-003-storyboard-media-buy-not-found": EnvRoute(
         tag="T-UC-003-storyboard-media-buy-not-found",
@@ -3832,6 +3847,11 @@ _UC_BUCKET_ROUTES: dict[str, EnvRoute] = {
     "UC-GET-PRODUCTS": EnvRoute(tag="UC-GET-PRODUCTS", env_builder=_build_product_env),
     "UC-005": EnvRoute(tag="UC-005", env_builder=_build_creative_formats_env, seed=_seed_uc005),
     "UC-019": EnvRoute(tag="UC-019", env_builder=_build_media_buy_list_env, seed=_seed_uc019),
+    "A2A-TASK-OWNERSHIP": EnvRoute(
+        tag="A2A-TASK-OWNERSHIP",
+        env_builder=_build_a2a_task_ownership_env,
+        seed=_seed_a2a_task_ownership,
+    ),
 }
 
 # Tag sets the routing predicates below key on. They were inline `if` conditions

--- a/tests/bdd/conftest.py
+++ b/tests/bdd/conftest.py
@@ -1370,28 +1370,14 @@ def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
                 "SPEC-PRODUCTION GAP: sync_creatives does not set sandbox=true on "
                 "response for sandbox accounts (BR-RULE-209 INV-4)"
             ),
-            # Async submitted envelope: CreativeSyncEnv.call_a2a uses
-            # sync_creatives_raw (not _run_a2a_handler), so wire_dict() fails
-            # with "wire_response missing" before the submitted envelope can be
-            # graded — that harness gap is the proximate cause on the default
-            # [a2a] node. Underlying SPEC-PRODUCTION GAP: sync_creatives has no
-            # submitted envelope (_sync_creatives_impl only returns the success
-            # variant). Poll step unbound until create→poll seam exists (#1780).
-            "T-UC-006-main-async-submitted": (
-                "HARNESS GAP (proximate): CreativeSyncEnv.call_a2a does not stash "
-                "wire_response, so wire_dict() fails before grading. "
-                "SPEC-PRODUCTION GAP (underlying): sync_creatives has no submitted "
-                "envelope — _sync_creatives_impl only returns the success variant"
-            ),
-            # Same submitted-envelope gap as main-async-submitted; no poll step,
-            # so this entry retains the production-gap ratchet (flips when the
-            # envelope lands). A2A node also blocked by the wire_response stash.
-            "T-UC-006-sandbox-submitted-no-flag": (
-                "SPEC-PRODUCTION GAP: sync_creatives has no submitted envelope — "
-                "sandbox INV-11 (omit sandbox on submitted) cannot be graded until "
-                "status='submitted' with a pollable task_id is emitted "
-                "(A2A also blocked by CreativeSyncEnv wire_response stash gap)"
-            ),
+            # NOTE: T-UC-006-main-async-submitted and T-UC-006-sandbox-submitted-no-flag
+            # are NOT wired here (see the UC-006 harness-selection branch below) — both
+            # fall through to the blanket "UC-006 harness not yet wired" xfail, same as
+            # before #1720's poll-step seam. Wiring them into CreativeSyncEnv only to
+            # strict-xfail on the still-open SPEC-PRODUCTION GAP (sync_creatives emits no
+            # `submitted` envelope) would grow the strict-xfail registry to park a gap
+            # instead of closing it (shrink-only rule). Re-wire once _sync_creatives_impl
+            # emits the `submitted` envelope, so both scenarios pass outright.
             # Sandbox: invalid format_id does not trigger validation error at _impl level
             "T-UC-006-sandbox-validation": (
                 "SPEC-PRODUCTION GAP: production does not validate format_id pattern "

--- a/tests/bdd/conftest.py
+++ b/tests/bdd/conftest.py
@@ -1370,23 +1370,27 @@ def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
                 "SPEC-PRODUCTION GAP: sync_creatives does not set sandbox=true on "
                 "response for sandbox accounts (BR-RULE-209 INV-4)"
             ),
-            # Async submitted envelope: _sync_creatives_impl returns
-            # SyncCreativesResponse, which extends the library SUCCESS shape — there
-            # is no SyncCreativesSubmitted variant anywhere on the sync_creatives
-            # path, so the buyer can never be handed a task_id to poll. Steps
-            # (including the tasks/get poll binder) are implemented and grade the
-            # wire the moment production grows the variant. #1780
+            # Async submitted envelope: CreativeSyncEnv.call_a2a uses
+            # sync_creatives_raw (not _run_a2a_handler), so wire_dict() fails
+            # with "wire_response missing" before the submitted envelope can be
+            # graded — that harness gap is the proximate cause on the default
+            # [a2a] node. Underlying SPEC-PRODUCTION GAP: sync_creatives has no
+            # submitted envelope (_sync_creatives_impl only returns the success
+            # variant). Poll step unbound until create→poll seam exists (#1780).
             "T-UC-006-main-async-submitted": (
-                "SPEC-PRODUCTION GAP: sync_creatives has no submitted envelope — "
-                "_sync_creatives_impl only returns the success variant, so status='submitted' "
-                "with a pollable task_id is never emitted"
+                "HARNESS GAP (proximate): CreativeSyncEnv.call_a2a does not stash "
+                "wire_response, so wire_dict() fails before grading. "
+                "SPEC-PRODUCTION GAP (underlying): sync_creatives has no submitted "
+                "envelope — _sync_creatives_impl only returns the success variant"
             ),
-            # Same submitted-envelope gap as main-async-submitted; sandbox INV-11
-            # (omit sandbox on submitted) cannot grade until that envelope exists.
+            # Same submitted-envelope gap as main-async-submitted; no poll step,
+            # so this entry retains the production-gap ratchet (flips when the
+            # envelope lands). A2A node also blocked by the wire_response stash.
             "T-UC-006-sandbox-submitted-no-flag": (
                 "SPEC-PRODUCTION GAP: sync_creatives has no submitted envelope — "
                 "sandbox INV-11 (omit sandbox on submitted) cannot be graded until "
-                "status='submitted' with a pollable task_id is emitted"
+                "status='submitted' with a pollable task_id is emitted "
+                "(A2A also blocked by CreativeSyncEnv wire_response stash gap)"
             ),
             # Sandbox: invalid format_id does not trigger validation error at _impl level
             "T-UC-006-sandbox-validation": (
@@ -3210,7 +3214,7 @@ _ADMIN_TAG_PREFIX = "T-ADMIN-"
 # Locally-added A2A protocol-method scenarios (tasks/get, tasks/cancel — #1780).
 # Tagged @a2a as well, so they are never parametrized across transports: the
 # methods exist only on the A2A wire.
-_A2A_TASK_OWNERSHIP_TAG_PREFIX = "T-A2A-TASK-OWNERSHIP"
+_A2A_TASK_OWNERSHIP_TAG_PREFIX = "T-A2A-TASK-OWNERSHIP-"
 
 # UCs whose tool has no REST route — parametrize across A2A + MCP only (a REST
 # variant would 404). get_media_buys (UC-019) is A2A/MCP-only.
@@ -3256,7 +3260,9 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
         return
 
     # A2A task ownership grades tasks/get|cancel on the shared handler only —
-    # no MCP/REST equivalent. Skip multiply even if a scenario drops @a2a.
+    # no MCP/REST equivalent. Redundant with ``_TRANSPORT_SPECIFIC_TAGS`` today
+    # (all scenarios also carry ``@a2a``, which returns above); kept as
+    # belt-and-braces if a scenario drops ``@a2a`` while retaining the tag prefix.
     if any(t.startswith(_A2A_TASK_OWNERSHIP_TAG_PREFIX) for t in marker_names):
         return
 

--- a/tests/bdd/features/local-a2a-task-ownership.feature
+++ b/tests/bdd/features/local-a2a-task-ownership.feature
@@ -59,19 +59,22 @@ Feature: A2A in-memory task ownership for tasks/get and tasks/cancel (local)
   Scenario: A denied tasks/cancel does not mutate the owner's task
     When the "sibling" calls tasks/cancel for task "task-owned-1"
     Then the A2A task response should be a JSON-RPC task-not-found error for "task-owned-1"
-    And the stored task "task-owned-1" should be in state WORKING
+    When the "owner" calls tasks/get for task "task-owned-1"
+    Then the A2A task response should carry task "task-owned-1" in state WORKING
 
   @T-A2A-TASK-OWNERSHIP-other-tenant-cancel @a2a
   Scenario: A principal in another tenant is denied via tasks/cancel
     When the "other_tenant" calls tasks/cancel for task "task-owned-1"
     Then the A2A task response should be a JSON-RPC task-not-found error for "task-owned-1"
-    And the stored task "task-owned-1" should be in state WORKING
+    When the "owner" calls tasks/get for task "task-owned-1"
+    Then the A2A task response should carry task "task-owned-1" in state WORKING
 
   @T-A2A-TASK-OWNERSHIP-owner-cancel @a2a
   Scenario: The owner cancels their own task
     When the "owner" calls tasks/cancel for task "task-owned-1"
     Then the A2A task response should carry task "task-owned-1" in state CANCELED
-    And the stored task "task-owned-1" should be in state CANCELED
+    When the "owner" calls tasks/get for task "task-owned-1"
+    Then the A2A task response should carry task "task-owned-1" in state CANCELED
 
   @T-A2A-TASK-OWNERSHIP-no-owner-get @a2a
   Scenario: A task present without an owner record is denied as not-found

--- a/tests/bdd/features/local-a2a-task-ownership.feature
+++ b/tests/bdd/features/local-a2a-task-ownership.feature
@@ -10,12 +10,26 @@
 # indistinguishable from an unknown id (no existence oracle). Reconcile
 # upstream in adcp-req, then retire this file for the regenerated scenarios.
 #
+# Spec grounding (A2A Protocol):
+# - §3.3.2 — servers MUST NOT reveal existence of resources the client is not
+#   authorized to access (example: "attempting to access a task created by
+#   another user"); MUST return not-found when a resource "does not exist or
+#   is not accessible"; SHOULD NOT distinguish the two.
+# - §13.1 — Get/Cancel MUST verify access, and authorization MUST occur before
+#   any query that could leak existence (auth-first ordering).
+# This altitude is upstream-ungraded by design: AdCP task-lifecycle places
+# transport-native tasks/* outside AdCP polling. AdCP 3.1.1 grades the analogue
+# at get_products_async (get_products_task_status_wrong_account /
+# list_products_task_wrong_account → REFERENCE_NOT_FOUND).
+#
 # @a2a: these are protocol methods, not AdCP skills — there is no MCP or REST
-# equivalent to parametrize across. The denial oracle grades the handler-
-# exception shape mirrored to today's v0.3 JSON-RPC body (CoreInternalError /
-# -32603), not a live adapter capture and not a two-layer AdCP envelope. Live
-# JSON-RPC wire serialization is proven in tests/unit/test_a2a_task_identity_wire.py
-# (#1720).
+# equivalent to parametrize across. The denial oracle grades the live v0.3
+# compat JSON-RPC body captured through create_jsonrpc_routes
+# (enable_v0_3_compat=True). Spec TaskNotFoundError code is -32001; today's
+# compat path emits -32603 (system InternalError) — pinned here as the verified
+# live wire. The live-server strict xfail in
+# tests/e2e/test_a2a_endpoints_working.py asserts -32001 and flips when #1670
+# closes the flattening. Not a two-layer AdCP envelope.
 Feature: A2A in-memory task ownership for tasks/get and tasks/cancel (local)
 
   Background:
@@ -58,3 +72,14 @@ Feature: A2A in-memory task ownership for tasks/get and tasks/cancel (local)
     When the "owner" calls tasks/cancel for task "task-owned-1"
     Then the A2A task response should carry task "task-owned-1" in state CANCELED
     And the stored task "task-owned-1" should be in state CANCELED
+
+  @T-A2A-TASK-OWNERSHIP-no-owner-get @a2a
+  Scenario: A task present without an owner record is denied as not-found
+    Given an in-memory A2A task "task-orphan-1" with no owner record
+    When the "owner" calls tasks/get for task "task-orphan-1"
+    Then the A2A task response should be a JSON-RPC task-not-found error for "task-orphan-1"
+
+  @T-A2A-TASK-OWNERSHIP-unauth-get @a2a
+  Scenario: An unauthenticated caller gets an auth failure, not task-not-found
+    When an unauthenticated caller calls tasks/get for task "task-owned-1"
+    Then the A2A task response should be an authentication failure, not task-not-found

--- a/tests/bdd/features/local-a2a-task-ownership.feature
+++ b/tests/bdd/features/local-a2a-task-ownership.feature
@@ -1,0 +1,60 @@
+# Hand-authored feature — not compiled from adcp-req.
+#
+# LOCALLY-ADDED (survives BR-*.feature regeneration).
+# Upstream gap: no storyboard scenario drives the A2A protocol methods
+# `tasks/get` / `tasks/cancel` against a task another principal owns. That is
+# the surface the in-memory ownership gate defends (#1702): a task_id is
+# unguessable but not secret once known (webhook payloads, logs, support
+# channels), so serving or cancelling an in-memory hit for anyone who learned
+# the id leaks — and mutates — another buyer's task. The denial must be
+# indistinguishable from an unknown id (no existence oracle). Reconcile
+# upstream in adcp-req, then retire this file for the regenerated scenarios.
+#
+# @a2a: these are protocol methods, not AdCP skills — there is no MCP or REST
+# equivalent to parametrize across. The denial oracle grades the handler-
+# exception shape mirrored to today's v0.3 JSON-RPC body (CoreInternalError /
+# -32603), not a live adapter capture and not a two-layer AdCP envelope. Live
+# JSON-RPC wire serialization is proven in tests/unit/test_a2a_task_identity_wire.py
+# (#1720).
+Feature: A2A in-memory task ownership for tasks/get and tasks/cancel (local)
+
+  Background:
+    Given an in-memory A2A task "task-owned-1" owned by the owning principal
+
+  @T-A2A-TASK-OWNERSHIP-owner-get @a2a
+  Scenario: The owner retrieves their own task via tasks/get
+    When the "owner" calls tasks/get for task "task-owned-1"
+    Then the A2A task response should carry task "task-owned-1" in state WORKING
+
+  @T-A2A-TASK-OWNERSHIP-sibling-get @a2a
+  Scenario: A sibling principal in the same tenant is denied via tasks/get
+    When the "sibling" calls tasks/get for task "task-owned-1"
+    Then the A2A task response should be a JSON-RPC task-not-found error for "task-owned-1"
+
+  @T-A2A-TASK-OWNERSHIP-other-tenant-get @a2a
+  Scenario: A principal in another tenant is denied via tasks/get
+    When the "other_tenant" calls tasks/get for task "task-owned-1"
+    Then the A2A task response should be a JSON-RPC task-not-found error for "task-owned-1"
+
+  @T-A2A-TASK-OWNERSHIP-unknown-get @a2a
+  Scenario: An unknown task id is denied in the same shape as an ownership miss
+    When the "owner" calls tasks/get for task "task-never-created"
+    Then the A2A task response should be a JSON-RPC task-not-found error for "task-never-created"
+
+  @T-A2A-TASK-OWNERSHIP-sibling-cancel @a2a
+  Scenario: A denied tasks/cancel does not mutate the owner's task
+    When the "sibling" calls tasks/cancel for task "task-owned-1"
+    Then the A2A task response should be a JSON-RPC task-not-found error for "task-owned-1"
+    And the stored task "task-owned-1" should be in state WORKING
+
+  @T-A2A-TASK-OWNERSHIP-other-tenant-cancel @a2a
+  Scenario: A principal in another tenant is denied via tasks/cancel
+    When the "other_tenant" calls tasks/cancel for task "task-owned-1"
+    Then the A2A task response should be a JSON-RPC task-not-found error for "task-owned-1"
+    And the stored task "task-owned-1" should be in state WORKING
+
+  @T-A2A-TASK-OWNERSHIP-owner-cancel @a2a
+  Scenario: The owner cancels their own task
+    When the "owner" calls tasks/cancel for task "task-owned-1"
+    Then the A2A task response should carry task "task-owned-1" in state CANCELED
+    And the stored task "task-owned-1" should be in state CANCELED

--- a/tests/bdd/steps/domain/a2a_task_ownership.py
+++ b/tests/bdd/steps/domain/a2a_task_ownership.py
@@ -111,20 +111,5 @@ def then_auth_failure_not_task_not_found(ctx: dict) -> None:
     assert_wire_auth_failure(error)
 
 
-@then(parsers.parse('the stored task "{task_id}" should be in state {state}'))
-def then_stored_task_state(ctx: dict, task_id: str, state: str) -> None:
-    """Poll the task as its owner and grade the wire result, not in-process state.
-
-    A denied cancel must leave the task servable and unmutated to its owner —
-    checked at the same altitude ``then_task_served`` grades, by re-dispatching
-    ``tasks/get`` rather than reaching into ``handler.tasks`` (#1720 review).
-    """
-    env = ctx["env"]
-    env.run_a2a_task_method("tasks/get", task_id, identity=env.identity_for_role("owner"))
-    assert env.last_a2a_task_error is None, (
-        f"Expected task {task_id} to still be servable to its owner, got error: {env.last_a2a_task_error}"
-    )
-    task = env.last_a2a_task
-    assert task is not None, f"No Task returned for {task_id}"
-    assert task.id == task_id
-    assert task.status.state == _task_state(state)
+# Non-mutation after denied cancel is graded by a follow-up When/Then pair in the
+# feature (owner polls tasks/get) — no request inside Then (BDD guard).

--- a/tests/bdd/steps/domain/a2a_task_ownership.py
+++ b/tests/bdd/steps/domain/a2a_task_ownership.py
@@ -2,11 +2,10 @@
 
 Grades the protocol surface of ``tasks/get`` / ``tasks/cancel``, not an AdCP
 skill: a denial has no artifact and no two-layer envelope. The oracle is
-``assert_wire_task_not_found`` on the **handler-exception shape mirrored** to
-today's v0.3 JSON-RPC body (``CoreInternalError`` / ``-32603``) — not a live
-capture through ``create_jsonrpc_routes``. Live adapter wire serialization is
-proven in ``tests/unit/test_a2a_task_identity_wire.py`` (#1720). Never use
-``assert_envelope_shape`` / ``wire_error_envelope`` here.
+``assert_wire_task_not_found`` on the **live** v0.3 JSON-RPC body captured
+through ``create_jsonrpc_routes(..., enable_v0_3_compat=True)``. Live adapter
+wire serialization is also proven in ``tests/unit/test_a2a_task_identity_wire.py``
+(#1720). Never use ``assert_envelope_shape`` / ``wire_error_envelope`` here.
 
 Owner, same-tenant sibling and other-tenant caller are seeded by
 ``A2ATaskOwnershipEnv`` with real access tokens, so every dispatch runs the
@@ -41,18 +40,29 @@ def given_owned_in_memory_task(ctx: dict, task_id: str) -> None:
     env.seed_a2a_task(task_id, identity=env.identity_for_role("owner"))
 
 
-@when(parsers.parse('the "{role}" calls tasks/get for task "{task_id}"'))
-def when_role_calls_tasks_get(ctx: dict, role: str, task_id: str) -> None:
-    """Dispatch tasks/get as *role* against the shared handler."""
+@given(parsers.parse('an in-memory A2A task "{task_id}" with no owner record'))
+def given_orphan_in_memory_task(ctx: dict, task_id: str) -> None:
+    """Seed a task in ``handler.tasks`` without recording ``_task_owners``.
+
+    Grades the fail-closed path when a task exists but has no owner record
+    (legacy tasks / future create paths that forget to record ownership).
+    """
     env = ctx["env"]
-    env._run_a2a_task_method("tasks/get", task_id, identity=env.identity_for_role(role))
+    env.seed_a2a_task(task_id, identity=env.identity_for_role("owner"), record_owner=False)
 
 
-@when(parsers.parse('the "{role}" calls tasks/cancel for task "{task_id}"'))
-def when_role_calls_tasks_cancel(ctx: dict, role: str, task_id: str) -> None:
-    """Dispatch tasks/cancel as *role* against the shared handler."""
+@when(parsers.parse('the "{role}" calls {method} for task "{task_id}"'))
+def when_role_calls_task_method(ctx: dict, role: str, method: str, task_id: str) -> None:
+    """Dispatch ``tasks/get`` / ``tasks/cancel`` as *role* against the shared handler."""
     env = ctx["env"]
-    env._run_a2a_task_method("tasks/cancel", task_id, identity=env.identity_for_role(role))
+    env.run_a2a_task_method(method, task_id, identity=env.identity_for_role(role))
+
+
+@when(parsers.parse('an unauthenticated caller calls {method} for task "{task_id}"'))
+def when_unauth_calls_task_method(ctx: dict, method: str, task_id: str) -> None:
+    """Dispatch with ``identity=None`` — auth failure must not collapse to not-found."""
+    env = ctx["env"]
+    env.run_a2a_task_method(method, task_id, identity=None)
 
 
 @then(parsers.parse('the A2A task response should carry task "{task_id}" in state {state}'))
@@ -70,18 +80,40 @@ def then_task_served(ctx: dict, task_id: str, state: str) -> None:
 
 @then(parsers.parse('the A2A task response should be a JSON-RPC task-not-found error for "{task_id}"'))
 def then_task_not_found(ctx: dict, task_id: str) -> None:
-    """Assert the mirrored not-found body — the same for denial and unknown id.
+    """Assert the live not-found body — the same for denial and unknown id.
 
     ``assert_wire_task_not_found`` pins code/message/data literally on the
-    handler-exception reconstruction (not a live JSON-RPC response). An
-    ownership denial that leaked "you may not touch this" (or any tenant /
-    principal identifier) would fail here rather than pass as "some error".
+    captured JSON-RPC error (independent of ``_task_not_found_message``). An
+    ownership denial that leaked "you may not touch this" would fail the exact
+    equality. A static identity leak inside the shared message builder is
+    caught by the forbidden-substring check over this env's role ids (not the
+    unit-fixture defaults, which BDD bodies never contain).
     """
     env = ctx["env"]
     assert env.last_a2a_task is None, f"Denied call still returned a Task: {env.last_a2a_task}"
     error = env.last_a2a_task_error
     assert error is not None, f"Expected a task-not-found error for {task_id}, got none"
     assert_wire_task_not_found(error, task_id)
+    blob = f"{error.get('message', '')}{error.get('data')!s}"
+    for needle in (
+        env.OWNER_TENANT_ID,
+        env.OWNER_PRINCIPAL_ID,
+        env.SIBLING_PRINCIPAL_ID,
+        env.OTHER_TENANT_ID,
+        env.OTHER_PRINCIPAL_ID,
+    ):
+        assert needle not in blob, f"identity leak {needle!r} in not-found body: {error!r}"
+
+
+@then("the A2A task response should be an authentication failure, not task-not-found")
+def then_auth_failure_not_task_not_found(ctx: dict) -> None:
+    """Unauthenticated callers must not receive the ownership-denial not-found shape."""
+    env = ctx["env"]
+    assert env.last_a2a_task is None, f"Unauth call still returned a Task: {env.last_a2a_task}"
+    error = env.last_a2a_task_error
+    assert error is not None, "Expected an authentication failure, got none"
+    assert error.get("message") == "Missing authentication token", f"expected auth-failure message, got {error!r}"
+    assert "Task not found" not in str(error.get("message", ""))
 
 
 @then(parsers.parse('the stored task "{task_id}" should be in state {state}'))

--- a/tests/bdd/steps/domain/a2a_task_ownership.py
+++ b/tests/bdd/steps/domain/a2a_task_ownership.py
@@ -14,23 +14,24 @@ production auth chain before the ownership gate decides.
 
 from __future__ import annotations
 
-from typing import Any
-
+from a2a.types import TaskState
 from pytest_bdd import given, parsers, then, when
 
-from tests.a2a_helpers import assert_wire_no_identity_leak, assert_wire_task_not_found
+from tests.a2a_helpers import (
+    assert_wire_auth_failure,
+    assert_wire_no_identity_leak,
+    assert_wire_task_not_found,
+)
 
-_OWNED_TASK_STATE_BY_NAME = {
-    "WORKING": "TASK_STATE_WORKING",
-    "CANCELED": "TASK_STATE_CANCELED",
+_OWNED_TASK_STATE_BY_NAME: dict[str, TaskState.ValueType] = {
+    "WORKING": TaskState.TASK_STATE_WORKING,
+    "CANCELED": TaskState.TASK_STATE_CANCELED,
 }
 
 
-def _task_state(name: str) -> Any:
-    """Resolve a Gherkin state word to the a2a ``TaskState`` enum member."""
-    from a2a.types import TaskState
-
-    return getattr(TaskState, _OWNED_TASK_STATE_BY_NAME[name])
+def _task_state(name: str) -> TaskState.ValueType:
+    """Resolve a Gherkin state word to the a2a ``TaskState`` enum value."""
+    return _OWNED_TASK_STATE_BY_NAME[name]
 
 
 @given(parsers.parse('an in-memory A2A task "{task_id}" owned by the owning principal'))
@@ -107,8 +108,7 @@ def then_auth_failure_not_task_not_found(ctx: dict) -> None:
     assert env.last_a2a_task is None, f"Unauth call still returned a Task: {env.last_a2a_task}"
     error = env.last_a2a_task_error
     assert error is not None, "Expected an authentication failure, got none"
-    assert error.get("message") == "Missing authentication token", f"expected auth-failure message, got {error!r}"
-    assert "Task not found" not in str(error.get("message", ""))
+    assert_wire_auth_failure(error)
 
 
 @then(parsers.parse('the stored task "{task_id}" should be in state {state}'))

--- a/tests/bdd/steps/domain/a2a_task_ownership.py
+++ b/tests/bdd/steps/domain/a2a_task_ownership.py
@@ -18,7 +18,7 @@ from typing import Any
 
 from pytest_bdd import given, parsers, then, when
 
-from tests.a2a_helpers import assert_wire_task_not_found
+from tests.a2a_helpers import assert_wire_no_identity_leak, assert_wire_task_not_found
 
 _OWNED_TASK_STATE_BY_NAME = {
     "WORKING": "TASK_STATE_WORKING",
@@ -94,15 +94,10 @@ def then_task_not_found(ctx: dict, task_id: str) -> None:
     error = env.last_a2a_task_error
     assert error is not None, f"Expected a task-not-found error for {task_id}, got none"
     assert_wire_task_not_found(error, task_id)
-    blob = f"{error.get('message', '')}{error.get('data')!s}"
-    for needle in (
-        env.OWNER_TENANT_ID,
-        env.OWNER_PRINCIPAL_ID,
-        env.SIBLING_PRINCIPAL_ID,
-        env.OTHER_TENANT_ID,
-        env.OTHER_PRINCIPAL_ID,
-    ):
-        assert needle not in blob, f"identity leak {needle!r} in not-found body: {error!r}"
+    # Shared wire-dict oracle driven from the canonical OWNED_TASK_FORBIDDEN_SUBSTRINGS
+    # set (not env.*_ID re-aliases) — the copy most likely to be missed if the
+    # non-disclosure policy changes (#1720 review).
+    assert_wire_no_identity_leak(error)
 
 
 @then("the A2A task response should be an authentication failure, not task-not-found")
@@ -118,6 +113,18 @@ def then_auth_failure_not_task_not_found(ctx: dict) -> None:
 
 @then(parsers.parse('the stored task "{task_id}" should be in state {state}'))
 def then_stored_task_state(ctx: dict, task_id: str, state: str) -> None:
-    """Read the handler's stored Task back — a denied cancel must not mutate it."""
+    """Poll the task as its owner and grade the wire result, not in-process state.
+
+    A denied cancel must leave the task servable and unmutated to its owner —
+    checked at the same altitude ``then_task_served`` grades, by re-dispatching
+    ``tasks/get`` rather than reaching into ``handler.tasks`` (#1720 review).
+    """
     env = ctx["env"]
-    assert env.a2a_task_state(task_id) == _task_state(state)
+    env.run_a2a_task_method("tasks/get", task_id, identity=env.identity_for_role("owner"))
+    assert env.last_a2a_task_error is None, (
+        f"Expected task {task_id} to still be servable to its owner, got error: {env.last_a2a_task_error}"
+    )
+    task = env.last_a2a_task
+    assert task is not None, f"No Task returned for {task_id}"
+    assert task.id == task_id
+    assert task.status.state == _task_state(state)

--- a/tests/bdd/steps/domain/a2a_task_ownership.py
+++ b/tests/bdd/steps/domain/a2a_task_ownership.py
@@ -1,0 +1,91 @@
+"""BDD steps for the A2A in-memory task ownership gate (local feature, #1780).
+
+Grades the protocol surface of ``tasks/get`` / ``tasks/cancel``, not an AdCP
+skill: a denial has no artifact and no two-layer envelope. The oracle is
+``assert_wire_task_not_found`` on the **handler-exception shape mirrored** to
+today's v0.3 JSON-RPC body (``CoreInternalError`` / ``-32603``) — not a live
+capture through ``create_jsonrpc_routes``. Live adapter wire serialization is
+proven in ``tests/unit/test_a2a_task_identity_wire.py`` (#1720). Never use
+``assert_envelope_shape`` / ``wire_error_envelope`` here.
+
+Owner, same-tenant sibling and other-tenant caller are seeded by
+``A2ATaskOwnershipEnv`` with real access tokens, so every dispatch runs the
+production auth chain before the ownership gate decides.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pytest_bdd import given, parsers, then, when
+
+from tests.a2a_helpers import assert_wire_task_not_found
+
+_OWNED_TASK_STATE_BY_NAME = {
+    "WORKING": "TASK_STATE_WORKING",
+    "CANCELED": "TASK_STATE_CANCELED",
+}
+
+
+def _task_state(name: str) -> Any:
+    """Resolve a Gherkin state word to the a2a ``TaskState`` enum member."""
+    from a2a.types import TaskState
+
+    return getattr(TaskState, _OWNED_TASK_STATE_BY_NAME[name])
+
+
+@given(parsers.parse('an in-memory A2A task "{task_id}" owned by the owning principal'))
+def given_owned_in_memory_task(ctx: dict, task_id: str) -> None:
+    """Seed a WORKING task owned by the owner principal on the shared handler."""
+    env = ctx["env"]
+    env.seed_a2a_task(task_id, identity=env.identity_for_role("owner"))
+
+
+@when(parsers.parse('the "{role}" calls tasks/get for task "{task_id}"'))
+def when_role_calls_tasks_get(ctx: dict, role: str, task_id: str) -> None:
+    """Dispatch tasks/get as *role* against the shared handler."""
+    env = ctx["env"]
+    env._run_a2a_task_method("tasks/get", task_id, identity=env.identity_for_role(role))
+
+
+@when(parsers.parse('the "{role}" calls tasks/cancel for task "{task_id}"'))
+def when_role_calls_tasks_cancel(ctx: dict, role: str, task_id: str) -> None:
+    """Dispatch tasks/cancel as *role* against the shared handler."""
+    env = ctx["env"]
+    env._run_a2a_task_method("tasks/cancel", task_id, identity=env.identity_for_role(role))
+
+
+@then(parsers.parse('the A2A task response should carry task "{task_id}" in state {state}'))
+def then_task_served(ctx: dict, task_id: str, state: str) -> None:
+    """Assert the caller was served the Task itself — id and state both graded."""
+    env = ctx["env"]
+    assert env.last_a2a_task_error is None, (
+        f"Expected task {task_id} to be served, got error: {env.last_a2a_task_error}"
+    )
+    task = env.last_a2a_task
+    assert task is not None, f"No Task returned for {task_id}"
+    assert task.id == task_id
+    assert task.status.state == _task_state(state)
+
+
+@then(parsers.parse('the A2A task response should be a JSON-RPC task-not-found error for "{task_id}"'))
+def then_task_not_found(ctx: dict, task_id: str) -> None:
+    """Assert the mirrored not-found body — the same for denial and unknown id.
+
+    ``assert_wire_task_not_found`` pins code/message/data literally on the
+    handler-exception reconstruction (not a live JSON-RPC response). An
+    ownership denial that leaked "you may not touch this" (or any tenant /
+    principal identifier) would fail here rather than pass as "some error".
+    """
+    env = ctx["env"]
+    assert env.last_a2a_task is None, f"Denied call still returned a Task: {env.last_a2a_task}"
+    error = env.last_a2a_task_error
+    assert error is not None, f"Expected a task-not-found error for {task_id}, got none"
+    assert_wire_task_not_found(error, task_id)
+
+
+@then(parsers.parse('the stored task "{task_id}" should be in state {state}'))
+def then_stored_task_state(ctx: dict, task_id: str, state: str) -> None:
+    """Read the handler's stored Task back — a denied cancel must not mutate it."""
+    env = ctx["env"]
+    assert env.a2a_task_state(task_id) == _task_state(state)

--- a/tests/bdd/test_a2a_task_ownership.py
+++ b/tests/bdd/test_a2a_task_ownership.py
@@ -1,0 +1,13 @@
+"""BDD binding for the locally-added A2A task ownership feature (#1780).
+
+Grades the in-memory ownership gate (#1702) at the JSON-RPC protocol altitude:
+`tasks/get` and `tasks/cancel` against a task owned by another principal.
+Retire together with the local feature once the upstream storyboard (adcp-req)
+grows the equivalent scenarios.
+"""
+
+from __future__ import annotations
+
+from pytest_bdd import scenarios
+
+scenarios("features/local-a2a-task-ownership.feature")

--- a/tests/e2e/test_a2a_endpoints_working.py
+++ b/tests/e2e/test_a2a_endpoints_working.py
@@ -11,7 +11,7 @@ This test validates the actual HTTP endpoints that our A2A server exposes.
 import json
 import os
 import sys
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 import requests
@@ -22,6 +22,7 @@ from adcp import get_adcp_spec_version
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 
 from tests.e2e.conftest import e2e_host
+from tests.factories import PrincipalFactory
 
 
 def _a2a_base_url() -> str:
@@ -310,14 +311,14 @@ class TestA2ARequestHandler:
     async def test_unknown_task_id_raises_task_not_found(self, request_cls, method_name):
         """An unknown task id raises TaskNotFoundError, not the generic internal
         error a bare None return produces — cancel is the same not-found condition
-        as get, and both route through the shared ``_get_task_or_raise``.
+        as get, and both route through the shared ``_get_owned_in_memory_task_or_raise``.
 
         Fast smoke check on the raise only. It does NOT prove the wire code: the
         exception carries no code, and the client actually sees -32603 — see
-        ``_get_task_or_raise`` (src/a2a_server/adcp_a2a_server.py) and #1670 for
-        why, plus the xfail'd live-server test in TestA2AServerIntegration that
-        grades the code on the wire. Assert on str(exc), not exc.code — there is
-        none.
+        ``_get_owned_in_memory_task_or_raise`` (src/a2a_server/adcp_a2a_server.py)
+        and #1670 for why, plus the xfail'd live-server test in
+        TestA2AServerIntegration that grades the code on the wire. Assert on
+        str(exc), not exc.code — there is none.
 
         Parametrized over both entry points so the shared assertion cannot drift
         between two byte-identical copies.
@@ -326,9 +327,20 @@ class TestA2ARequestHandler:
         structured ``data`` payload clients actually parse. Asserting the message
         alone would let ``data={"task_id": ...}`` be deleted with the suite still
         green, since the id appears in the message either way.
+
+        Auth is mocked so this grades the not-found shape after the identity
+        gate (#1702), not an auth-failure collapse into the same error.
         """
-        with pytest.raises(TaskNotFoundError) as exc:
-            await getattr(self.handler, method_name)(request_cls(id="task_does_not_exist"), MagicMock())
+        with (
+            patch.object(self.handler, "_get_auth_token", return_value="tok"),
+            patch.object(
+                self.handler,
+                "_resolve_a2a_identity",
+                return_value=PrincipalFactory.make_identity(protocol="a2a"),
+            ),
+        ):
+            with pytest.raises(TaskNotFoundError) as exc:
+                await getattr(self.handler, method_name)(request_cls(id="task_does_not_exist"), MagicMock())
         assert "task_does_not_exist" in str(exc.value)  # the requested id is surfaced
         assert exc.value.data == {"task_id": "task_does_not_exist"}  # ...and machine-readable
 
@@ -389,8 +401,9 @@ class TestA2AServerIntegration:
         locked in when #1670 lands.
 
         STRICT xfail against #1670: the code is -32603 today, not the spec's
-        -32001 — see ``_get_task_or_raise`` (src/a2a_server/adcp_a2a_server.py) and
-        #1670 for the enable_v0_3_compat dispatch path that flattens it. Both
+        -32001 — see ``_get_owned_in_memory_task_or_raise``
+        (src/a2a_server/adcp_a2a_server.py) and #1670 for the
+        enable_v0_3_compat dispatch path that flattens it. Both
         `tasks/get` and `tasks/cancel` reach that path, so both are -32603 today
         whether they raise TaskNotFoundError or return None.
 

--- a/tests/e2e/test_a2a_endpoints_working.py
+++ b/tests/e2e/test_a2a_endpoints_working.py
@@ -337,7 +337,11 @@ class TestA2ARequestHandler:
         with a2a_auth_as(self.handler, PrincipalFactory.make_identity(protocol="a2a")):
             with pytest.raises(TaskNotFoundError) as exc:
                 await getattr(self.handler, method_name)(request_cls(id="task_does_not_exist"), MagicMock())
-        assert_task_not_found_nondisclosure(exc.value, "task_does_not_exist")
+        assert_task_not_found_nondisclosure(
+            exc.value,
+            "task_does_not_exist",
+            forbidden_substrings=("test_tenant", "test_principal"),
+        )
 
     def test_handler_has_skill_methods(self):
         """Test that handler has skill-specific methods."""

--- a/tests/e2e/test_a2a_endpoints_working.py
+++ b/tests/e2e/test_a2a_endpoints_working.py
@@ -11,7 +11,7 @@ This test validates the actual HTTP endpoints that our A2A server exposes.
 import json
 import os
 import sys
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 import requests
@@ -21,6 +21,7 @@ from adcp import get_adcp_spec_version
 # Add parent directories to path for imports
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 
+from tests.a2a_helpers import a2a_auth_as
 from tests.e2e.conftest import e2e_host
 from tests.factories import PrincipalFactory
 
@@ -331,14 +332,7 @@ class TestA2ARequestHandler:
         Auth is mocked so this grades the not-found shape after the identity
         gate (#1702), not an auth-failure collapse into the same error.
         """
-        with (
-            patch.object(self.handler, "_get_auth_token", return_value="tok"),
-            patch.object(
-                self.handler,
-                "_resolve_a2a_identity",
-                return_value=PrincipalFactory.make_identity(protocol="a2a"),
-            ),
-        ):
+        with a2a_auth_as(self.handler, PrincipalFactory.make_identity(protocol="a2a")):
             with pytest.raises(TaskNotFoundError) as exc:
                 await getattr(self.handler, method_name)(request_cls(id="task_does_not_exist"), MagicMock())
         assert "task_does_not_exist" in str(exc.value)  # the requested id is surfaced
@@ -397,6 +391,9 @@ class TestA2AServerIntegration:
 
         Sends a valid tenant Bearer token so the request reaches the
         ownership/unknown-id branch rather than exiting at the auth gate (#1702).
+        Cross-principal ownership compare on the wire is graded in-process by
+        ``tests/unit/test_a2a_task_identity_wire.py`` (live_server has no seeded
+        in-memory owner map); this live_server case still POSTs an unknown id.
 
         Parametrized over both methods this PR changed. `tasks/cancel` of an
         unknown id went from a silent None to an error in this PR, so it needs the

--- a/tests/e2e/test_a2a_endpoints_working.py
+++ b/tests/e2e/test_a2a_endpoints_working.py
@@ -424,6 +424,11 @@ class TestA2AServerIntegration:
         assert response.status_code == 200, f"JSON-RPC errors ride a 200 envelope: {response.status_code}"
         data = response.json()
         assert "error" in data, f"unknown task id must produce a JSON-RPC error: {data}"
+        # Branch-reached: token/init_db drift must not silently exit at the auth
+        # gate and still xfail on a non--32001 code for the wrong reason (#1720).
+        assert data["error"]["message"] != "Missing authentication token", (
+            f"unknown-id tripwire exited at auth instead of the ownership branch: {data['error']!r}"
+        )
         assert data["error"]["code"] == -32001, (
             f"A2A spec defines -32001 (TaskNotFoundError) for an unknown task id, got "
             f"{data['error']['code']} — see #1670"

--- a/tests/e2e/test_a2a_endpoints_working.py
+++ b/tests/e2e/test_a2a_endpoints_working.py
@@ -325,9 +325,10 @@ class TestA2ARequestHandler:
         between two byte-identical copies.
 
         Both halves of the raise are pinned: the human-readable message AND the
-        structured ``data`` payload clients actually parse. Asserting the message
-        alone would let ``data={"task_id": ...}`` be deleted with the suite still
-        green, since the id appears in the message either way.
+        structured ``data`` field on the exception object (the JSON-RPC wire
+        still returns ``data: null`` under v0.3 compat — see #1670). Asserting
+        the message alone would let ``data={"task_id": ...}`` be deleted with
+        the suite still green, since the id appears in the message either way.
 
         Auth is mocked so this grades the not-found shape after the identity
         gate (#1702), not an auth-failure collapse into the same error.
@@ -336,7 +337,7 @@ class TestA2ARequestHandler:
             with pytest.raises(TaskNotFoundError) as exc:
                 await getattr(self.handler, method_name)(request_cls(id="task_does_not_exist"), MagicMock())
         assert "task_does_not_exist" in str(exc.value)  # the requested id is surfaced
-        assert exc.value.data == {"task_id": "task_does_not_exist"}  # ...and machine-readable
+        assert exc.value.data == {"task_id": "task_does_not_exist"}  # exception-object payload
 
     def test_handler_has_skill_methods(self):
         """Test that handler has skill-specific methods."""

--- a/tests/e2e/test_a2a_endpoints_working.py
+++ b/tests/e2e/test_a2a_endpoints_working.py
@@ -315,7 +315,7 @@ class TestA2ARequestHandler:
 
         Fast smoke check on the raise only. It does NOT prove the wire code: the
         exception carries no code, and the client actually sees -32603 — see
-        ``_get_owned_in_memory_task_or_raise`` (src/a2a_server/adcp_a2a_server.py)
+        ``_task_not_found`` (src/a2a_server/adcp_a2a_server.py)
         and #1670 for why, plus the xfail'd live-server test in
         TestA2AServerIntegration that grades the code on the wire. Assert on
         str(exc), not exc.code — there is none.
@@ -382,7 +382,7 @@ class TestA2AServerIntegration:
         strict=True,
     )
     @pytest.mark.parametrize("method", ["tasks/get", "tasks/cancel"])
-    def test_unknown_task_id_returns_task_not_found_code_on_the_wire(self, method, live_server):
+    def test_unknown_task_id_returns_task_not_found_code_on_the_wire(self, method, live_server, test_auth_token):
         """The deliverable of the TaskNotFoundError change is what an A2A client
         SEES: JSON-RPC error code -32001. That code is not carried by the
         exception — it is synthesized downstream — so the direct-call test in
@@ -395,13 +395,16 @@ class TestA2AServerIntegration:
         on the ad-hoc port — a skip under strict xfail is neither XFAIL nor XPASS,
         so the sole on-the-wire grade must never be allowed to no-op.
 
+        Sends a valid tenant Bearer token so the request reaches the
+        ownership/unknown-id branch rather than exiting at the auth gate (#1702).
+
         Parametrized over both methods this PR changed. `tasks/cancel` of an
         unknown id went from a silent None to an error in this PR, so it needs the
         same wire tripwire as `tasks/get` — otherwise only half the contract gets
         locked in when #1670 lands.
 
         STRICT xfail against #1670: the code is -32603 today, not the spec's
-        -32001 — see ``_get_owned_in_memory_task_or_raise``
+        -32001 — see ``_task_not_found``
         (src/a2a_server/adcp_a2a_server.py) and #1670 for the
         enable_v0_3_compat dispatch path that flattens it. Both
         `tasks/get` and `tasks/cancel` reach that path, so both are -32603 today
@@ -416,6 +419,7 @@ class TestA2AServerIntegration:
         response = requests.post(
             f"{live_server['a2a']}/a2a",
             json={"jsonrpc": "2.0", "id": 1, "method": method, "params": {"id": "task_does_not_exist"}},
+            headers={"Authorization": f"Bearer {test_auth_token}"},
             timeout=5,
         )
 

--- a/tests/e2e/test_a2a_endpoints_working.py
+++ b/tests/e2e/test_a2a_endpoints_working.py
@@ -21,7 +21,7 @@ from adcp import get_adcp_spec_version
 # Add parent directories to path for imports
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 
-from tests.a2a_helpers import a2a_auth_as
+from tests.a2a_helpers import a2a_auth_as, assert_task_not_found_nondisclosure
 from tests.e2e.conftest import e2e_host
 from tests.factories import PrincipalFactory
 
@@ -325,19 +325,19 @@ class TestA2ARequestHandler:
         between two byte-identical copies.
 
         Both halves of the raise are pinned: the human-readable message AND the
-        structured ``data`` field on the exception object (the JSON-RPC wire
-        still returns ``data: null`` under v0.3 compat — see #1670). Asserting
-        the message alone would let ``data={"task_id": ...}`` be deleted with
-        the suite still green, since the id appears in the message either way.
+        structured ``data`` field on the exception object (two-layer AdCP
+        envelope + ``task_id``; JSON-RPC wire still returns ``data: null`` under
+        v0.3 compat — see #1670). Asserting the message alone would let the
+        envelope/``task_id`` payload be deleted with the suite still green.
 
         Auth is mocked so this grades the not-found shape after the identity
-        gate (#1702), not an auth-failure collapse into the same error.
+        gate (#1702), not an auth-failure collapse into the same error. Shape
+        matches ownership-deny via the shared nondisclosure oracle (Chris R5).
         """
         with a2a_auth_as(self.handler, PrincipalFactory.make_identity(protocol="a2a")):
             with pytest.raises(TaskNotFoundError) as exc:
                 await getattr(self.handler, method_name)(request_cls(id="task_does_not_exist"), MagicMock())
-        assert "task_does_not_exist" in str(exc.value)  # the requested id is surfaced
-        assert exc.value.data == {"task_id": "task_does_not_exist"}  # exception-object payload
+        assert_task_not_found_nondisclosure(exc.value, "task_does_not_exist")
 
     def test_handler_has_skill_methods(self):
         """Test that handler has skill-specific methods."""

--- a/tests/factories/principal.py
+++ b/tests/factories/principal.py
@@ -12,7 +12,12 @@ from src.core.resolved_identity import ResolvedIdentity
 from src.core.testing_hooks import AdCPTestContext
 from tests.factories.core import TenantFactory
 
-_UNSET = object()
+
+class _Unset:
+    """Sentinel type for omitted ``testing_context`` / ``tenant`` defaults."""
+
+
+_UNSET = _Unset()
 
 
 class PrincipalFactory(factory.alchemy.SQLAlchemyModelFactory):
@@ -37,7 +42,7 @@ class PrincipalFactory(factory.alchemy.SQLAlchemyModelFactory):
         dry_run: bool = False,
         auth_token: str | None = None,
         tenant: Any = _UNSET,
-        testing_context: Any = _UNSET,
+        testing_context: AdCPTestContext | None | _Unset = _UNSET,
         **tenant_overrides: object,
     ) -> ResolvedIdentity:
         """Build a ResolvedIdentity without DB persistence.
@@ -57,10 +62,18 @@ class PrincipalFactory(factory.alchemy.SQLAlchemyModelFactory):
         ``ResolvedIdentity.tenant`` field, which accepts plain dicts in
         most call sites and lazy proxies (``LazyTenantContext``) in tests
         that need deferred config resolution.
+
+        When ``tenant`` is omitted and ``tenant_id is None``, skip
+        ``make_tenant`` (would build a ``pub-None`` subdomain) and set
+        ``resolved_tenant=None``.
         """
-        resolved_tenant = (
-            TenantFactory.make_tenant(tenant_id=tenant_id, **tenant_overrides) if tenant is _UNSET else tenant
-        )
+        if tenant is _UNSET:
+            if tenant_id is None:
+                resolved_tenant = None
+            else:
+                resolved_tenant = TenantFactory.make_tenant(tenant_id=tenant_id, **tenant_overrides)
+        else:
+            resolved_tenant = tenant
         if testing_context is _UNSET:
             testing_context = AdCPTestContext(
                 dry_run=dry_run,
@@ -78,7 +91,7 @@ class PrincipalFactory(factory.alchemy.SQLAlchemyModelFactory):
         )
 
     @classmethod
-    def make_anonymous_a2a_identity(cls, tenant_id: str | None = None, **kwargs: Any) -> ResolvedIdentity:
+    def make_anonymous_a2a_identity(cls, tenant_id: str | None = None, **kwargs: object) -> ResolvedIdentity:
         """Anonymous A2A discovery identity — principal_id/tenant None, protocol a2a.
 
         Production always returns ResolvedIdentity (never None) for discovery.

--- a/tests/factories/principal.py
+++ b/tests/factories/principal.py
@@ -46,9 +46,12 @@ class PrincipalFactory(factory.alchemy.SQLAlchemyModelFactory):
         Pass explicit tenant=None for auth-error tests.
         Pass **tenant_overrides for domain fields (approval_mode, etc).
         Pass testing_context to override the default (e.g. set
-        test_session_id for harness routing). Pass ``testing_context=None``
-        explicitly for anonymous A2A discovery (production
-        ``AdCPTestContext.from_headers({})`` returns None).
+        test_session_id for harness routing).
+
+        ``testing_context`` meanings:
+        - omitted / sentinel (default): populated ``AdCPTestContext``
+        - ``testing_context=None``: explicit None (anonymous A2A discovery;
+          production ``AdCPTestContext.from_headers({})`` returns None)
 
         ``tenant`` is typed ``Any`` to match the underlying
         ``ResolvedIdentity.tenant`` field, which accepts plain dicts in
@@ -56,9 +59,7 @@ class PrincipalFactory(factory.alchemy.SQLAlchemyModelFactory):
         that need deferred config resolution.
         """
         resolved_tenant = (
-            TenantFactory.make_tenant(tenant_id=tenant_id, **tenant_overrides)
-            if tenant is _UNSET and tenant_id is not None
-            else (None if tenant is _UNSET else tenant)
+            TenantFactory.make_tenant(tenant_id=tenant_id, **tenant_overrides) if tenant is _UNSET else tenant
         )
         if testing_context is _UNSET:
             testing_context = AdCPTestContext(
@@ -77,7 +78,7 @@ class PrincipalFactory(factory.alchemy.SQLAlchemyModelFactory):
         )
 
     @classmethod
-    def make_anonymous_a2a_identity(cls, tenant_id: str | None = None, **kwargs: object) -> ResolvedIdentity:
+    def make_anonymous_a2a_identity(cls, tenant_id: str | None = None, **kwargs: Any) -> ResolvedIdentity:
         """Anonymous A2A discovery identity — principal_id/tenant None, protocol a2a.
 
         Production always returns ResolvedIdentity (never None) for discovery.

--- a/tests/factories/principal.py
+++ b/tests/factories/principal.py
@@ -32,7 +32,7 @@ class PrincipalFactory(factory.alchemy.SQLAlchemyModelFactory):
     def make_identity(
         cls,
         principal_id: str | None = "test_principal",
-        tenant_id: str = "test_tenant",
+        tenant_id: str | None = "test_tenant",
         protocol: str = "mcp",
         dry_run: bool = False,
         auth_token: str | None = None,
@@ -70,4 +70,18 @@ class PrincipalFactory(factory.alchemy.SQLAlchemyModelFactory):
             auth_token=auth_token,
             protocol=protocol,
             testing_context=testing_context,
+        )
+
+    @classmethod
+    def make_anonymous_a2a_identity(cls, tenant_id: str | None = None, **kwargs) -> ResolvedIdentity:
+        """Anonymous A2A discovery identity — principal_id/tenant None, protocol a2a.
+
+        Production always returns ResolvedIdentity (never None) for discovery.
+        """
+        return cls.make_identity(
+            principal_id=None,
+            tenant_id=tenant_id,
+            tenant=None,
+            protocol="a2a",
+            **kwargs,
         )

--- a/tests/factories/principal.py
+++ b/tests/factories/principal.py
@@ -54,7 +54,9 @@ class PrincipalFactory(factory.alchemy.SQLAlchemyModelFactory):
         that need deferred config resolution.
         """
         resolved_tenant = (
-            TenantFactory.make_tenant(tenant_id=tenant_id, **tenant_overrides) if tenant is _UNSET else tenant
+            TenantFactory.make_tenant(tenant_id=tenant_id, **tenant_overrides)
+            if tenant is _UNSET and tenant_id is not None
+            else (None if tenant is _UNSET else tenant)
         )
         if testing_context is None:
             testing_context = AdCPTestContext(
@@ -73,7 +75,7 @@ class PrincipalFactory(factory.alchemy.SQLAlchemyModelFactory):
         )
 
     @classmethod
-    def make_anonymous_a2a_identity(cls, tenant_id: str | None = None, **kwargs) -> ResolvedIdentity:
+    def make_anonymous_a2a_identity(cls, tenant_id: str | None = None, **kwargs: object) -> ResolvedIdentity:
         """Anonymous A2A discovery identity — principal_id/tenant None, protocol a2a.
 
         Production always returns ResolvedIdentity (never None) for discovery.

--- a/tests/factories/principal.py
+++ b/tests/factories/principal.py
@@ -37,7 +37,7 @@ class PrincipalFactory(factory.alchemy.SQLAlchemyModelFactory):
         dry_run: bool = False,
         auth_token: str | None = None,
         tenant: Any = _UNSET,
-        testing_context: AdCPTestContext | None = None,
+        testing_context: Any = _UNSET,
         **tenant_overrides: object,
     ) -> ResolvedIdentity:
         """Build a ResolvedIdentity without DB persistence.
@@ -46,7 +46,9 @@ class PrincipalFactory(factory.alchemy.SQLAlchemyModelFactory):
         Pass explicit tenant=None for auth-error tests.
         Pass **tenant_overrides for domain fields (approval_mode, etc).
         Pass testing_context to override the default (e.g. set
-        test_session_id for harness routing).
+        test_session_id for harness routing). Pass ``testing_context=None``
+        explicitly for anonymous A2A discovery (production
+        ``AdCPTestContext.from_headers({})`` returns None).
 
         ``tenant`` is typed ``Any`` to match the underlying
         ``ResolvedIdentity.tenant`` field, which accepts plain dicts in
@@ -58,7 +60,7 @@ class PrincipalFactory(factory.alchemy.SQLAlchemyModelFactory):
             if tenant is _UNSET and tenant_id is not None
             else (None if tenant is _UNSET else tenant)
         )
-        if testing_context is None:
+        if testing_context is _UNSET:
             testing_context = AdCPTestContext(
                 dry_run=dry_run,
                 mock_time=None,
@@ -79,11 +81,13 @@ class PrincipalFactory(factory.alchemy.SQLAlchemyModelFactory):
         """Anonymous A2A discovery identity — principal_id/tenant None, protocol a2a.
 
         Production always returns ResolvedIdentity (never None) for discovery.
+        ``testing_context=None`` matches ``AdCPTestContext.from_headers({})``.
         """
         return cls.make_identity(
             principal_id=None,
             tenant_id=tenant_id,
             tenant=None,
             protocol="a2a",
+            testing_context=None,
             **kwargs,
         )

--- a/tests/factories/principal.py
+++ b/tests/factories/principal.py
@@ -105,3 +105,7 @@ class PrincipalFactory(factory.alchemy.SQLAlchemyModelFactory):
             testing_context=None,
             **kwargs,
         )
+
+
+# Public omit-arg sentinel (typed ``_Unset``), for wrappers that forward defaults.
+PrincipalFactory.UNSET = _UNSET

--- a/tests/harness/_base.py
+++ b/tests/harness/_base.py
@@ -988,11 +988,9 @@ class BaseTestEnv:
         Returns the served Task, or None when the call errored.
         """
         from a2a.server.routes.common import ServerCallContext, ServerCallContextBuilder
-        from a2a.server.routes.jsonrpc_routes import create_jsonrpc_routes
-        from starlette.applications import Starlette
         from starlette.requests import Request
-        from starlette.testclient import TestClient
 
+        from tests.a2a_helpers import post_a2a_task_method
         from tests.harness.transport import Transport
 
         self._commit_factory_data()
@@ -1015,22 +1013,14 @@ class BaseTestEnv:
             def build(self, request: Request) -> ServerCallContext:
                 return server_context
 
-        routes = create_jsonrpc_routes(
-            request_handler=handler,
-            rpc_url="/a2a",
-            context_builder=_PreparedContextBuilder(),
-            enable_v0_3_compat=True,
-        )
-        client = TestClient(Starlette(routes=routes))
-
         self._last_a2a_task = None
         self._last_a2a_task_error = None
-        response = client.post(
-            "/a2a",
-            json={"jsonrpc": "2.0", "id": 1, "method": method, "params": {"id": task_id}},
+        body = post_a2a_task_method(
+            handler,
+            method=method,
+            task_id=task_id,
+            context_builder=_PreparedContextBuilder(),
         )
-        assert response.status_code == 200, f"JSON-RPC {method} returned HTTP {response.status_code}: {response.text}"
-        body = response.json()
         if "error" in body:
             self._last_a2a_task_error = body["error"]
             return None

--- a/tests/harness/_base.py
+++ b/tests/harness/_base.py
@@ -962,7 +962,7 @@ class BaseTestEnv:
         method: str,
         task_id: str,
         *,
-        identity: Any = _NO_OVERRIDE,
+        identity: ResolvedIdentity | None | _NoOverride = _NO_OVERRIDE,
     ) -> Task | None:
         """Dispatch ``tasks/get`` / ``tasks/cancel`` on the shared handler.
 
@@ -1042,7 +1042,7 @@ class BaseTestEnv:
         self,
         task_id: str,
         *,
-        identity: Any = _NO_OVERRIDE,
+        identity: ResolvedIdentity | None | _NoOverride = _NO_OVERRIDE,
         state: TaskState | None = None,
         record_owner: bool = True,
     ) -> Task:
@@ -1078,15 +1078,6 @@ class BaseTestEnv:
                 principal_id=owner.principal_id,
             )
         return task
-
-    def a2a_task_state(self, task_id: str) -> TaskState | None:
-        """State of the seeded in-memory task, or None if the handler has no such id.
-
-        Public read-back accessor: a denied ``tasks/cancel`` must leave the stored
-        Task untouched, and step functions must not reach into ``handler.tasks``.
-        """
-        task = self.a2a_handler.tasks.get(task_id)
-        return task.status.state if task is not None else None
 
     def _run_mcp_client(
         self,

--- a/tests/harness/_base.py
+++ b/tests/harness/_base.py
@@ -28,8 +28,6 @@ from contextlib import suppress
 from typing import TYPE_CHECKING, Any, Self
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from tests.harness._realize import e2e_unsupported, realize_e2e
-
 # The MCP transport boots the real FastMCP app lifespan, which starts the
 # background schedulers. Those run a batch immediately on the *real* wall clock
 # and rewrite media-buy status rows — silently mutating data a test just seeded
@@ -43,9 +41,12 @@ os.environ.setdefault("ADCP_RUN_BACKGROUND_SCHEDULERS", "false")
 from tests.harness.transport import DeliverResult, strip_a2a_protocol_fields
 
 if TYPE_CHECKING:
+    from a2a.server.routes.common import ServerCallContext
+    from a2a.types import Task, TaskState
     from pydantic import BaseModel
     from sqlalchemy.orm import Session
 
+    from src.a2a_server.adcp_a2a_server import AdCPRequestHandler
     from src.core.resolved_identity import ResolvedIdentity
     from tests.harness.transport import E2EConfig, Transport, TransportResult
 
@@ -467,7 +468,7 @@ class BaseTestEnv:
         self._last_a2a_task_error: dict[str, Any] | None = None
         # One AdCPRequestHandler per env: the handler owns the in-memory task
         # store, so create → tasks/get / tasks/cancel must hit the same instance.
-        self._a2a_handler: Any = None
+        self._a2a_handler: AdCPRequestHandler | None = None
 
     # -- Transport mode -----------------------------------------------------
 
@@ -663,8 +664,8 @@ class BaseTestEnv:
         return self.deliver_a2a(**kwargs).payload
 
     @property
-    def last_a2a_task(self) -> Any:
-        """Raw A2A Task from the last ``_run_a2a_handler`` dispatch (or None).
+    def last_a2a_task(self) -> Task | None:
+        """Raw A2A Task from the last ``_run_a2a_handler`` / ``run_a2a_task_method``.
 
         Public accessor for Task-level contract assertions — e.g. the submitted
         (manual-approval) contract, where state=TASK_STATE_SUBMITTED with NO
@@ -863,7 +864,11 @@ class BaseTestEnv:
             payload=response_cls(**strip_a2a_protocol_fields(artifact_data)), wire_response=wire_response
         )
 
-    def _prepare_a2a_server_context(self, handler: Any, a2a_identity: Any) -> Any:
+    def _prepare_a2a_server_context(
+        self,
+        handler: AdCPRequestHandler,
+        a2a_identity: ResolvedIdentity | None,
+    ) -> ServerCallContext:
         """Build the ``ServerCallContext`` for one in-process A2A dispatch.
 
         Auth strategy mirrors _run_mcp_client. When the identity carries a real
@@ -875,7 +880,7 @@ class BaseTestEnv:
         chain itself is real. When no real token exists (unit mode), inject the
         identity directly via the single mock point (unchanged behavior).
 
-        Shared by ``_run_a2a_handler`` (skills) and ``_run_a2a_task_method``
+        Shared by ``_run_a2a_handler`` (skills) and ``run_a2a_task_method``
         (``tasks/get`` / ``tasks/cancel``) so both dispatch styles authenticate
         the same way against the same handler.
         """
@@ -893,6 +898,10 @@ class BaseTestEnv:
             # denial scenario would silently reuse the previous caller's identity.
             handler.__dict__.pop("_resolve_a2a_identity", None)
             handler.__dict__.pop("_get_auth_token", None)
+            # Oracle: deleting the two pops above leaves unit-mode lambdas in
+            # place and a subsequent token-mode sibling tasks/get is served.
+            assert "_resolve_a2a_identity" not in handler.__dict__
+            assert "_get_auth_token" not in handler.__dict__
 
             headers = auth_headers_mapping(
                 {
@@ -922,8 +931,8 @@ class BaseTestEnv:
             # otherwise the handler rejects the request before _resolve_a2a_identity
             # is called. Use auth_token from identity, falling back to a sentinel.
             # Unauthenticated (a2a_identity is None) stays token-less.
-            handler._resolve_a2a_identity = lambda *args, **kw: resolved  # type: ignore[assignment]
-            handler._get_auth_token = lambda *args, **kw: (  # type: ignore[assignment]
+            handler._resolve_a2a_identity = lambda *args, **kw: resolved  # type: ignore[method-assign]
+            handler._get_auth_token = lambda *args, **kw: (  # type: ignore[method-assign]
                 (a2a_identity.auth_token or "harness-test-token") if a2a_identity else None
             )
             server_context = ServerCallContext()
@@ -936,7 +945,13 @@ class BaseTestEnv:
 
         return server_context
 
-    def _run_a2a_task_method(self, method: str, task_id: str, *, identity: Any = _NO_OVERRIDE) -> Any:
+    def run_a2a_task_method(
+        self,
+        method: str,
+        task_id: str,
+        *,
+        identity: Any = _NO_OVERRIDE,
+    ) -> Task | None:
         """Dispatch ``tasks/get`` / ``tasks/cancel`` on the shared handler.
 
         Runs against the SAME handler ``_run_a2a_handler`` uses, so the task a
@@ -946,23 +961,25 @@ class BaseTestEnv:
         These are protocol methods, not AdCP skills: there is no artifact and no
         two-layer envelope. Results land on the grading surface —
         ``last_a2a_task`` for the served Task, ``last_a2a_task_error`` for a
-        not-found (unknown id AND ownership denial collapse to it identically).
-        Anything else propagates as an unwrapped AdCPError, the same as skills.
+        JSON-RPC error (unknown id AND ownership denial collapse to not-found
+        identically; unauthenticated callers get an auth-failure body).
 
-        Denial altitude: calls ``on_get_task`` / ``on_cancel_task`` directly and,
-        on ``TaskNotFoundError``, stores a **compat-shaped reconstruction**
-        (``CoreInternalError(message=str(exc)).model_dump``) matching today's
-        v0.3 adapter body — it does **not** POST through
-        ``create_jsonrpc_routes(..., enable_v0_3_compat=True)``. Live JSON-RPC
-        wire serialization is graded in ``tests/unit/test_a2a_task_identity_wire.py``
-        (#1720).
+        Denial altitude: POSTs through ``create_jsonrpc_routes(...,
+        enable_v0_3_compat=True)`` — the same call production makes — on the
+        shared handler, reusing ``_prepare_a2a_server_context`` for auth.
+        Captures the real buyer wire body (not a reconstructed mirror).
 
-        Returns the served Task, or None when the call was denied.
+        Explicit ``identity=None`` is unauthenticated: empty ServerCallContext,
+        no unit-mode identity lambdas, so the handler's real auth failure
+        surfaces on the wire (must not collapse to task-not-found).
+
+        Returns the served Task, or None when the call errored.
         """
-        import asyncio
-
-        from a2a.server.jsonrpc_models import InternalError as CoreInternalError
-        from a2a.types import CancelTaskRequest, GetTaskRequest, TaskNotFoundError
+        from a2a.server.routes.common import ServerCallContext, ServerCallContextBuilder
+        from a2a.server.routes.jsonrpc_routes import create_jsonrpc_routes
+        from starlette.applications import Starlette
+        from starlette.requests import Request
+        from starlette.testclient import TestClient
 
         from tests.harness.transport import Transport
 
@@ -972,59 +989,86 @@ class BaseTestEnv:
             self._ensure_tenant_for_audit(a2a_identity.tenant_id)
 
         handler = self.a2a_handler
-        server_context = self._prepare_a2a_server_context(handler, a2a_identity)
 
-        request_cls, on_method = {
-            "tasks/get": (GetTaskRequest, handler.on_get_task),
-            "tasks/cancel": (CancelTaskRequest, handler.on_cancel_task),
-        }[method]
+        if a2a_identity is None:
+            # Explicit unauthenticated dispatch — do not inject anonymous
+            # identity lambdas (skill-dispatch compensating path). Clear any
+            # leftover unit-mode mocks so the real auth chain denies.
+            handler.__dict__.pop("_resolve_a2a_identity", None)
+            handler.__dict__.pop("_get_auth_token", None)
+            server_context = ServerCallContext()
+        else:
+            server_context = self._prepare_a2a_server_context(handler, a2a_identity)
+
+        class _PreparedContextBuilder(ServerCallContextBuilder):
+            def build(self, request: Request) -> ServerCallContext:
+                return server_context
+
+        routes = create_jsonrpc_routes(
+            request_handler=handler,
+            rpc_url="/a2a",
+            context_builder=_PreparedContextBuilder(),
+            enable_v0_3_compat=True,
+        )
+        client = TestClient(Starlette(routes=routes))
 
         self._last_a2a_task = None
         self._last_a2a_task_error = None
-        try:
-            task = asyncio.run(on_method(request_cls(id=task_id), server_context))
-        except TaskNotFoundError as exc:
-            # Intentional altitude (#1780 review): mirror today's v0.3 compat body
-            # (enable_v0_3_compat rebuilds any raised error as CoreInternalError —
-            # code -32603, data dropped, #1670). Not a live JSON-RPC capture;
-            # adapter wire proof lives in test_a2a_task_identity_wire.py (#1720).
-            self._last_a2a_task_error = CoreInternalError(message=str(exc)).model_dump(by_alias=True)
+        response = client.post(
+            "/a2a",
+            json={"jsonrpc": "2.0", "id": 1, "method": method, "params": {"id": task_id}},
+        )
+        assert response.status_code == 200, f"JSON-RPC {method} returned HTTP {response.status_code}: {response.text}"
+        body = response.json()
+        if "error" in body:
+            self._last_a2a_task_error = body["error"]
             return None
-        except Exception as exc:
-            raise _unwrap_a2a_server_error(exc) from exc
 
+        # Success: prefer the handler's stored Task (cancel mutates it in place)
+        # over re-parsing body["result"] — same instance the gate authorized.
+        task = handler.tasks.get(task_id)
         self._last_a2a_task = task
         return task
 
-    @realize_e2e(e2e_unsupported("in-process handler memory"))
-    def seed_a2a_task(self, task_id: str, *, identity: Any = _NO_OVERRIDE, state: Any = None) -> Any:
+    def seed_a2a_task(
+        self,
+        task_id: str,
+        *,
+        identity: Any = _NO_OVERRIDE,
+        state: TaskState | None = None,
+        record_owner: bool = True,
+    ) -> Task:
         """Seed an in-memory task owned by *identity* on the shared handler.
 
         Authz-gate altitude for ownership BDD (#1780): writes ``handler.tasks``
-        and ``_task_owners`` directly so get/cancel can grade the gate with real
-        tokens. This is **not** bind-on-create via ``on_message_send`` (that path
-        is covered by #1720 unit tests). Do not use this seed to claim create→poll
-        co-location in UC-006 — that Then fails until sync create records owners.
-
-        Over e2e the live server owns its own handler process memory, which no
-        test-side seed can reach — hence the ``e2e_unsupported`` realization.
+        and (unless ``record_owner=False``) ``_task_owners`` directly so
+        get/cancel can grade the gate with real tokens. This is **not**
+        bind-on-create via ``on_message_send`` (that path is covered by #1720
+        unit tests). Do not use this seed to claim create→poll co-location in
+        UC-006 — that Then fails until sync create records owners.
 
         Defaults to ``TASK_STATE_WORKING`` so a denied cancel has a state that
         would visibly change if the ownership gate let it through.
+
+        ``record_owner=False`` grades the fail-closed path for a task present
+        in ``handler.tasks`` with no ownership record.
         """
         from a2a.types import Task, TaskState, TaskStatus
 
-        from src.a2a_server.adcp_a2a_server import _TaskOwner
+        from tests.a2a_helpers import record_a2a_task_owner
         from tests.harness.transport import Transport
 
         owner = self.identity_for(Transport.A2A) if identity is _NO_OVERRIDE else identity
         handler = self.a2a_handler
         task = Task(id=task_id, status=TaskStatus(state=state or TaskState.TASK_STATE_WORKING))
         handler.tasks[task_id] = task
-        handler._task_owners[task_id] = _TaskOwner(
-            tenant_id=owner.tenant_id,
-            principal_id=owner.principal_id,
-        )
+        if record_owner:
+            record_a2a_task_owner(
+                handler,
+                task_id,
+                tenant_id=owner.tenant_id,
+                principal_id=owner.principal_id,
+            )
         return task
 
     def a2a_task_state(self, task_id: str) -> Any:

--- a/tests/harness/_base.py
+++ b/tests/harness/_base.py
@@ -811,9 +811,15 @@ class BaseTestEnv:
             # None. Create+own co-location reads ``identity.tenant_id`` (#1702);
             # mocking None made unauth A2A BDD paths AttributeError into
             # SERVICE_UNAVAILABLE instead of AUTH_REQUIRED.
-            from src.core.resolved_identity import ResolvedIdentity
+            # Use PrincipalFactory (not inline ResolvedIdentity) for the arch guard.
+            from tests.factories.principal import PrincipalFactory
 
-            resolved = a2a_identity or ResolvedIdentity(protocol="a2a")
+            resolved = a2a_identity or PrincipalFactory.make_identity(
+                principal_id=None,
+                tenant_id=None,
+                tenant=None,
+                protocol="a2a",
+            )
             # _get_auth_token must return a non-None value when identity exists,
             # otherwise the handler rejects the request before _resolve_a2a_identity
             # is called. Use auth_token from identity, falling back to a sentinel.

--- a/tests/harness/_base.py
+++ b/tests/harness/_base.py
@@ -347,6 +347,25 @@ def _a2a_send_message_configuration(spec: dict[str, Any]) -> Any:
     return SendMessageConfiguration(task_push_notification_config=TaskPushNotificationConfig(**fields))
 
 
+def _clear_unit_mode_identity(handler: AdCPRequestHandler) -> None:
+    """Drop any unit-mode identity lambdas the handler outlives a dispatch with.
+
+    The handler instance is shared across dispatches within one scenario, so an
+    earlier unit-mode call (``_prepare_a2a_server_context``'s token-less branch)
+    may have left ``_resolve_a2a_identity`` / ``_get_auth_token`` lambdas bound
+    on the instance. A subsequent real-token or explicit-unauth dispatch must
+    clear them first, otherwise it silently reuses the previous caller's
+    identity — the exact denial-scenario bug this guards against.
+
+    Oracle: skipping either pop leaves a unit-mode lambda in place and a
+    subsequent dispatch is served (or denied) as the wrong caller.
+    """
+    handler.__dict__.pop("_resolve_a2a_identity", None)
+    handler.__dict__.pop("_get_auth_token", None)
+    assert "_resolve_a2a_identity" not in handler.__dict__
+    assert "_get_auth_token" not in handler.__dict__
+
+
 class _TestClock:
     """Minimal clock for BDD relative date-token resolution.
 
@@ -892,16 +911,9 @@ class BaseTestEnv:
             from src.core.auth_context import AUTH_CONTEXT_STATE_KEY, AuthContext
             from tests.a2a_helpers import auth_headers_mapping
 
-            # The handler outlives a single dispatch, so an earlier unit-mode
-            # call may have left identity lambdas on this instance. Drop them —
-            # a real token must resolve through the real auth chain, otherwise a
+            # A real token must resolve through the real auth chain, otherwise a
             # denial scenario would silently reuse the previous caller's identity.
-            handler.__dict__.pop("_resolve_a2a_identity", None)
-            handler.__dict__.pop("_get_auth_token", None)
-            # Oracle: deleting the two pops above leaves unit-mode lambdas in
-            # place and a subsequent token-mode sibling tasks/get is served.
-            assert "_resolve_a2a_identity" not in handler.__dict__
-            assert "_get_auth_token" not in handler.__dict__
+            _clear_unit_mode_identity(handler)
 
             headers = auth_headers_mapping(
                 {
@@ -994,8 +1006,7 @@ class BaseTestEnv:
             # Explicit unauthenticated dispatch — do not inject anonymous
             # identity lambdas (skill-dispatch compensating path). Clear any
             # leftover unit-mode mocks so the real auth chain denies.
-            handler.__dict__.pop("_resolve_a2a_identity", None)
-            handler.__dict__.pop("_get_auth_token", None)
+            _clear_unit_mode_identity(handler)
             server_context = ServerCallContext()
         else:
             server_context = self._prepare_a2a_server_context(handler, a2a_identity)
@@ -1024,9 +1035,16 @@ class BaseTestEnv:
             self._last_a2a_task_error = body["error"]
             return None
 
-        # Success: prefer the handler's stored Task (cancel mutates it in place)
-        # over re-parsing body["result"] — same instance the gate authorized.
-        task = handler.tasks.get(task_id)
+        # Success: rebuild the Task from body["result"] — the actual buyer-facing
+        # wire payload — rather than trusting handler.tasks.get(task_id), the
+        # in-process object the gate just authorized. A v0.3-compat serializer
+        # regression that emits the wrong status.state on the wire must redden
+        # this, even while the in-process object stays correct (#1720 review).
+        from a2a.types import Task, TaskState, TaskStatus
+
+        result = body["result"]
+        wire_state_name = "TASK_STATE_" + result["status"]["state"].upper()
+        task = Task(id=result["id"], status=TaskStatus(state=TaskState.Value(wire_state_name)))
         self._last_a2a_task = task
         return task
 
@@ -1071,7 +1089,7 @@ class BaseTestEnv:
             )
         return task
 
-    def a2a_task_state(self, task_id: str) -> Any:
+    def a2a_task_state(self, task_id: str) -> TaskState | None:
         """State of the seeded in-memory task, or None if the handler has no such id.
 
         Public read-back accessor: a denied ``tasks/cancel`` must leave the stored

--- a/tests/harness/_base.py
+++ b/tests/harness/_base.py
@@ -1030,11 +1030,11 @@ class BaseTestEnv:
         # in-process object the gate just authorized. A v0.3-compat serializer
         # regression that emits the wrong status.state on the wire must redden
         # this, even while the in-process object stays correct (#1720 review).
-        from a2a.types import Task, TaskState, TaskStatus
+        from a2a.compat.v0_3 import conversions as v03_conversions
+        from a2a.compat.v0_3 import types as v03_types
 
         result = body["result"]
-        wire_state_name = "TASK_STATE_" + result["status"]["state"].upper()
-        task = Task(id=result["id"], status=TaskStatus(state=TaskState.Value(wire_state_name)))
+        task = v03_conversions.to_core_task(v03_types.Task.model_validate(result))
         self._last_a2a_task = task
         return task
 
@@ -1042,8 +1042,8 @@ class BaseTestEnv:
         self,
         task_id: str,
         *,
-        identity: ResolvedIdentity | None | _NoOverride = _NO_OVERRIDE,
-        state: TaskState | None = None,
+        identity: ResolvedIdentity | _NoOverride = _NO_OVERRIDE,
+        state: TaskState.ValueType | None = None,
         record_owner: bool = True,
     ) -> Task:
         """Seed an in-memory task owned by *identity* on the shared handler.
@@ -1067,8 +1067,13 @@ class BaseTestEnv:
         from tests.harness.transport import Transport
 
         owner = self.identity_for(Transport.A2A) if identity is _NO_OVERRIDE else identity
+        if record_owner and owner is None:
+            raise ValueError("seed_a2a_task with record_owner=True requires a ResolvedIdentity")
         handler = self.a2a_handler
-        task = Task(id=task_id, status=TaskStatus(state=state or TaskState.TASK_STATE_WORKING))
+        task = Task(
+            id=task_id,
+            status=TaskStatus(state=state if state is not None else TaskState.TASK_STATE_WORKING),
+        )
         handler.tasks[task_id] = task
         if record_owner:
             record_a2a_task_owner(

--- a/tests/harness/_base.py
+++ b/tests/harness/_base.py
@@ -806,10 +806,19 @@ class BaseTestEnv:
                 state={AUTH_CONTEXT_STATE_KEY: AuthContext(auth_token=auth_token, headers=headers)}
             )
         else:
+            # Production ``_resolve_a2a_identity`` always returns ResolvedIdentity
+            # (principal_id may be None for unauthenticated discovery) — never
+            # None. Create+own co-location reads ``identity.tenant_id`` (#1702);
+            # mocking None made unauth A2A BDD paths AttributeError into
+            # SERVICE_UNAVAILABLE instead of AUTH_REQUIRED.
+            from src.core.resolved_identity import ResolvedIdentity
+
+            resolved = a2a_identity or ResolvedIdentity(protocol="a2a")
             # _get_auth_token must return a non-None value when identity exists,
             # otherwise the handler rejects the request before _resolve_a2a_identity
             # is called. Use auth_token from identity, falling back to a sentinel.
-            handler._resolve_a2a_identity = lambda *args, **kw: a2a_identity  # type: ignore[assignment]
+            # Unauthenticated (a2a_identity is None) stays token-less.
+            handler._resolve_a2a_identity = lambda *args, **kw: resolved  # type: ignore[assignment]
             handler._get_auth_token = lambda *args, **kw: (  # type: ignore[assignment]
                 (a2a_identity.auth_token or "harness-test-token") if a2a_identity else None
             )

--- a/tests/harness/_base.py
+++ b/tests/harness/_base.py
@@ -814,11 +814,8 @@ class BaseTestEnv:
             # Use PrincipalFactory (not inline ResolvedIdentity) for the arch guard.
             from tests.factories.principal import PrincipalFactory
 
-            resolved = a2a_identity or PrincipalFactory.make_identity(
-                principal_id=None,
+            resolved = a2a_identity or PrincipalFactory.make_anonymous_a2a_identity(
                 tenant_id=None,
-                tenant=None,
-                protocol="a2a",
             )
             # _get_auth_token must return a non-None value when identity exists,
             # otherwise the handler rejects the request before _resolve_a2a_identity

--- a/tests/harness/_base.py
+++ b/tests/harness/_base.py
@@ -38,7 +38,7 @@ os.environ.setdefault("ADCP_RUN_BACKGROUND_SCHEDULERS", "false")
 
 # Runtime import: DeliverResult is CONSTRUCTED here (the dispatch return contract),
 # not merely annotated, so it cannot live in the TYPE_CHECKING block below.
-from tests.harness.transport import DeliverResult, strip_a2a_protocol_fields
+from tests.harness.transport import NO_IDENTITY_OVERRIDE, DeliverResult, strip_a2a_protocol_fields
 
 if TYPE_CHECKING:
     from a2a.server.routes.common import ServerCallContext
@@ -782,7 +782,6 @@ class BaseTestEnv:
 
         from a2a.types import SendMessageRequest, Task
 
-        from src.a2a_server.adcp_a2a_server import AdCPRequestHandler
         from tests.harness.transport import NO_IDENTITY_OVERRIDE, Transport
         from tests.utils.a2a_helpers import create_a2a_message_with_skill, extract_data_from_artifact
 
@@ -962,7 +961,7 @@ class BaseTestEnv:
         method: str,
         task_id: str,
         *,
-        identity: ResolvedIdentity | None | _NoOverride = _NO_OVERRIDE,
+        identity: ResolvedIdentity | None | Any = NO_IDENTITY_OVERRIDE,
     ) -> Task | None:
         """Dispatch ``tasks/get`` / ``tasks/cancel`` on the shared handler.
 
@@ -991,10 +990,10 @@ class BaseTestEnv:
         from starlette.requests import Request
 
         from tests.a2a_helpers import post_a2a_task_method
-        from tests.harness.transport import Transport
+        from tests.harness.transport import NO_IDENTITY_OVERRIDE, Transport
 
         self._commit_factory_data()
-        a2a_identity = self.identity_for(Transport.A2A) if identity is _NO_OVERRIDE else identity
+        a2a_identity = self.identity_for(Transport.A2A) if identity is NO_IDENTITY_OVERRIDE else identity
         if self.use_real_db and a2a_identity and a2a_identity.tenant_id:
             self._ensure_tenant_for_audit(a2a_identity.tenant_id)
 
@@ -1042,7 +1041,7 @@ class BaseTestEnv:
         self,
         task_id: str,
         *,
-        identity: ResolvedIdentity | _NoOverride = _NO_OVERRIDE,
+        identity: ResolvedIdentity | Any = NO_IDENTITY_OVERRIDE,
         state: TaskState.ValueType | None = None,
         record_owner: bool = True,
     ) -> Task:
@@ -1064,9 +1063,9 @@ class BaseTestEnv:
         from a2a.types import Task, TaskState, TaskStatus
 
         from tests.a2a_helpers import record_a2a_task_owner
-        from tests.harness.transport import Transport
+        from tests.harness.transport import NO_IDENTITY_OVERRIDE, Transport
 
-        owner = self.identity_for(Transport.A2A) if identity is _NO_OVERRIDE else identity
+        owner = self.identity_for(Transport.A2A) if identity is NO_IDENTITY_OVERRIDE else identity
         if record_owner and owner is None:
             raise ValueError("seed_a2a_task with record_owner=True requires a ResolvedIdentity")
         handler = self.a2a_handler

--- a/tests/harness/_base.py
+++ b/tests/harness/_base.py
@@ -797,11 +797,14 @@ class BaseTestEnv:
 
         if auth_token:
             from src.core.auth_context import AUTH_CONTEXT_STATE_KEY, AuthContext
+            from tests.a2a_helpers import auth_headers_mapping
 
-            headers = {
-                "x-adcp-auth": auth_token,
-                "x-adcp-tenant": a2a_identity.tenant_id or "",
-            }
+            headers = auth_headers_mapping(
+                {
+                    "x-adcp-auth": auth_token,
+                    "x-adcp-tenant": a2a_identity.tenant_id or "",
+                }
+            )
             server_context = ServerCallContext(
                 state={AUTH_CONTEXT_STATE_KEY: AuthContext(auth_token=auth_token, headers=headers)}
             )
@@ -811,6 +814,7 @@ class BaseTestEnv:
             # None. Create+own co-location reads ``identity.tenant_id`` (#1702);
             # mocking None made unauth A2A BDD paths AttributeError into
             # SERVICE_UNAVAILABLE instead of AUTH_REQUIRED.
+            # Pin: @T-UC-011-list-unauth grades this compensating unauth path.
             # Use PrincipalFactory (not inline ResolvedIdentity) for the arch guard.
             from tests.factories.principal import PrincipalFactory
 

--- a/tests/harness/_base.py
+++ b/tests/harness/_base.py
@@ -28,6 +28,8 @@ from contextlib import suppress
 from typing import TYPE_CHECKING, Any, Self
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from tests.harness._realize import e2e_unsupported, realize_e2e
+
 # The MCP transport boots the real FastMCP app lifespan, which starts the
 # background schedulers. Those run a batch immediately on the *real* wall clock
 # and rewrite media-buy status rows — silently mutating data a test just seeded
@@ -459,6 +461,13 @@ class BaseTestEnv:
         # with NO artifacts — and the synthesized submitted wire above cannot
         # prove artifact absence, so guards assert on this captured Task.
         self._last_a2a_task: Any = None
+        # JSON-RPC error body from the last ``_run_a2a_task_method`` dispatch,
+        # in the shape the v0.3 compat adapter puts on the wire. Task methods
+        # have no AdCP envelope — their failure IS the JSON-RPC error.
+        self._last_a2a_task_error: dict[str, Any] | None = None
+        # One AdCPRequestHandler per env: the handler owns the in-memory task
+        # store, so create → tasks/get / tasks/cancel must hit the same instance.
+        self._a2a_handler: Any = None
 
     # -- Transport mode -----------------------------------------------------
 
@@ -751,7 +760,6 @@ class BaseTestEnv:
         """
         import asyncio
 
-        from a2a.server.routes.common import ServerCallContext
         from a2a.types import SendMessageRequest, Task
 
         from src.a2a_server.adcp_a2a_server import AdCPRequestHandler
@@ -783,61 +791,8 @@ class BaseTestEnv:
         else:
             parameters = dict(kwargs)
 
-        handler = AdCPRequestHandler()
-
-        # Auth strategy mirrors _run_mcp_client. When the identity carries a real
-        # auth_token (integration mode), populate the AuthContext that the SDK
-        # call-context builder would have built from the wire and run the REAL
-        # _get_auth_token + _resolve_a2a_identity (header → token → DB lookup →
-        # ResolvedIdentity). Only the transport's state injection is supplied here
-        # (the in-process equivalent of MCP's get_http_headers seam) — the auth
-        # chain itself is real. When no real token exists (unit mode), inject the
-        # identity directly via the single mock point (unchanged behavior).
-        auth_token = a2a_identity.auth_token if a2a_identity else None
-
-        if auth_token:
-            from src.core.auth_context import AUTH_CONTEXT_STATE_KEY, AuthContext
-            from tests.a2a_helpers import auth_headers_mapping
-
-            headers = auth_headers_mapping(
-                {
-                    "x-adcp-auth": auth_token,
-                    "x-adcp-tenant": a2a_identity.tenant_id or "",
-                }
-            )
-            server_context = ServerCallContext(
-                state={AUTH_CONTEXT_STATE_KEY: AuthContext(auth_token=auth_token, headers=headers)}
-            )
-        else:
-            # Production ``_resolve_a2a_identity`` always returns ResolvedIdentity
-            # (principal_id may be None for unauthenticated discovery) — never
-            # None. Create+own co-location reads ``identity.tenant_id`` (#1702);
-            # mocking None made unauth A2A BDD paths AttributeError into
-            # SERVICE_UNAVAILABLE instead of AUTH_REQUIRED.
-            # Pin: @T-UC-011-list-unauth[a2a] and @T-UC-005-ext-a[a2a] — both
-            # invoke DISCOVERY_SKILLS, so execution passes the auth-required
-            # gate and reaches the create+own co-location (#1702 / R5-N5a).
-            # Use PrincipalFactory (not inline ResolvedIdentity) for the arch guard.
-            from tests.factories.principal import PrincipalFactory
-
-            resolved = a2a_identity or PrincipalFactory.make_anonymous_a2a_identity(
-                tenant_id=None,
-            )
-            # _get_auth_token must return a non-None value when identity exists,
-            # otherwise the handler rejects the request before _resolve_a2a_identity
-            # is called. Use auth_token from identity, falling back to a sentinel.
-            # Unauthenticated (a2a_identity is None) stays token-less.
-            handler._resolve_a2a_identity = lambda *args, **kw: resolved  # type: ignore[assignment]
-            handler._get_auth_token = lambda *args, **kw: (  # type: ignore[assignment]
-                (a2a_identity.auth_token or "harness-test-token") if a2a_identity else None
-            )
-            server_context = ServerCallContext()
-
-        # Set tenant ContextVar so production code can read it
-        if a2a_identity and a2a_identity.tenant:
-            from src.core.config_loader import set_current_tenant
-
-            set_current_tenant(a2a_identity.tenant)
+        handler = self.a2a_handler
+        server_context = self._prepare_a2a_server_context(handler, a2a_identity)
 
         message = create_a2a_message_with_skill(skill_name=skill_name, parameters=parameters)
         if protocol_push_config is None:
@@ -907,6 +862,179 @@ class BaseTestEnv:
         return DeliverResult(
             payload=response_cls(**strip_a2a_protocol_fields(artifact_data)), wire_response=wire_response
         )
+
+    def _prepare_a2a_server_context(self, handler: Any, a2a_identity: Any) -> Any:
+        """Build the ``ServerCallContext`` for one in-process A2A dispatch.
+
+        Auth strategy mirrors _run_mcp_client. When the identity carries a real
+        auth_token (integration mode), populate the AuthContext that the SDK
+        call-context builder would have built from the wire and run the REAL
+        _get_auth_token + _resolve_a2a_identity (header → token → DB lookup →
+        ResolvedIdentity). Only the transport's state injection is supplied here
+        (the in-process equivalent of MCP's get_http_headers seam) — the auth
+        chain itself is real. When no real token exists (unit mode), inject the
+        identity directly via the single mock point (unchanged behavior).
+
+        Shared by ``_run_a2a_handler`` (skills) and ``_run_a2a_task_method``
+        (``tasks/get`` / ``tasks/cancel``) so both dispatch styles authenticate
+        the same way against the same handler.
+        """
+        from a2a.server.routes.common import ServerCallContext
+
+        auth_token = a2a_identity.auth_token if a2a_identity else None
+
+        if auth_token:
+            from src.core.auth_context import AUTH_CONTEXT_STATE_KEY, AuthContext
+            from tests.a2a_helpers import auth_headers_mapping
+
+            # The handler outlives a single dispatch, so an earlier unit-mode
+            # call may have left identity lambdas on this instance. Drop them —
+            # a real token must resolve through the real auth chain, otherwise a
+            # denial scenario would silently reuse the previous caller's identity.
+            handler.__dict__.pop("_resolve_a2a_identity", None)
+            handler.__dict__.pop("_get_auth_token", None)
+
+            headers = auth_headers_mapping(
+                {
+                    "x-adcp-auth": auth_token,
+                    "x-adcp-tenant": a2a_identity.tenant_id or "",
+                }
+            )
+            server_context = ServerCallContext(
+                state={AUTH_CONTEXT_STATE_KEY: AuthContext(auth_token=auth_token, headers=headers)}
+            )
+        else:
+            # Production ``_resolve_a2a_identity`` always returns ResolvedIdentity
+            # (principal_id may be None for unauthenticated discovery) — never
+            # None. Create+own co-location reads ``identity.tenant_id`` (#1702);
+            # mocking None made unauth A2A BDD paths AttributeError into
+            # SERVICE_UNAVAILABLE instead of AUTH_REQUIRED.
+            # Pin: @T-UC-011-list-unauth[a2a] and @T-UC-005-ext-a[a2a] — both
+            # invoke DISCOVERY_SKILLS, so execution passes the auth-required
+            # gate and reaches the create+own co-location (#1702 / R5-N5a).
+            # Use PrincipalFactory (not inline ResolvedIdentity) for the arch guard.
+            from tests.factories.principal import PrincipalFactory
+
+            resolved = a2a_identity or PrincipalFactory.make_anonymous_a2a_identity(
+                tenant_id=None,
+            )
+            # _get_auth_token must return a non-None value when identity exists,
+            # otherwise the handler rejects the request before _resolve_a2a_identity
+            # is called. Use auth_token from identity, falling back to a sentinel.
+            # Unauthenticated (a2a_identity is None) stays token-less.
+            handler._resolve_a2a_identity = lambda *args, **kw: resolved  # type: ignore[assignment]
+            handler._get_auth_token = lambda *args, **kw: (  # type: ignore[assignment]
+                (a2a_identity.auth_token or "harness-test-token") if a2a_identity else None
+            )
+            server_context = ServerCallContext()
+
+        # Set tenant ContextVar so production code can read it
+        if a2a_identity and a2a_identity.tenant:
+            from src.core.config_loader import set_current_tenant
+
+            set_current_tenant(a2a_identity.tenant)
+
+        return server_context
+
+    def _run_a2a_task_method(self, method: str, task_id: str, *, identity: Any = _NO_OVERRIDE) -> Any:
+        """Dispatch ``tasks/get`` / ``tasks/cancel`` on the shared handler.
+
+        Runs against the SAME handler ``_run_a2a_handler`` uses, so the task a
+        skill dispatch created is the task this polls or cancels, and the owner
+        recorded at create (#1702) is the owner the gate authorizes against.
+
+        These are protocol methods, not AdCP skills: there is no artifact and no
+        two-layer envelope. Results land on the grading surface —
+        ``last_a2a_task`` for the served Task, ``last_a2a_task_error`` for a
+        not-found (unknown id AND ownership denial collapse to it identically).
+        Anything else propagates as an unwrapped AdCPError, the same as skills.
+
+        Denial altitude: calls ``on_get_task`` / ``on_cancel_task`` directly and,
+        on ``TaskNotFoundError``, stores a **compat-shaped reconstruction**
+        (``CoreInternalError(message=str(exc)).model_dump``) matching today's
+        v0.3 adapter body — it does **not** POST through
+        ``create_jsonrpc_routes(..., enable_v0_3_compat=True)``. Live JSON-RPC
+        wire serialization is graded in ``tests/unit/test_a2a_task_identity_wire.py``
+        (#1720).
+
+        Returns the served Task, or None when the call was denied.
+        """
+        import asyncio
+
+        from a2a.server.jsonrpc_models import InternalError as CoreInternalError
+        from a2a.types import CancelTaskRequest, GetTaskRequest, TaskNotFoundError
+
+        from tests.harness.transport import Transport
+
+        self._commit_factory_data()
+        a2a_identity = self.identity_for(Transport.A2A) if identity is _NO_OVERRIDE else identity
+        if self.use_real_db and a2a_identity and a2a_identity.tenant_id:
+            self._ensure_tenant_for_audit(a2a_identity.tenant_id)
+
+        handler = self.a2a_handler
+        server_context = self._prepare_a2a_server_context(handler, a2a_identity)
+
+        request_cls, on_method = {
+            "tasks/get": (GetTaskRequest, handler.on_get_task),
+            "tasks/cancel": (CancelTaskRequest, handler.on_cancel_task),
+        }[method]
+
+        self._last_a2a_task = None
+        self._last_a2a_task_error = None
+        try:
+            task = asyncio.run(on_method(request_cls(id=task_id), server_context))
+        except TaskNotFoundError as exc:
+            # Intentional altitude (#1780 review): mirror today's v0.3 compat body
+            # (enable_v0_3_compat rebuilds any raised error as CoreInternalError —
+            # code -32603, data dropped, #1670). Not a live JSON-RPC capture;
+            # adapter wire proof lives in test_a2a_task_identity_wire.py (#1720).
+            self._last_a2a_task_error = CoreInternalError(message=str(exc)).model_dump(by_alias=True)
+            return None
+        except Exception as exc:
+            raise _unwrap_a2a_server_error(exc) from exc
+
+        self._last_a2a_task = task
+        return task
+
+    @realize_e2e(e2e_unsupported("in-process handler memory"))
+    def seed_a2a_task(self, task_id: str, *, identity: Any = _NO_OVERRIDE, state: Any = None) -> Any:
+        """Seed an in-memory task owned by *identity* on the shared handler.
+
+        Authz-gate altitude for ownership BDD (#1780): writes ``handler.tasks``
+        and ``_task_owners`` directly so get/cancel can grade the gate with real
+        tokens. This is **not** bind-on-create via ``on_message_send`` (that path
+        is covered by #1720 unit tests). Do not use this seed to claim create→poll
+        co-location in UC-006 — that Then fails until sync create records owners.
+
+        Over e2e the live server owns its own handler process memory, which no
+        test-side seed can reach — hence the ``e2e_unsupported`` realization.
+
+        Defaults to ``TASK_STATE_WORKING`` so a denied cancel has a state that
+        would visibly change if the ownership gate let it through.
+        """
+        from a2a.types import Task, TaskState, TaskStatus
+
+        from src.a2a_server.adcp_a2a_server import _TaskOwner
+        from tests.harness.transport import Transport
+
+        owner = self.identity_for(Transport.A2A) if identity is _NO_OVERRIDE else identity
+        handler = self.a2a_handler
+        task = Task(id=task_id, status=TaskStatus(state=state or TaskState.TASK_STATE_WORKING))
+        handler.tasks[task_id] = task
+        handler._task_owners[task_id] = _TaskOwner(
+            tenant_id=owner.tenant_id,
+            principal_id=owner.principal_id,
+        )
+        return task
+
+    def a2a_task_state(self, task_id: str) -> Any:
+        """State of the seeded in-memory task, or None if the handler has no such id.
+
+        Public read-back accessor: a denied ``tasks/cancel`` must leave the stored
+        Task untouched, and step functions must not reach into ``handler.tasks``.
+        """
+        task = self.a2a_handler.tasks.get(task_id)
+        return task.status.state if task is not None else None
 
     def _run_mcp_client(
         self,

--- a/tests/harness/_base.py
+++ b/tests/harness/_base.py
@@ -814,7 +814,9 @@ class BaseTestEnv:
             # None. Create+own co-location reads ``identity.tenant_id`` (#1702);
             # mocking None made unauth A2A BDD paths AttributeError into
             # SERVICE_UNAVAILABLE instead of AUTH_REQUIRED.
-            # Pin: @T-UC-011-list-unauth grades this compensating unauth path.
+            # Pin: @T-UC-011-list-unauth[a2a] and @T-UC-005-ext-a[a2a] — both
+            # invoke DISCOVERY_SKILLS, so execution passes the auth-required
+            # gate and reaches the create+own co-location (#1702 / R5-N5a).
             # Use PrincipalFactory (not inline ResolvedIdentity) for the arch guard.
             from tests.factories.principal import PrincipalFactory
 

--- a/tests/harness/_base.py
+++ b/tests/harness/_base.py
@@ -693,6 +693,27 @@ class BaseTestEnv:
         """
         return self._last_a2a_task
 
+    @property
+    def a2a_handler(self) -> AdCPRequestHandler:
+        """The one ``AdCPRequestHandler`` this env dispatches A2A through.
+
+        In-memory task state (``tasks`` and the ``_task_owners`` recorded at
+        create, #1702) lives on the handler instance. Building a fresh handler
+        per dispatch would drop that state between a create and the subsequent
+        ``tasks/get`` / ``tasks/cancel``, so ownership could never be graded.
+
+        Side effect: every A2A skill dispatch on this env reuses the same
+        handler, so in-scenario multi-call paths can accumulate tasks. Clear
+        or replace the handler per scenario once any UC dispatches more than
+        one A2A skill call in one scenario (shared-handler reuse stops being
+        acceptable at that point).
+        """
+        if self._a2a_handler is None:
+            from src.a2a_server.adcp_a2a_server import AdCPRequestHandler
+
+            self._a2a_handler = AdCPRequestHandler()
+        return self._a2a_handler
+
     def deliver_mcp(self, **kwargs: Any) -> DeliverResult:
         """Dispatch through the real FastMCP Client pipeline, returning payload AND wire.
 

--- a/tests/harness/_mixins.py
+++ b/tests/harness/_mixins.py
@@ -35,6 +35,7 @@ from src.services.webhook_delivery_service import (
     CircuitState,
     WebhookDeliveryService,
 )
+from tests.harness._base import _NO_OVERRIDE
 from tests.harness._realize import e2e_unsupported, realize_e2e
 from tests.helpers.egress_hatches import egress_hatch_env
 from tests.helpers.local_http_origin import (

--- a/tests/harness/_mixins.py
+++ b/tests/harness/_mixins.py
@@ -35,7 +35,6 @@ from src.services.webhook_delivery_service import (
     CircuitState,
     WebhookDeliveryService,
 )
-from tests.harness._base import _NO_OVERRIDE
 from tests.harness._realize import e2e_unsupported, realize_e2e
 from tests.helpers.egress_hatches import egress_hatch_env
 from tests.helpers.local_http_origin import (

--- a/tests/harness/a2a_task_ownership.py
+++ b/tests/harness/a2a_task_ownership.py
@@ -22,7 +22,7 @@ Usage::
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING
 
 from src.core.resolved_identity import ResolvedIdentity
 from tests.a2a_helpers import (
@@ -34,9 +34,19 @@ from tests.a2a_helpers import (
 )
 from tests.harness._base import IntegrationEnv
 
+if TYPE_CHECKING:
+    from src.core.database.models import Principal, Tenant
+
 OWNER_ROLE = "owner"
 SIBLING_ROLE = "sibling"
 OTHER_TENANT_ROLE = "other_tenant"
+
+# Role → (tenant_id, principal_id) built once from the shared OWNED_TASK_* vocabulary.
+_ROLE_TARGETS: dict[str, tuple[str, str]] = {
+    OWNER_ROLE: (OWNED_TASK_TENANT, OWNED_TASK_OWNER),
+    SIBLING_ROLE: (OWNED_TASK_TENANT, OWNED_TASK_SIBLING),
+    OTHER_TENANT_ROLE: (OWNED_TASK_OTHER_TENANT, OWNED_TASK_OTHER_PRINCIPAL),
+}
 
 
 class A2ATaskOwnershipEnv(IntegrationEnv):
@@ -44,22 +54,13 @@ class A2ATaskOwnershipEnv(IntegrationEnv):
 
     EXTERNAL_PATCHES: dict[str, str] = {}
 
-    # Shared with unit/wire altitudes (tests/a2a_helpers.py) — one vocabulary.
-    OWNER_TENANT_ID = OWNED_TASK_TENANT
-    OWNER_PRINCIPAL_ID = OWNED_TASK_OWNER
-    SIBLING_PRINCIPAL_ID = OWNED_TASK_SIBLING
-    OTHER_TENANT_ID = OWNED_TASK_OTHER_TENANT
-    # Same principal_id under another tenant so cross-tenant scenarios grade the
-    # tenant half of ``_TaskOwner`` (principal-only mutation must redden).
-    OTHER_PRINCIPAL_ID = OWNED_TASK_OTHER_PRINCIPAL
-
-    def __init__(self, **kwargs: Any) -> None:
-        kwargs.setdefault("tenant_id", self.OWNER_TENANT_ID)
-        kwargs.setdefault("principal_id", self.OWNER_PRINCIPAL_ID)
-        super().__init__(**kwargs)
+    def __init__(self, **kwargs: object) -> None:
+        kwargs.setdefault("tenant_id", OWNED_TASK_TENANT)
+        kwargs.setdefault("principal_id", OWNED_TASK_OWNER)
+        super().__init__(**kwargs)  # type: ignore[arg-type]
         self._role_identities: dict[str, ResolvedIdentity] = {}
 
-    def setup_principals(self) -> tuple[Any, Any]:
+    def setup_principals(self) -> tuple[Tenant, Principal]:
         """Seed the owner tenant + all three principals, each with a real access token.
 
         Returns the (tenant, owner principal) pair for the owning tenant.
@@ -67,9 +68,9 @@ class A2ATaskOwnershipEnv(IntegrationEnv):
         from tests.factories import PrincipalFactory, TenantFactory
 
         tenant, owner = self.setup_default_data()
-        PrincipalFactory(tenant=tenant, principal_id=self.SIBLING_PRINCIPAL_ID)
-        other_tenant = TenantFactory(tenant_id=self.OTHER_TENANT_ID)
-        PrincipalFactory(tenant=other_tenant, principal_id=self.OTHER_PRINCIPAL_ID)
+        PrincipalFactory(tenant=tenant, principal_id=OWNED_TASK_SIBLING)
+        other_tenant = TenantFactory(tenant_id=OWNED_TASK_OTHER_TENANT)
+        PrincipalFactory(tenant=other_tenant, principal_id=OWNED_TASK_OTHER_PRINCIPAL)
         self._commit_factory_data()
         return tenant, owner
 
@@ -83,13 +84,8 @@ class A2ATaskOwnershipEnv(IntegrationEnv):
         """
         from tests.harness.transport import Transport
 
-        role_targets = {
-            OWNER_ROLE: (self.OWNER_TENANT_ID, self.OWNER_PRINCIPAL_ID),
-            SIBLING_ROLE: (self.OWNER_TENANT_ID, self.SIBLING_PRINCIPAL_ID),
-            OTHER_TENANT_ROLE: (self.OTHER_TENANT_ID, self.OTHER_PRINCIPAL_ID),
-        }
         if role not in self._role_identities:
-            tenant_id, principal_id = role_targets[role]
+            tenant_id, principal_id = _ROLE_TARGETS[role]
             self.switch_tenant(tenant_id)
             self.switch_principal(principal_id)
             try:
@@ -100,6 +96,6 @@ class A2ATaskOwnershipEnv(IntegrationEnv):
                 )
                 self._role_identities[role] = identity
             finally:
-                self.switch_tenant(self.OWNER_TENANT_ID)
-                self.switch_principal(self.OWNER_PRINCIPAL_ID)
+                self.switch_tenant(OWNED_TASK_TENANT)
+                self.switch_principal(OWNED_TASK_OWNER)
         return self._role_identities[role]

--- a/tests/harness/a2a_task_ownership.py
+++ b/tests/harness/a2a_task_ownership.py
@@ -86,9 +86,9 @@ class A2ATaskOwnershipEnv(IntegrationEnv):
 
         if role not in self._role_identities:
             tenant_id, principal_id = _ROLE_TARGETS[role]
-            self.switch_tenant(tenant_id)
-            self.switch_principal(principal_id)
             try:
+                self.switch_tenant(tenant_id)
+                self.switch_principal(principal_id)
                 identity = self.identity_for(Transport.A2A)
                 assert identity.auth_token, (
                     f"No access token resolved for role {role!r} ({tenant_id}/{principal_id}) — "

--- a/tests/harness/a2a_task_ownership.py
+++ b/tests/harness/a2a_task_ownership.py
@@ -1,0 +1,93 @@
+"""A2ATaskOwnershipEnv — multi-principal env for the A2A in-memory task gate.
+
+``tasks/get`` / ``tasks/cancel`` authorize an in-memory hit against the
+``_TaskOwner`` recorded at create (#1702). Grading that gate needs three real,
+DB-backed callers — the owner, a sibling principal in the SAME tenant, and a
+principal in ANOTHER tenant — because the denial must be identical for a
+cross-principal caller, a cross-tenant caller, and an unknown task id.
+
+Real tokens (not injected identities) so each dispatch runs the production auth
+chain: header → token → DB lookup → ResolvedIdentity. Nothing is patched; the
+handler, its task store, and the ownership gate are all production code.
+
+Usage::
+
+    with A2ATaskOwnershipEnv() as env:
+        env.setup_principals()
+        env.seed_a2a_task("task-1", identity=env.identity_for_role("owner"))
+        denied = env._run_a2a_task_method(
+            "tasks/get", "task-1", identity=env.identity_for_role("sibling")
+        )
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from src.core.resolved_identity import ResolvedIdentity
+from tests.harness._base import IntegrationEnv
+
+OWNER_ROLE = "owner"
+SIBLING_ROLE = "sibling"
+OTHER_TENANT_ROLE = "other_tenant"
+
+
+class A2ATaskOwnershipEnv(IntegrationEnv):
+    """Integration env exposing owner / same-tenant sibling / other-tenant callers."""
+
+    EXTERNAL_PATCHES: dict[str, str] = {}
+
+    OWNER_TENANT_ID = "task_owner_tenant"
+    OWNER_PRINCIPAL_ID = "task_owner"
+    SIBLING_PRINCIPAL_ID = "task_sibling"
+    OTHER_TENANT_ID = "task_other_tenant"
+    OTHER_PRINCIPAL_ID = "task_other_principal"
+
+    def __init__(self, **kwargs: Any) -> None:
+        kwargs.setdefault("tenant_id", self.OWNER_TENANT_ID)
+        kwargs.setdefault("principal_id", self.OWNER_PRINCIPAL_ID)
+        super().__init__(**kwargs)
+        self._role_identities: dict[str, ResolvedIdentity] = {}
+
+    def setup_principals(self) -> tuple[Any, Any]:
+        """Seed the owner tenant + all three principals, each with a real access token.
+
+        Returns the (tenant, owner principal) pair for the owning tenant.
+        """
+        from tests.factories import PrincipalFactory, TenantFactory
+
+        tenant, owner = self.setup_default_data()
+        PrincipalFactory(tenant=tenant, principal_id=self.SIBLING_PRINCIPAL_ID)
+        other_tenant = TenantFactory(tenant_id=self.OTHER_TENANT_ID)
+        PrincipalFactory(tenant=other_tenant, principal_id=self.OTHER_PRINCIPAL_ID)
+        self._commit_factory_data()
+        return tenant, owner
+
+    def identity_for_role(self, role: str) -> ResolvedIdentity:
+        """A2A ``ResolvedIdentity`` carrying the real token of *role*'s principal.
+
+        Roles: ``owner``, ``sibling`` (same tenant), ``other_tenant``. Built by
+        re-pointing the env at that principal so the token comes from the seeded
+        row, then restoring the owner as the env default — callers always name
+        the role they mean rather than depending on env state.
+        """
+        from tests.harness.transport import Transport
+
+        role_targets = {
+            OWNER_ROLE: (self.OWNER_TENANT_ID, self.OWNER_PRINCIPAL_ID),
+            SIBLING_ROLE: (self.OWNER_TENANT_ID, self.SIBLING_PRINCIPAL_ID),
+            OTHER_TENANT_ROLE: (self.OTHER_TENANT_ID, self.OTHER_PRINCIPAL_ID),
+        }
+        if role not in self._role_identities:
+            tenant_id, principal_id = role_targets[role]
+            self.switch_tenant(tenant_id)
+            self.switch_principal(principal_id)
+            identity = self.identity_for(Transport.A2A)
+            assert identity.auth_token, (
+                f"No access token resolved for role {role!r} ({tenant_id}/{principal_id}) — "
+                "call setup_principals() before building role identities."
+            )
+            self._role_identities[role] = identity
+            self.switch_tenant(self.OWNER_TENANT_ID)
+            self.switch_principal(self.OWNER_PRINCIPAL_ID)
+        return self._role_identities[role]

--- a/tests/harness/a2a_task_ownership.py
+++ b/tests/harness/a2a_task_ownership.py
@@ -15,7 +15,7 @@ Usage::
     with A2ATaskOwnershipEnv() as env:
         env.setup_principals()
         env.seed_a2a_task("task-1", identity=env.identity_for_role("owner"))
-        denied = env._run_a2a_task_method(
+        denied = env.run_a2a_task_method(
             "tasks/get", "task-1", identity=env.identity_for_role("sibling")
         )
 """
@@ -25,6 +25,13 @@ from __future__ import annotations
 from typing import Any
 
 from src.core.resolved_identity import ResolvedIdentity
+from tests.a2a_helpers import (
+    OWNED_TASK_OTHER_PRINCIPAL,
+    OWNED_TASK_OTHER_TENANT,
+    OWNED_TASK_OWNER,
+    OWNED_TASK_SIBLING,
+    OWNED_TASK_TENANT,
+)
 from tests.harness._base import IntegrationEnv
 
 OWNER_ROLE = "owner"
@@ -37,11 +44,14 @@ class A2ATaskOwnershipEnv(IntegrationEnv):
 
     EXTERNAL_PATCHES: dict[str, str] = {}
 
-    OWNER_TENANT_ID = "task_owner_tenant"
-    OWNER_PRINCIPAL_ID = "task_owner"
-    SIBLING_PRINCIPAL_ID = "task_sibling"
-    OTHER_TENANT_ID = "task_other_tenant"
-    OTHER_PRINCIPAL_ID = "task_other_principal"
+    # Shared with unit/wire altitudes (tests/a2a_helpers.py) — one vocabulary.
+    OWNER_TENANT_ID = OWNED_TASK_TENANT
+    OWNER_PRINCIPAL_ID = OWNED_TASK_OWNER
+    SIBLING_PRINCIPAL_ID = OWNED_TASK_SIBLING
+    OTHER_TENANT_ID = OWNED_TASK_OTHER_TENANT
+    # Same principal_id under another tenant so cross-tenant scenarios grade the
+    # tenant half of ``_TaskOwner`` (principal-only mutation must redden).
+    OTHER_PRINCIPAL_ID = OWNED_TASK_OTHER_PRINCIPAL
 
     def __init__(self, **kwargs: Any) -> None:
         kwargs.setdefault("tenant_id", self.OWNER_TENANT_ID)
@@ -82,12 +92,14 @@ class A2ATaskOwnershipEnv(IntegrationEnv):
             tenant_id, principal_id = role_targets[role]
             self.switch_tenant(tenant_id)
             self.switch_principal(principal_id)
-            identity = self.identity_for(Transport.A2A)
-            assert identity.auth_token, (
-                f"No access token resolved for role {role!r} ({tenant_id}/{principal_id}) — "
-                "call setup_principals() before building role identities."
-            )
-            self._role_identities[role] = identity
-            self.switch_tenant(self.OWNER_TENANT_ID)
-            self.switch_principal(self.OWNER_PRINCIPAL_ID)
+            try:
+                identity = self.identity_for(Transport.A2A)
+                assert identity.auth_token, (
+                    f"No access token resolved for role {role!r} ({tenant_id}/{principal_id}) — "
+                    "call setup_principals() before building role identities."
+                )
+                self._role_identities[role] = identity
+            finally:
+                self.switch_tenant(self.OWNER_TENANT_ID)
+                self.switch_principal(self.OWNER_PRINCIPAL_ID)
         return self._role_identities[role]

--- a/tests/integration/test_a2a_error_responses.py
+++ b/tests/integration/test_a2a_error_responses.py
@@ -1067,11 +1067,8 @@ class TestA2AContextEcho:
             # Auth/identity layer mocked at the boundary (matches gold-standard pattern).
             # Discovery resolve always returns ResolvedIdentity (possibly with a
             # None principal_id) — never None; owner recording reads .tenant_id.
-            anonymous = PrincipalFactory.make_identity(
-                principal_id=None,
+            anonymous = PrincipalFactory.make_anonymous_a2a_identity(
                 tenant_id="test_tenant",
-                tenant=None,
-                protocol="a2a",
             )
             handler._get_auth_token = MagicMock(return_value=None)
             handler._resolve_a2a_identity = MagicMock(return_value=anonymous)

--- a/tests/integration/test_a2a_error_responses.py
+++ b/tests/integration/test_a2a_error_responses.py
@@ -1065,8 +1065,16 @@ class TestA2AContextEcho:
         # so we don't need a real principal in DB (auth is optional).
         with patch.object(handler, "_handle_get_products_skill", raise_with_context):
             # Auth/identity layer mocked at the boundary (matches gold-standard pattern).
+            # Discovery resolve always returns ResolvedIdentity (possibly with a
+            # None principal_id) — never None; owner recording reads .tenant_id.
+            anonymous = PrincipalFactory.make_identity(
+                principal_id=None,
+                tenant_id="test_tenant",
+                tenant=None,
+                protocol="a2a",
+            )
             handler._get_auth_token = MagicMock(return_value=None)
-            handler._resolve_a2a_identity = MagicMock(return_value=None)
+            handler._resolve_a2a_identity = MagicMock(return_value=anonymous)
 
             message = create_a2a_message_with_skill("get_products", {"brief": "test"})
             req_params = SendMessageRequest(message=message)

--- a/tests/unit/test_a2a_harness_identity_cleanup.py
+++ b/tests/unit/test_a2a_harness_identity_cleanup.py
@@ -1,0 +1,46 @@
+"""Harness-contract: token-mode prepare drops unit-mode identity lambdas (#1780)."""
+
+from __future__ import annotations
+
+from tests.factories.principal import PrincipalFactory
+from tests.harness._base import BaseTestEnv
+
+
+class _A2APrepareEnv(BaseTestEnv):
+    """Minimal env so ``_prepare_a2a_server_context`` is reachable without a domain."""
+
+    EXTERNAL_PATCHES: dict[str, str] = {}
+
+    def call_impl(self, **kwargs: object) -> None:
+        raise NotImplementedError
+
+
+def test_token_mode_prepare_clears_unit_mode_identity_lambdas() -> None:
+    """Deleting the two pops in token-mode prepare must redden this oracle.
+
+    Sequence: unit-mode prepare installs identity lambdas on the shared
+    handler; token-mode prepare must drop them so a later real-token dispatch
+    cannot silently reuse the previous caller's identity.
+    """
+    with _A2APrepareEnv(use_real_db=False) as env:
+        handler = env.a2a_handler
+        unit_identity = PrincipalFactory.make_identity(
+            principal_id="unit_principal",
+            tenant_id="unit_tenant",
+            protocol="a2a",
+            auth_token=None,
+        )
+        token_identity = PrincipalFactory.make_identity(
+            principal_id="token_principal",
+            tenant_id="token_tenant",
+            protocol="a2a",
+            auth_token="harness-contract-tok",
+        )
+
+        env._prepare_a2a_server_context(handler, unit_identity)
+        assert "_resolve_a2a_identity" in handler.__dict__
+        assert "_get_auth_token" in handler.__dict__
+
+        env._prepare_a2a_server_context(handler, token_identity)
+        assert "_resolve_a2a_identity" not in handler.__dict__
+        assert "_get_auth_token" not in handler.__dict__

--- a/tests/unit/test_a2a_task_identity_scope.py
+++ b/tests/unit/test_a2a_task_identity_scope.py
@@ -1,0 +1,139 @@
+"""Identity-scope gate for A2A in-memory tasks/get and tasks/cancel (#1702).
+
+A bare ``self.tasks.get(task_id)`` served (or canceled) any caller's request
+once they knew the id. These tests pin auth-first ownership against
+``_task_owners`` and prove wrong-principal / unauthenticated callers get the
+same ``TaskNotFoundError`` as an unknown id (no existence oracle).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from a2a.types import (
+    CancelTaskRequest,
+    GetTaskRequest,
+    Task,
+    TaskNotFoundError,
+    TaskState,
+    TaskStatus,
+)
+
+from src.a2a_server.adcp_a2a_server import AdCPRequestHandler
+from tests.factories import PrincipalFactory
+
+_TENANT = "tenant_a"
+_OWNER = "principal_owner"
+_SIBLING = "principal_sibling"
+_TASK_ID = "task_owned_abc"
+
+
+def _owned_handler() -> AdCPRequestHandler:
+    handler = AdCPRequestHandler.__new__(AdCPRequestHandler)
+    done = Task(id=_TASK_ID, status=TaskStatus(state=TaskState.TASK_STATE_COMPLETED))
+    handler.tasks = {_TASK_ID: done}
+    handler._task_owners = {_TASK_ID: (_TENANT, _OWNER)}
+    handler._task_push_configs = {}
+    return handler
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "request_cls, method_name",
+    [(GetTaskRequest, "on_get_task"), (CancelTaskRequest, "on_cancel_task")],
+)
+async def test_owner_can_access_owned_in_memory_task(request_cls, method_name):
+    """The recorded owner authenticates and is served / can cancel."""
+    handler = _owned_handler()
+    identity = PrincipalFactory.make_identity(principal_id=_OWNER, tenant_id=_TENANT, protocol="a2a")
+
+    with (
+        patch.object(handler, "_get_auth_token", return_value="tok") as mock_auth,
+        patch.object(handler, "_resolve_a2a_identity", return_value=identity),
+    ):
+        task = await getattr(handler, method_name)(request_cls(id=_TASK_ID), context=None)
+
+    mock_auth.assert_called_once_with(None)
+    assert task.id == _TASK_ID
+    if method_name == "on_cancel_task":
+        assert task.status.state == TaskState.TASK_STATE_CANCELED
+    else:
+        assert task.status.state == TaskState.TASK_STATE_COMPLETED
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "request_cls, method_name",
+    [(GetTaskRequest, "on_get_task"), (CancelTaskRequest, "on_cancel_task")],
+)
+async def test_sibling_principal_denied_same_as_unknown(request_cls, method_name):
+    """Same-tenant sibling must not read or cancel — identical to unknown id."""
+    handler = _owned_handler()
+    sibling = PrincipalFactory.make_identity(principal_id=_SIBLING, tenant_id=_TENANT, protocol="a2a")
+
+    with (
+        patch.object(handler, "_get_auth_token", return_value="tok"),
+        patch.object(handler, "_resolve_a2a_identity", return_value=sibling),
+    ):
+        with pytest.raises(TaskNotFoundError) as exc:
+            await getattr(handler, method_name)(request_cls(id=_TASK_ID), context=None)
+
+    assert exc.value.data == {"task_id": _TASK_ID}
+    # Sibling denial must not mutate cancel state.
+    assert handler.tasks[_TASK_ID].status.state == TaskState.TASK_STATE_COMPLETED
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "request_cls, method_name",
+    [(GetTaskRequest, "on_get_task"), (CancelTaskRequest, "on_cancel_task")],
+)
+async def test_unauthenticated_poller_denied_same_as_unknown(request_cls, method_name):
+    """Auth failure collapses to TaskNotFoundError — no anonymous content oracle."""
+    handler = _owned_handler()
+
+    with (
+        patch.object(handler, "_get_auth_token", return_value=None),
+        patch.object(
+            handler,
+            "_resolve_a2a_identity",
+            side_effect=Exception("Missing authentication token"),
+        ),
+    ):
+        with pytest.raises(TaskNotFoundError) as exc:
+            await getattr(handler, method_name)(request_cls(id=_TASK_ID), context=None)
+
+    assert exc.value.data == {"task_id": _TASK_ID}
+    assert handler.tasks[_TASK_ID].status.state == TaskState.TASK_STATE_COMPLETED
+
+
+@pytest.mark.asyncio
+async def test_ownership_gate_mutation_proof():
+    """If ownership equality is dropped, sibling get leaks; with it, denied.
+
+    Plan mutation proof: temporarily serve bare ``self.tasks.get`` (pre-#1702),
+    confirm the sibling leak, then restore the owned helper and confirm deny.
+    """
+    handler = _owned_handler()
+    sibling = PrincipalFactory.make_identity(principal_id=_SIBLING, tenant_id=_TENANT, protocol="a2a")
+
+    def bare_tasks_get(task_id: str, context):  # noqa: ARG001 — mirrors pre-fix signature
+        task = handler.tasks.get(task_id)
+        assert task is not None
+        return task
+
+    with (
+        patch.object(handler, "_get_auth_token", return_value="tok"),
+        patch.object(handler, "_resolve_a2a_identity", return_value=sibling),
+        patch.object(handler, "_get_owned_in_memory_task_or_raise", side_effect=bare_tasks_get),
+    ):
+        leaked = await handler.on_get_task(GetTaskRequest(id=_TASK_ID), context=None)
+    assert leaked is handler.tasks[_TASK_ID]
+
+    with (
+        patch.object(handler, "_get_auth_token", return_value="tok"),
+        patch.object(handler, "_resolve_a2a_identity", return_value=sibling),
+    ):
+        with pytest.raises(TaskNotFoundError):
+            await handler.on_get_task(GetTaskRequest(id=_TASK_ID), context=None)

--- a/tests/unit/test_a2a_task_identity_scope.py
+++ b/tests/unit/test_a2a_task_identity_scope.py
@@ -10,13 +10,13 @@ propagate as ``InvalidRequestError`` and do not collapse to not-found.
 from __future__ import annotations
 
 import uuid
-from contextlib import contextmanager
 from unittest.mock import patch
 
 import pytest
 from a2a.types import (
     CancelTaskRequest,
     GetTaskRequest,
+    InternalError,
     InvalidRequestError,
     Message,
     Part,
@@ -27,10 +27,11 @@ from a2a.types import (
     TaskState,
     TaskStatus,
 )
+from sqlalchemy.exc import OperationalError
 
 from src.a2a_server.adcp_a2a_server import AdCPRequestHandler, _TaskOwner
 from src.core.schemas import GetProductsResponse
-from tests.a2a_helpers import make_a2a_context
+from tests.a2a_helpers import a2a_auth_as, make_a2a_context
 from tests.factories import PrincipalFactory
 
 _TENANT = "tenant_a"
@@ -46,16 +47,6 @@ def _owned_handler() -> AdCPRequestHandler:
     handler.tasks = {_TASK_ID: done}
     handler._task_owners = {_TASK_ID: _TaskOwner(tenant_id=_TENANT, principal_id=_OWNER)}
     return handler
-
-
-@contextmanager
-def a2a_auth_as(handler: AdCPRequestHandler, identity):
-    """Patch token extract + identity resolve for a single authenticated call."""
-    with (
-        patch.object(handler, "_get_auth_token", return_value="tok"),
-        patch.object(handler, "_resolve_a2a_identity", return_value=identity),
-    ):
-        yield
 
 
 def _make_nl_message(text: str) -> SendMessageRequest:
@@ -175,6 +166,76 @@ async def test_sibling_principal_denied_same_as_unknown(request_cls, method_name
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
+    "request_cls, method_name, wire_message",
+    [
+        (GetTaskRequest, "on_get_task", "get task failed"),
+        (CancelTaskRequest, "on_cancel_task", "cancel task failed"),
+    ],
+)
+async def test_auth_infra_failure_is_internal_error_not_task_not_found(request_cls, method_name, wire_message):
+    """DB/infra failure during identity resolve must not collapse to TaskNotFoundError.
+
+    Mutating the ``_authenticate`` except branch back to ``_task_not_found`` must
+    redden this test: buyers see a fixed human-phrase InternalError, not not-found.
+    """
+    handler = _owned_handler()
+
+    with (
+        patch.object(handler, "_get_auth_token", return_value="tok"),
+        patch.object(
+            handler,
+            "_resolve_a2a_identity",
+            side_effect=OperationalError("db down", None, None),
+        ),
+    ):
+        with pytest.raises(InternalError) as exc_info:
+            await getattr(handler, method_name)(request_cls(id=_TASK_ID), context=None)
+
+    raised = exc_info.value
+    assert not isinstance(raised, TaskNotFoundError)
+    assert raised.message == wire_message
+    assert "_" not in raised.message
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "request_cls, method_name",
+    [(GetTaskRequest, "on_get_task"), (CancelTaskRequest, "on_cancel_task")],
+)
+async def test_sibling_denied_via_real_auth_token_path(request_cls, method_name):
+    """Ownership compare with real ``_get_auth_token`` (only resolve_identity patched).
+
+    Unlike ``a2a_auth_as`` tests, the token is extracted from ServerCallContext so
+    mutating ``!= expected_owner`` out of the gate reddens this path — unknown-id
+    alone would stay green.
+    """
+    handler = _owned_handler()
+    owner = PrincipalFactory.make_identity(principal_id=_OWNER, tenant_id=_TENANT, protocol="a2a")
+    sibling = PrincipalFactory.make_identity(principal_id=_SIBLING, tenant_id=_TENANT, protocol="a2a")
+
+    def resolve(*, auth_token: str | None, **_kwargs):
+        if auth_token == "sibling-tok":
+            return sibling
+        if auth_token == "owner-tok":
+            return owner
+        raise AssertionError(f"unexpected token: {auth_token!r}")
+
+    with patch("src.core.resolved_identity.resolve_identity", side_effect=resolve):
+        sibling_ctx = make_a2a_context(auth_token="sibling-tok", headers={"host": "test.example.com"})
+        with pytest.raises(TaskNotFoundError) as deny_exc:
+            await getattr(handler, method_name)(request_cls(id=_TASK_ID), context=sibling_ctx)
+
+        owner_ctx = make_a2a_context(auth_token="owner-tok", headers={"host": "test.example.com"})
+        with pytest.raises(TaskNotFoundError) as unknown_exc:
+            await getattr(handler, method_name)(request_cls(id="task_does_not_exist"), context=owner_ctx)
+
+    _assert_not_found_matches(deny_exc.value, _TASK_ID)
+    _assert_not_found_matches(unknown_exc.value, "task_does_not_exist")
+    assert handler.tasks[_TASK_ID].status.state == TaskState.TASK_STATE_COMPLETED
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
     "request_cls, method_name",
     [(GetTaskRequest, "on_get_task"), (CancelTaskRequest, "on_cancel_task")],
 )
@@ -212,12 +273,7 @@ async def test_discovery_create_records_anonymous_owner_without_auth():
     from tests.utils.a2a_helpers import create_a2a_message_with_skill
 
     handler = AdCPRequestHandler()
-    anonymous = PrincipalFactory.make_identity(
-        principal_id=None,
-        tenant_id=_TENANT,
-        tenant=None,
-        protocol="a2a",
-    )
+    anonymous = PrincipalFactory.make_anonymous_a2a_identity(tenant_id=_TENANT)
 
     async def raise_validation(params, identity):
         raise AdCPValidationError("synthetic discovery failure")

--- a/tests/unit/test_a2a_task_identity_scope.py
+++ b/tests/unit/test_a2a_task_identity_scope.py
@@ -44,6 +44,8 @@ from tests.a2a_helpers import (
     OWNED_TASK_SIBLING_TOK,
     OWNED_TASK_TENANT,
     TASK_METHOD_MATRIX,
+    TASK_METHOD_PAIRS,
+    TASK_METHOD_WITH_OPS,
     a2a_auth_as,
     assert_task_not_found_nondisclosure,
     auth_operation_wire_phrase,
@@ -152,7 +154,7 @@ def test_internal_error_for_sql_normalized_exception_stays_out_of_message():
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "request_cls, method_name",
-    [(row[0], row[1]) for row in TASK_METHOD_MATRIX],
+    TASK_METHOD_PAIRS,
 )
 async def test_create_records_owner_and_scopes_poll(request_cls, method_name):
     """Real constructor create→poll: owner allowed; sibling/other-tenant denied."""
@@ -205,7 +207,7 @@ async def test_create_records_owner_and_scopes_poll(request_cls, method_name):
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "request_cls, method_name",
-    [(row[0], row[1]) for row in TASK_METHOD_MATRIX],
+    TASK_METHOD_PAIRS,
 )
 async def test_owner_can_access_owned_in_memory_task(request_cls, method_name):
     """The recorded owner authenticates and is served / can cancel."""
@@ -225,7 +227,7 @@ async def test_owner_can_access_owned_in_memory_task(request_cls, method_name):
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "request_cls, method_name, operation",
-    [(row[0], row[1], row[3]) for row in TASK_METHOD_MATRIX],
+    TASK_METHOD_WITH_OPS,
 )
 async def test_sibling_principal_denied_same_as_unknown(request_cls, method_name, operation, caplog):
     """Same-tenant sibling must not read or cancel — identical to unknown id."""
@@ -275,7 +277,7 @@ async def test_sibling_principal_denied_same_as_unknown(request_cls, method_name
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "request_cls, method_name, wire_message",
-    [(row[0], row[1], auth_operation_wire_phrase(row[3])) for row in TASK_METHOD_MATRIX],
+    [(row.request_cls, row.method_name, auth_operation_wire_phrase(row.operation)) for row in TASK_METHOD_MATRIX],
 )
 async def test_auth_infra_failure_is_internal_error_not_task_not_found(request_cls, method_name, wire_message):
     """DB/infra failure during identity resolve must not collapse to TaskNotFoundError.
@@ -309,7 +311,7 @@ async def test_auth_infra_failure_is_internal_error_not_task_not_found(request_c
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "request_cls, method_name",
-    [(row[0], row[1]) for row in TASK_METHOD_MATRIX],
+    TASK_METHOD_PAIRS,
 )
 async def test_sibling_denied_via_real_auth_token_path(request_cls, method_name):
     """Ownership compare with real ``_get_auth_token`` (only resolve_identity patched).
@@ -338,7 +340,7 @@ async def test_sibling_denied_via_real_auth_token_path(request_cls, method_name)
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "request_cls, method_name",
-    [(row[0], row[1]) for row in TASK_METHOD_MATRIX],
+    TASK_METHOD_PAIRS,
 )
 async def test_unauthenticated_poller_raises_invalid_request(request_cls, method_name):
     """Missing token raises InvalidRequestError — must not collapse to TaskNotFoundError."""
@@ -354,7 +356,7 @@ async def test_unauthenticated_poller_raises_invalid_request(request_cls, method
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "request_cls, method_name",
-    [(row[0], row[1]) for row in TASK_METHOD_MATRIX],
+    TASK_METHOD_PAIRS,
 )
 async def test_null_principal_denied_against_null_owner_row(request_cls, method_name):
     """Null-principal identity must not match a (None, None) owner row (R5-A2)."""

--- a/tests/unit/test_a2a_task_identity_scope.py
+++ b/tests/unit/test_a2a_task_identity_scope.py
@@ -416,9 +416,9 @@ async def test_auth_resolve_failure_leaves_no_orphan_push_config():
     assert handler.tasks == {}
     assert handler._task_owners == {}
     assert handler._task_push_configs == {}
-    webhook.assert_called_once()
-    assert webhook.call_args.kwargs.get("config") == push
-    assert webhook.call_args.kwargs.get("config").url == "https://example.com/hook"
+    # Thread request-scoped config (no orphan map write) — assert_called_once_with
+    # so the weak-mock guard does not flag a split call_args inspection.
+    webhook.assert_called_once_with(ANY, status="failed", config=push)
 
 
 def test_resolve_identity_without_principal_id_raises_invalid_request():

--- a/tests/unit/test_a2a_task_identity_scope.py
+++ b/tests/unit/test_a2a_task_identity_scope.py
@@ -9,6 +9,10 @@ propagate as ``InvalidRequestError`` and do not collapse to not-found.
 
 from __future__ import annotations
 
+import ast
+import logging
+import re
+from pathlib import Path
 from unittest.mock import ANY, patch
 
 import pytest
@@ -24,7 +28,7 @@ from a2a.types import (
 )
 from sqlalchemy.exc import OperationalError
 
-from src.a2a_server.adcp_a2a_server import AdCPRequestHandler, _TaskOwner
+from src.a2a_server.adcp_a2a_server import AdCPRequestHandler, _task_not_found_message, _TaskOwner
 from src.core.exceptions import AdCPTaskNotFoundError
 from src.core.schemas import GetProductsResponse
 from tests.a2a_helpers import (
@@ -35,6 +39,7 @@ from tests.a2a_helpers import (
     OWNED_TASK_SIBLING_TOK,
     OWNED_TASK_TENANT,
     a2a_auth_as,
+    assert_task_not_found_nondisclosure,
     make_a2a_context,
     seeded_owned_a2a_handler,
     token_identity_resolver,
@@ -42,37 +47,32 @@ from tests.a2a_helpers import (
 from tests.factories import PrincipalFactory
 from tests.utils.a2a_helpers import create_a2a_text_message
 
-_TENANT = OWNED_TASK_TENANT
-_OWNER = OWNED_TASK_OWNER
-_SIBLING = OWNED_TASK_SIBLING
 _OTHER_TENANT = "tenant_b"
-_TASK_ID = OWNED_TASK_ID
-
-# Op ids passed to ``_authenticate`` — wire phrases must stay underscore-free.
-_AUTH_OPERATION_IDS = (
-    "get_task",
-    "cancel_task",
-    "get_push_notification_config",
-    "set_push_notification_config",
-    "list_push_notification_configs",
-    "delete_push_notification_config",
-)
+_OP_ID_RE = re.compile(r"^[a-z]+(_[a-z]+)*$")
+_A2A_SERVER = Path(__file__).resolve().parents[2] / "src" / "a2a_server" / "adcp_a2a_server.py"
 
 
-def _assert_not_found_matches(exc: TaskNotFoundError, task_id: str) -> None:
-    """Grades the exception object (not the JSON-RPC wire envelope).
+def _authenticate_operation_literals() -> list[str]:
+    """String literals passed as ``operation=`` into ``_authenticate`` / owned lookup."""
+    tree = ast.parse(_A2A_SERVER.read_text(), filename=str(_A2A_SERVER))
+    ops: list[str] = []
 
-    Literal message/data — never call ``_task_not_found`` for the expected side
-    (both sides would move together and hide an identity leak in the envelope).
-    """
-    assert exc.message == f"Task not found: {task_id}"
-    # Grades exception object ``data``, not the wire envelope (compat drops it).
-    assert exc.data == {"task_id": task_id}
-    blob = f"{exc.message}{exc.data!s}"
-    assert _TENANT not in blob
-    assert _OWNER not in blob
-    assert _SIBLING not in blob
-    assert "leaked_tenant" not in blob
+    class _Visitor(ast.NodeVisitor):
+        def visit_Call(self, node: ast.Call) -> None:
+            func = node.func
+            name = None
+            if isinstance(func, ast.Name):
+                name = func.id
+            elif isinstance(func, ast.Attribute):
+                name = func.attr
+            if name in {"_authenticate", "_get_owned_in_memory_task_or_raise"}:
+                for kw in node.keywords:
+                    if kw.arg == "operation" and isinstance(kw.value, ast.Constant) and isinstance(kw.value.value, str):
+                        ops.append(kw.value.value)
+            self.generic_visit(node)
+
+    _Visitor().visit(tree)
+    return ops
 
 
 @pytest.mark.asyncio
@@ -83,9 +83,13 @@ def _assert_not_found_matches(exc: TaskNotFoundError, task_id: str) -> None:
 async def test_create_records_owner_and_scopes_poll(request_cls, method_name):
     """Real constructor create→poll: owner allowed; sibling/other-tenant denied."""
     handler = AdCPRequestHandler()
-    owner = PrincipalFactory.make_identity(principal_id=_OWNER, tenant_id=_TENANT, protocol="a2a")
-    sibling = PrincipalFactory.make_identity(principal_id=_SIBLING, tenant_id=_TENANT, protocol="a2a")
-    other_tenant = PrincipalFactory.make_identity(principal_id=_OWNER, tenant_id=_OTHER_TENANT, protocol="a2a")
+    owner = PrincipalFactory.make_identity(principal_id=OWNED_TASK_OWNER, tenant_id=OWNED_TASK_TENANT, protocol="a2a")
+    sibling = PrincipalFactory.make_identity(
+        principal_id=OWNED_TASK_SIBLING, tenant_id=OWNED_TASK_TENANT, protocol="a2a"
+    )
+    other_tenant = PrincipalFactory.make_identity(
+        principal_id=OWNED_TASK_OWNER, tenant_id=_OTHER_TENANT, protocol="a2a"
+    )
     ctx = make_a2a_context(auth_token="test-token", headers={"host": "test.example.com"})
     params = SendMessageRequest(message=create_a2a_text_message("Show me available products in the catalog"))
 
@@ -95,7 +99,7 @@ async def test_create_records_owner_and_scopes_poll(request_cls, method_name):
             created = await handler.on_message_send(params, context=ctx)
 
     task_id = created.id
-    assert handler._task_owners[task_id] == _TaskOwner(tenant_id=_TENANT, principal_id=_OWNER)
+    assert handler._task_owners[task_id] == _TaskOwner(tenant_id=OWNED_TASK_TENANT, principal_id=OWNED_TASK_OWNER)
 
     with a2a_auth_as(handler, owner):
         task = await getattr(handler, method_name)(request_cls(id=task_id), context=None)
@@ -120,9 +124,9 @@ async def test_create_records_owner_and_scopes_poll(request_cls, method_name):
         with pytest.raises(TaskNotFoundError) as unknown_exc:
             await getattr(handler, method_name)(request_cls(id="task_does_not_exist"), context=None)
 
-    _assert_not_found_matches(sibling_exc.value, task_id)
-    _assert_not_found_matches(other_exc.value, task_id)
-    _assert_not_found_matches(unknown_exc.value, "task_does_not_exist")
+    assert_task_not_found_nondisclosure(sibling_exc.value, task_id)
+    assert_task_not_found_nondisclosure(other_exc.value, task_id)
+    assert_task_not_found_nondisclosure(unknown_exc.value, "task_does_not_exist")
     # Deny shape for the owned id matches the canonical not-found from this handler.
     assert sibling_exc.value.message == other_exc.value.message
     assert sibling_exc.value.data == other_exc.value.data
@@ -136,12 +140,14 @@ async def test_create_records_owner_and_scopes_poll(request_cls, method_name):
 async def test_owner_can_access_owned_in_memory_task(request_cls, method_name):
     """The recorded owner authenticates and is served / can cancel."""
     handler = seeded_owned_a2a_handler()
-    identity = PrincipalFactory.make_identity(principal_id=_OWNER, tenant_id=_TENANT, protocol="a2a")
+    identity = PrincipalFactory.make_identity(
+        principal_id=OWNED_TASK_OWNER, tenant_id=OWNED_TASK_TENANT, protocol="a2a"
+    )
 
     with a2a_auth_as(handler, identity):
-        task = await getattr(handler, method_name)(request_cls(id=_TASK_ID), context=None)
+        task = await getattr(handler, method_name)(request_cls(id=OWNED_TASK_ID), context=None)
 
-    assert task.id == _TASK_ID
+    assert task.id == OWNED_TASK_ID
     if method_name == "on_cancel_task":
         assert task.status.state == TaskState.TASK_STATE_CANCELED
     else:
@@ -156,36 +162,48 @@ async def test_owner_can_access_owned_in_memory_task(request_cls, method_name):
         (CancelTaskRequest, "on_cancel_task", "cancel_task"),
     ],
 )
-async def test_sibling_principal_denied_same_as_unknown(request_cls, method_name, operation):
+async def test_sibling_principal_denied_same_as_unknown(request_cls, method_name, operation, caplog):
     """Same-tenant sibling must not read or cancel — identical to unknown id."""
     handler = seeded_owned_a2a_handler()
-    sibling = PrincipalFactory.make_identity(principal_id=_SIBLING, tenant_id=_TENANT, protocol="a2a")
-    owner = PrincipalFactory.make_identity(principal_id=_OWNER, tenant_id=_TENANT, protocol="a2a")
+    sibling = PrincipalFactory.make_identity(
+        principal_id=OWNED_TASK_SIBLING, tenant_id=OWNED_TASK_TENANT, protocol="a2a"
+    )
+    owner = PrincipalFactory.make_identity(principal_id=OWNED_TASK_OWNER, tenant_id=OWNED_TASK_TENANT, protocol="a2a")
 
     with a2a_auth_as(handler, sibling):
         with patch("src.a2a_server.adcp_a2a_server.record_boundary_error") as record_error:
-            with pytest.raises(TaskNotFoundError) as deny_exc:
-                await getattr(handler, method_name)(request_cls(id=_TASK_ID), context=None)
+            with caplog.at_level(logging.WARNING, logger="src.a2a_server.adcp_a2a_server"):
+                with pytest.raises(TaskNotFoundError) as deny_exc:
+                    await getattr(handler, method_name)(request_cls(id=OWNED_TASK_ID), context=None)
 
     record_error.assert_called_once_with(
         "a2a",
         operation,
         ANY,
-        tenant_id=_TENANT,
-        principal_id=_SIBLING,
+        tenant_id=OWNED_TASK_TENANT,
+        principal_id=OWNED_TASK_SIBLING,
     )
     telem = record_error.call_args.args[2]
     assert type(telem) is AdCPTaskNotFoundError
-    assert telem.message == f"Task not found: {_TASK_ID}"
+    assert telem.message == _task_not_found_message(OWNED_TASK_ID)
+    assert any("Ownership denial for task" in r.getMessage() for r in caplog.records)
 
     with a2a_auth_as(handler, owner):
-        with pytest.raises(TaskNotFoundError) as unknown_exc:
-            await getattr(handler, method_name)(request_cls(id="task_does_not_exist"), context=None)
+        with patch("src.a2a_server.adcp_a2a_server.record_boundary_error") as record_unknown:
+            with caplog.at_level(logging.WARNING, logger="src.a2a_server.adcp_a2a_server"):
+                with pytest.raises(TaskNotFoundError) as unknown_exc:
+                    await getattr(handler, method_name)(request_cls(id="task_does_not_exist"), context=None)
 
-    _assert_not_found_matches(deny_exc.value, _TASK_ID)
-    _assert_not_found_matches(unknown_exc.value, "task_does_not_exist")
+    # Stale-handle / unknown-id: sinks self-skip (no tenant_id / principal_id).
+    record_unknown.assert_called_once_with("a2a", operation, ANY)
+    assert "tenant_id" not in record_unknown.call_args.kwargs
+    assert "principal_id" not in record_unknown.call_args.kwargs
+    assert any("Unknown task id on" in r.getMessage() for r in caplog.records)
+
+    assert_task_not_found_nondisclosure(deny_exc.value, OWNED_TASK_ID)
+    assert_task_not_found_nondisclosure(unknown_exc.value, "task_does_not_exist")
     # Sibling denial must not mutate cancel state.
-    assert handler.tasks[_TASK_ID].status.state == TaskState.TASK_STATE_COMPLETED
+    assert handler.tasks[OWNED_TASK_ID].status.state == TaskState.TASK_STATE_COMPLETED
 
 
 @pytest.mark.asyncio
@@ -213,15 +231,16 @@ async def test_auth_infra_failure_is_internal_error_not_task_not_found(request_c
         ),
     ):
         with pytest.raises(InternalError) as exc_info:
-            await getattr(handler, method_name)(request_cls(id=_TASK_ID), context=None)
+            await getattr(handler, method_name)(request_cls(id=OWNED_TASK_ID), context=None)
 
     raised = exc_info.value
-    assert type(raised) is InternalError
     assert raised.message == wire_message
     assert "_" not in raised.message
     # Recovery envelope attached (compat may still flatten ``data`` on the wire).
+    # Spec MUST: senders populate error.recovery on every error (error-handling.mdx).
     assert raised.data is not None
-    assert "adcp_error" in raised.data
+    assert raised.data["adcp_error"]["recovery"] == "transient"
+    assert raised.data["adcp_error"]["code"] == "SERVICE_UNAVAILABLE"
 
 
 @pytest.mark.asyncio
@@ -237,8 +256,10 @@ async def test_sibling_denied_via_real_auth_token_path(request_cls, method_name)
     alone would stay green.
     """
     handler = seeded_owned_a2a_handler()
-    owner = PrincipalFactory.make_identity(principal_id=_OWNER, tenant_id=_TENANT, protocol="a2a")
-    sibling = PrincipalFactory.make_identity(principal_id=_SIBLING, tenant_id=_TENANT, protocol="a2a")
+    owner = PrincipalFactory.make_identity(principal_id=OWNED_TASK_OWNER, tenant_id=OWNED_TASK_TENANT, protocol="a2a")
+    sibling = PrincipalFactory.make_identity(
+        principal_id=OWNED_TASK_SIBLING, tenant_id=OWNED_TASK_TENANT, protocol="a2a"
+    )
     resolve = token_identity_resolver(
         {
             OWNED_TASK_SIBLING_TOK: sibling,
@@ -249,15 +270,15 @@ async def test_sibling_denied_via_real_auth_token_path(request_cls, method_name)
     with patch("src.core.resolved_identity.resolve_identity", side_effect=resolve):
         sibling_ctx = make_a2a_context(auth_token=OWNED_TASK_SIBLING_TOK, headers={"host": "test.example.com"})
         with pytest.raises(TaskNotFoundError) as deny_exc:
-            await getattr(handler, method_name)(request_cls(id=_TASK_ID), context=sibling_ctx)
+            await getattr(handler, method_name)(request_cls(id=OWNED_TASK_ID), context=sibling_ctx)
 
         owner_ctx = make_a2a_context(auth_token=OWNED_TASK_OWNER_TOK, headers={"host": "test.example.com"})
         with pytest.raises(TaskNotFoundError) as unknown_exc:
             await getattr(handler, method_name)(request_cls(id="task_does_not_exist"), context=owner_ctx)
 
-    _assert_not_found_matches(deny_exc.value, _TASK_ID)
-    _assert_not_found_matches(unknown_exc.value, "task_does_not_exist")
-    assert handler.tasks[_TASK_ID].status.state == TaskState.TASK_STATE_COMPLETED
+    assert_task_not_found_nondisclosure(deny_exc.value, OWNED_TASK_ID)
+    assert_task_not_found_nondisclosure(unknown_exc.value, "task_does_not_exist")
+    assert handler.tasks[OWNED_TASK_ID].status.state == TaskState.TASK_STATE_COMPLETED
 
 
 @pytest.mark.asyncio
@@ -271,15 +292,15 @@ async def test_unauthenticated_poller_raises_invalid_request(request_cls, method
 
     with patch.object(handler, "_get_auth_token", return_value=None):
         with pytest.raises(InvalidRequestError):
-            await getattr(handler, method_name)(request_cls(id=_TASK_ID), context=None)
+            await getattr(handler, method_name)(request_cls(id=OWNED_TASK_ID), context=None)
 
-    assert handler.tasks[_TASK_ID].status.state == TaskState.TASK_STATE_COMPLETED
+    assert handler.tasks[OWNED_TASK_ID].status.state == TaskState.TASK_STATE_COMPLETED
 
 
 def test_resolve_identity_without_principal_id_raises_invalid_request():
     """Authenticated resolve with no principal_id hits the no-principal guard."""
     handler = AdCPRequestHandler()
-    no_principal = PrincipalFactory.make_identity(principal_id=None, tenant_id=_TENANT, protocol="a2a")
+    no_principal = PrincipalFactory.make_identity(principal_id=None, tenant_id=OWNED_TASK_TENANT, protocol="a2a")
     ctx = make_a2a_context(auth_token="tok", headers={"host": "test.example.com"})
 
     with patch("src.core.resolved_identity.resolve_identity", return_value=no_principal):
@@ -288,11 +309,18 @@ def test_resolve_identity_without_principal_id_raises_invalid_request():
 
 
 def test_auth_operation_ids_are_underscore_replaceable():
-    """Op ids passed to ``_authenticate`` must not need a hand-maintained phrase map."""
-    for op_id in _AUTH_OPERATION_IDS:
+    """Op ids reaching ``_authenticate`` must match snake_case (no hand-maintained map)."""
+    ops = _authenticate_operation_literals()
+    assert ops, "expected at least one operation= literal in adcp_a2a_server.py"
+    for op_id in ops:
+        assert _OP_ID_RE.fullmatch(op_id), f"op id {op_id!r} is not underscore-replaceable"
         phrase = op_id.replace("_", " ")
         assert "_" not in phrase
-        assert phrase == " ".join(op_id.split("_"))
+
+
+def test_anonymous_a2a_identity_has_no_testing_context():
+    """Anonymous factory must match production ``from_headers({})`` → None testing_context."""
+    assert PrincipalFactory.make_anonymous_a2a_identity().testing_context is None
 
 
 @pytest.mark.asyncio
@@ -307,7 +335,7 @@ async def test_discovery_create_records_anonymous_owner_without_auth():
     from tests.utils.a2a_helpers import create_a2a_message_with_skill
 
     handler = AdCPRequestHandler()
-    anonymous = PrincipalFactory.make_anonymous_a2a_identity(tenant_id=_TENANT)
+    anonymous = PrincipalFactory.make_anonymous_a2a_identity(tenant_id=OWNED_TASK_TENANT)
 
     async def raise_validation(params, identity):
         raise AdCPValidationError("synthetic discovery failure")
@@ -321,5 +349,5 @@ async def test_discovery_create_records_anonymous_owner_without_auth():
         )
 
     assert created.id in handler._task_owners
-    assert handler._task_owners[created.id] == _TaskOwner(tenant_id=_TENANT, principal_id=None)
+    assert handler._task_owners[created.id] == _TaskOwner(tenant_id=OWNED_TASK_TENANT, principal_id=None)
     assert created.id in handler.tasks

--- a/tests/unit/test_a2a_task_identity_scope.py
+++ b/tests/unit/test_a2a_task_identity_scope.py
@@ -39,6 +39,7 @@ from src.core.exceptions import AdCPTaskNotFoundError, AdCPValidationError
 from src.core.schemas import GetProductsResponse
 from tests.a2a_helpers import (
     OWNED_TASK_ID,
+    OWNED_TASK_OTHER_TENANT,
     OWNED_TASK_OWNER,
     OWNED_TASK_OWNER_TOK,
     OWNED_TASK_SIBLING,
@@ -55,7 +56,6 @@ from tests.a2a_helpers import (
 from tests.factories import PrincipalFactory
 from tests.utils.a2a_helpers import create_a2a_text_message
 
-_OTHER_TENANT = "tenant_b"
 _OP_ID_RE = re.compile(r"^[a-z]+(_[a-z]+)*$")
 _A2A_SERVER = Path(__file__).resolve().parents[2] / "src" / "a2a_server" / "adcp_a2a_server.py"
 
@@ -157,7 +157,7 @@ async def test_create_records_owner_and_scopes_poll(request_cls, method_name):
         principal_id=OWNED_TASK_SIBLING, tenant_id=OWNED_TASK_TENANT, protocol="a2a"
     )
     other_tenant = PrincipalFactory.make_identity(
-        principal_id=OWNED_TASK_OWNER, tenant_id=_OTHER_TENANT, protocol="a2a"
+        principal_id=OWNED_TASK_OWNER, tenant_id=OWNED_TASK_OTHER_TENANT, protocol="a2a"
     )
     ctx = make_a2a_context(auth_token="test-token", headers={"host": "test.example.com"})
     params = SendMessageRequest(message=create_a2a_text_message("Show me available products in the catalog"))

--- a/tests/unit/test_a2a_task_identity_scope.py
+++ b/tests/unit/test_a2a_task_identity_scope.py
@@ -9,7 +9,7 @@ propagate as ``InvalidRequestError`` and do not collapse to not-found.
 
 from __future__ import annotations
 
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 import pytest
 from a2a.types import (
@@ -150,10 +150,13 @@ async def test_owner_can_access_owned_in_memory_task(request_cls, method_name):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "request_cls, method_name",
-    [(GetTaskRequest, "on_get_task"), (CancelTaskRequest, "on_cancel_task")],
+    "request_cls, method_name, operation",
+    [
+        (GetTaskRequest, "on_get_task", "get_task"),
+        (CancelTaskRequest, "on_cancel_task", "cancel_task"),
+    ],
 )
-async def test_sibling_principal_denied_same_as_unknown(request_cls, method_name):
+async def test_sibling_principal_denied_same_as_unknown(request_cls, method_name, operation):
     """Same-tenant sibling must not read or cancel — identical to unknown id."""
     handler = seeded_owned_a2a_handler()
     sibling = PrincipalFactory.make_identity(principal_id=_SIBLING, tenant_id=_TENANT, protocol="a2a")
@@ -164,15 +167,16 @@ async def test_sibling_principal_denied_same_as_unknown(request_cls, method_name
             with pytest.raises(TaskNotFoundError) as deny_exc:
                 await getattr(handler, method_name)(request_cls(id=_TASK_ID), context=None)
 
-    record_error.assert_called_once()
-    call_kwargs = record_error.call_args
-    assert call_kwargs.args[0] == "a2a"
-    assert call_kwargs.args[1] in {"get_task", "cancel_task"}
-    telem = call_kwargs.args[2]
-    assert isinstance(telem, AdCPTaskNotFoundError)
-    assert not isinstance(telem, TaskNotFoundError)
-    assert call_kwargs.kwargs["tenant_id"] == _TENANT
-    assert call_kwargs.kwargs["principal_id"] == _SIBLING
+    record_error.assert_called_once_with(
+        "a2a",
+        operation,
+        ANY,
+        tenant_id=_TENANT,
+        principal_id=_SIBLING,
+    )
+    telem = record_error.call_args.args[2]
+    assert type(telem) is AdCPTaskNotFoundError
+    assert telem.message == f"Task not found: {_TASK_ID}"
 
     with a2a_auth_as(handler, owner):
         with pytest.raises(TaskNotFoundError) as unknown_exc:

--- a/tests/unit/test_a2a_task_identity_scope.py
+++ b/tests/unit/test_a2a_task_identity_scope.py
@@ -28,8 +28,14 @@ from a2a.types import (
 )
 from sqlalchemy.exc import OperationalError
 
-from src.a2a_server.adcp_a2a_server import AdCPRequestHandler, _task_not_found_message, _TaskOwner
-from src.core.exceptions import AdCPTaskNotFoundError
+from src.a2a_server.adcp_a2a_server import (
+    AdCPRequestHandler,
+    _internal_error_for,
+    _safe_task_id_for_log,
+    _task_not_found_message,
+    _TaskOwner,
+)
+from src.core.exceptions import AdCPTaskNotFoundError, AdCPValidationError
 from src.core.schemas import GetProductsResponse
 from tests.a2a_helpers import (
     OWNED_TASK_ID,
@@ -38,8 +44,10 @@ from tests.a2a_helpers import (
     OWNED_TASK_SIBLING,
     OWNED_TASK_SIBLING_TOK,
     OWNED_TASK_TENANT,
+    TASK_METHOD_MATRIX,
     a2a_auth_as,
     assert_task_not_found_nondisclosure,
+    invoke_owned_task_method,
     make_a2a_context,
     seeded_owned_a2a_handler,
     token_identity_resolver,
@@ -67,12 +75,73 @@ def _authenticate_operation_literals() -> list[str]:
                 name = func.attr
             if name in {"_authenticate", "_get_owned_in_memory_task_or_raise"}:
                 for kw in node.keywords:
-                    if kw.arg == "operation" and isinstance(kw.value, ast.Constant) and isinstance(kw.value.value, str):
-                        ops.append(kw.value.value)
+                    if kw.arg != "operation":
+                        continue
+                    # Parameter forward inside ``_get_owned_in_memory_task_or_raise``.
+                    if isinstance(kw.value, ast.Name) and kw.value.id == "operation":
+                        continue
+                    assert isinstance(kw.value, ast.Constant), (
+                        f"operation= must be a string Constant, got {type(kw.value).__name__}"
+                    )
+                    assert isinstance(kw.value.value, str), (
+                        f"operation= Constant must be str, got {type(kw.value.value).__name__}"
+                    )
+                    ops.append(kw.value.value)
             self.generic_visit(node)
 
     _Visitor().visit(tree)
     return ops
+
+
+def test_task_not_found_message_is_literal_contract():
+    """Buyer-facing formatter pinned by a hand-written literal (R5-B1)."""
+    assert _task_not_found_message("task_x") == "Task not found: task_x"
+
+
+def test_safe_task_id_for_log_escapes_and_truncates():
+    """Sanitizer oracle — allowlist + truncate (R5-C2 / R5-N1a)."""
+    assert _safe_task_id_for_log("a\nWARNING forged") == "a?WARNING?forged"
+    assert _safe_task_id_for_log("x" * 200) == "x" * 100
+    assert "\\" not in _safe_task_id_for_log("A" * 99 + "\r" + "B" * 50)
+
+
+@pytest.mark.parametrize(
+    "exc, expected_message, expected_code, expected_recovery",
+    [
+        (
+            RuntimeError("boom [SQL: SELECT x] [parameters: {'tok': 'secret'}]"),
+            "op failed",
+            "SERVICE_UNAVAILABLE",
+            "transient",
+        ),
+        (
+            AdCPValidationError("capability missing"),
+            "capability missing",
+            "VALIDATION_ERROR",
+            "correctable",
+        ),
+    ],
+)
+def test_internal_error_for_typed_and_untyped(exc, expected_message, expected_code, expected_recovery):
+    """``_internal_error_for`` branches pinned (R5-D2)."""
+    err = _internal_error_for("op", exc)
+    assert isinstance(err, InternalError)
+    assert err.message == expected_message
+    assert "[SQL:" not in err.message
+    assert "secret" not in err.message
+    assert err.data is not None
+    assert err.data["adcp_error"]["code"] == expected_code
+    assert err.data["adcp_error"]["recovery"] == expected_recovery
+
+
+def test_internal_error_for_sql_normalized_exception_stays_out_of_message():
+    """Normalized SQLAlchemy text must not reach InternalError.message (R5-D2)."""
+    sql_exc = OperationalError("SELECT principals.token WHERE tok=:tok", {"tok": "super-secret"}, None)
+    err = _internal_error_for("message processing", sql_exc)
+    assert err.message == "message processing failed"
+    blob = f"{err.message}{err.data!s}"
+    assert "super-secret" not in blob
+    assert "[SQL:" not in blob
 
 
 @pytest.mark.asyncio
@@ -102,7 +171,7 @@ async def test_create_records_owner_and_scopes_poll(request_cls, method_name):
     assert handler._task_owners[task_id] == _TaskOwner(tenant_id=OWNED_TASK_TENANT, principal_id=OWNED_TASK_OWNER)
 
     with a2a_auth_as(handler, owner):
-        task = await getattr(handler, method_name)(request_cls(id=task_id), context=None)
+        task = await invoke_owned_task_method(handler, method_name, request_cls, task_id)
     assert task.id == task_id
     if method_name == "on_cancel_task":
         assert task.status.state == TaskState.TASK_STATE_CANCELED
@@ -114,15 +183,15 @@ async def test_create_records_owner_and_scopes_poll(request_cls, method_name):
 
     with a2a_auth_as(handler, sibling):
         with pytest.raises(TaskNotFoundError) as sibling_exc:
-            await getattr(handler, method_name)(request_cls(id=task_id), context=None)
+            await invoke_owned_task_method(handler, method_name, request_cls, task_id)
 
     with a2a_auth_as(handler, other_tenant):
         with pytest.raises(TaskNotFoundError) as other_exc:
-            await getattr(handler, method_name)(request_cls(id=task_id), context=None)
+            await invoke_owned_task_method(handler, method_name, request_cls, task_id)
 
     with a2a_auth_as(handler, owner):
         with pytest.raises(TaskNotFoundError) as unknown_exc:
-            await getattr(handler, method_name)(request_cls(id="task_does_not_exist"), context=None)
+            await invoke_owned_task_method(handler, method_name, request_cls, "task_does_not_exist")
 
     assert_task_not_found_nondisclosure(sibling_exc.value, task_id)
     assert_task_not_found_nondisclosure(other_exc.value, task_id)
@@ -135,7 +204,7 @@ async def test_create_records_owner_and_scopes_poll(request_cls, method_name):
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "request_cls, method_name",
-    [(GetTaskRequest, "on_get_task"), (CancelTaskRequest, "on_cancel_task")],
+    [(row[0], row[1]) for row in TASK_METHOD_MATRIX],
 )
 async def test_owner_can_access_owned_in_memory_task(request_cls, method_name):
     """The recorded owner authenticates and is served / can cancel."""
@@ -145,7 +214,7 @@ async def test_owner_can_access_owned_in_memory_task(request_cls, method_name):
     )
 
     with a2a_auth_as(handler, identity):
-        task = await getattr(handler, method_name)(request_cls(id=OWNED_TASK_ID), context=None)
+        task = await invoke_owned_task_method(handler, method_name, request_cls, OWNED_TASK_ID)
 
     assert task.id == OWNED_TASK_ID
     if method_name == "on_cancel_task":
@@ -164,7 +233,8 @@ async def test_owner_can_access_owned_in_memory_task(request_cls, method_name):
 )
 async def test_sibling_principal_denied_same_as_unknown(request_cls, method_name, operation, caplog):
     """Same-tenant sibling must not read or cancel — identical to unknown id."""
-    handler = seeded_owned_a2a_handler()
+    forged_id = f"{OWNED_TASK_ID}\nWARNING forged"
+    handler = seeded_owned_a2a_handler(task_id=forged_id)
     sibling = PrincipalFactory.make_identity(
         principal_id=OWNED_TASK_SIBLING, tenant_id=OWNED_TASK_TENANT, protocol="a2a"
     )
@@ -174,36 +244,38 @@ async def test_sibling_principal_denied_same_as_unknown(request_cls, method_name
         with patch("src.a2a_server.adcp_a2a_server.record_boundary_error") as record_error:
             with caplog.at_level(logging.WARNING, logger="src.a2a_server.adcp_a2a_server"):
                 with pytest.raises(TaskNotFoundError) as deny_exc:
-                    await getattr(handler, method_name)(request_cls(id=OWNED_TASK_ID), context=None)
+                    await invoke_owned_task_method(handler, method_name, request_cls, forged_id)
 
-    record_error.assert_called_once_with(
-        "a2a",
-        operation,
-        ANY,
-        tenant_id=OWNED_TASK_TENANT,
-        principal_id=OWNED_TASK_SIBLING,
-    )
+    # Symmetric sinks — omit tenant/principal on both deny paths (R5-C1).
+    record_error.assert_called_once_with("a2a", operation, ANY)
+    assert "tenant_id" not in record_error.call_args.kwargs
+    assert "principal_id" not in record_error.call_args.kwargs
     telem = record_error.call_args.args[2]
     assert type(telem) is AdCPTaskNotFoundError
-    assert telem.message == _task_not_found_message(OWNED_TASK_ID)
-    assert any("Ownership denial for task" in r.getMessage() for r in caplog.records)
+    assert telem.message == f"Task not found: {_safe_task_id_for_log(forged_id)}"
+    assert any("Task access denied on" in r.getMessage() for r in caplog.records)
+    assert all("\n" not in r.getMessage() for r in caplog.records)
 
+    caplog.clear()
     with a2a_auth_as(handler, owner):
         with patch("src.a2a_server.adcp_a2a_server.record_boundary_error") as record_unknown:
             with caplog.at_level(logging.WARNING, logger="src.a2a_server.adcp_a2a_server"):
                 with pytest.raises(TaskNotFoundError) as unknown_exc:
-                    await getattr(handler, method_name)(request_cls(id="task_does_not_exist"), context=None)
+                    await invoke_owned_task_method(handler, method_name, request_cls, "task_does_not_exist")
 
-    # Stale-handle / unknown-id: sinks self-skip (no tenant_id / principal_id).
+    # Same kwargs shape as ownership miss (R5-C1 / R5-N2c).
     record_unknown.assert_called_once_with("a2a", operation, ANY)
     assert "tenant_id" not in record_unknown.call_args.kwargs
     assert "principal_id" not in record_unknown.call_args.kwargs
-    assert any("Unknown task id on" in r.getMessage() for r in caplog.records)
+    unknown_telem = record_unknown.call_args.args[2]
+    assert type(unknown_telem) is AdCPTaskNotFoundError
+    assert unknown_telem.message == f"Task not found: {_safe_task_id_for_log('task_does_not_exist')}"
+    assert any("Task access denied on" in r.getMessage() for r in caplog.records)
 
-    assert_task_not_found_nondisclosure(deny_exc.value, OWNED_TASK_ID)
+    assert_task_not_found_nondisclosure(deny_exc.value, forged_id)
     assert_task_not_found_nondisclosure(unknown_exc.value, "task_does_not_exist")
     # Sibling denial must not mutate cancel state.
-    assert handler.tasks[OWNED_TASK_ID].status.state == TaskState.TASK_STATE_COMPLETED
+    assert handler.tasks[forged_id].status.state == TaskState.TASK_STATE_COMPLETED
 
 
 @pytest.mark.asyncio
@@ -231,13 +303,13 @@ async def test_auth_infra_failure_is_internal_error_not_task_not_found(request_c
         ),
     ):
         with pytest.raises(InternalError) as exc_info:
-            await getattr(handler, method_name)(request_cls(id=OWNED_TASK_ID), context=None)
+            await invoke_owned_task_method(handler, method_name, request_cls, OWNED_TASK_ID)
 
     raised = exc_info.value
     assert raised.message == wire_message
     assert "_" not in raised.message
-    # Recovery envelope attached (compat may still flatten ``data`` on the wire).
-    # Spec MUST: senders populate error.recovery on every error (error-handling.mdx).
+    # Spec MUST: senders populate error.recovery on every error —
+    # by-layer/L3/error-handling.mdx § Forward-compatible decoding (normative), AdCP 3.1.1.
     assert raised.data is not None
     assert raised.data["adcp_error"]["recovery"] == "transient"
     assert raised.data["adcp_error"]["code"] == "SERVICE_UNAVAILABLE"
@@ -246,7 +318,7 @@ async def test_auth_infra_failure_is_internal_error_not_task_not_found(request_c
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "request_cls, method_name",
-    [(GetTaskRequest, "on_get_task"), (CancelTaskRequest, "on_cancel_task")],
+    [(row[0], row[1]) for row in TASK_METHOD_MATRIX],
 )
 async def test_sibling_denied_via_real_auth_token_path(request_cls, method_name):
     """Ownership compare with real ``_get_auth_token`` (only resolve_identity patched).
@@ -284,7 +356,7 @@ async def test_sibling_denied_via_real_auth_token_path(request_cls, method_name)
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "request_cls, method_name",
-    [(GetTaskRequest, "on_get_task"), (CancelTaskRequest, "on_cancel_task")],
+    [(row[0], row[1]) for row in TASK_METHOD_MATRIX],
 )
 async def test_unauthenticated_poller_raises_invalid_request(request_cls, method_name):
     """Missing token raises InvalidRequestError — must not collapse to TaskNotFoundError."""
@@ -292,9 +364,61 @@ async def test_unauthenticated_poller_raises_invalid_request(request_cls, method
 
     with patch.object(handler, "_get_auth_token", return_value=None):
         with pytest.raises(InvalidRequestError):
-            await getattr(handler, method_name)(request_cls(id=OWNED_TASK_ID), context=None)
+            await invoke_owned_task_method(handler, method_name, request_cls, OWNED_TASK_ID)
 
     assert handler.tasks[OWNED_TASK_ID].status.state == TaskState.TASK_STATE_COMPLETED
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "request_cls, method_name",
+    [(row[0], row[1]) for row in TASK_METHOD_MATRIX],
+)
+async def test_null_principal_denied_against_null_owner_row(request_cls, method_name):
+    """Null-principal identity must not match a (None, None) owner row (R5-A2)."""
+    handler = seeded_owned_a2a_handler(tenant_id=None, principal_id=None)
+    null_identity = PrincipalFactory.make_identity(principal_id=None, tenant_id=None, tenant=None, protocol="a2a")
+
+    with patch.object(handler, "_authenticate", return_value=null_identity):
+        with pytest.raises(TaskNotFoundError) as exc_info:
+            await invoke_owned_task_method(handler, method_name, request_cls, OWNED_TASK_ID)
+
+    assert_task_not_found_nondisclosure(exc_info.value, OWNED_TASK_ID)
+
+
+@pytest.mark.asyncio
+async def test_auth_resolve_failure_leaves_no_orphan_push_config():
+    """Resolve failure must not orphan ``_task_push_configs`` (R5-A1)."""
+    from a2a.types import SendMessageConfiguration, TaskPushNotificationConfig
+
+    from tests.utils.a2a_helpers import create_a2a_message_with_skill
+
+    handler = AdCPRequestHandler()
+    push = TaskPushNotificationConfig(url="https://example.com/hook")
+    params = SendMessageRequest(
+        message=create_a2a_message_with_skill("get_products", {"brief": "test"}),
+        configuration=SendMessageConfiguration(task_push_notification_config=push),
+    )
+    ctx = make_a2a_context(auth_token="tok", headers={"host": "test.example.com"})
+
+    with (
+        patch.object(handler, "_get_auth_token", return_value="tok"),
+        patch.object(
+            handler,
+            "_resolve_a2a_identity",
+            side_effect=RuntimeError("resolve exploded"),
+        ),
+        patch.object(handler, "_send_protocol_webhook", return_value=None) as webhook,
+    ):
+        with pytest.raises(InternalError):
+            await handler.on_message_send(params, context=ctx)
+
+    assert handler.tasks == {}
+    assert handler._task_owners == {}
+    assert handler._task_push_configs == {}
+    webhook.assert_called_once()
+    assert webhook.call_args.kwargs.get("config") == push
+    assert webhook.call_args.kwargs.get("config").url == "https://example.com/hook"
 
 
 def test_resolve_identity_without_principal_id_raises_invalid_request():
@@ -314,8 +438,6 @@ def test_auth_operation_ids_are_underscore_replaceable():
     assert ops, "expected at least one operation= literal in adcp_a2a_server.py"
     for op_id in ops:
         assert _OP_ID_RE.fullmatch(op_id), f"op id {op_id!r} is not underscore-replaceable"
-        phrase = op_id.replace("_", " ")
-        assert "_" not in phrase
 
 
 def test_anonymous_a2a_identity_has_no_testing_context():

--- a/tests/unit/test_a2a_task_identity_scope.py
+++ b/tests/unit/test_a2a_task_identity_scope.py
@@ -2,30 +2,41 @@
 
 A bare ``self.tasks.get(task_id)`` served (or canceled) any caller's request
 once they knew the id. These tests pin auth-first ownership against
-``_task_owners`` and prove wrong-principal / unauthenticated callers get the
-same ``TaskNotFoundError`` as an unknown id (no existence oracle).
+``_task_owners`` and prove wrong-principal callers get the same
+``TaskNotFoundError`` as an unknown id (no existence oracle). Auth failures
+propagate as ``InvalidRequestError`` and do not collapse to not-found.
 """
 
 from __future__ import annotations
 
+import uuid
+from contextlib import contextmanager
 from unittest.mock import patch
 
 import pytest
 from a2a.types import (
     CancelTaskRequest,
     GetTaskRequest,
+    InvalidRequestError,
+    Message,
+    Part,
+    Role,
+    SendMessageRequest,
     Task,
     TaskNotFoundError,
     TaskState,
     TaskStatus,
 )
 
-from src.a2a_server.adcp_a2a_server import AdCPRequestHandler
+from src.a2a_server.adcp_a2a_server import AdCPRequestHandler, _TaskOwner
+from src.core.schemas import GetProductsResponse
+from tests.a2a_helpers import make_a2a_context
 from tests.factories import PrincipalFactory
 
 _TENANT = "tenant_a"
 _OWNER = "principal_owner"
 _SIBLING = "principal_sibling"
+_OTHER_TENANT = "tenant_b"
 _TASK_ID = "task_owned_abc"
 
 
@@ -33,9 +44,88 @@ def _owned_handler() -> AdCPRequestHandler:
     handler = AdCPRequestHandler.__new__(AdCPRequestHandler)
     done = Task(id=_TASK_ID, status=TaskStatus(state=TaskState.TASK_STATE_COMPLETED))
     handler.tasks = {_TASK_ID: done}
-    handler._task_owners = {_TASK_ID: (_TENANT, _OWNER)}
-    handler._task_push_configs = {}
+    handler._task_owners = {_TASK_ID: _TaskOwner(tenant_id=_TENANT, principal_id=_OWNER)}
     return handler
+
+
+@contextmanager
+def a2a_auth_as(handler: AdCPRequestHandler, identity):
+    """Patch token extract + identity resolve for a single authenticated call."""
+    with (
+        patch.object(handler, "_get_auth_token", return_value="tok"),
+        patch.object(handler, "_resolve_a2a_identity", return_value=identity),
+    ):
+        yield
+
+
+def _make_nl_message(text: str) -> SendMessageRequest:
+    message = Message(
+        message_id=str(uuid.uuid4()),
+        role=Role.ROLE_USER,
+    )
+    message.parts.append(Part(text=text))
+    return SendMessageRequest(message=message)
+
+
+def _assert_not_found_matches(exc: TaskNotFoundError, task_id: str) -> None:
+    """Grades the exception object (not the JSON-RPC wire envelope)."""
+    expected = AdCPRequestHandler._task_not_found(task_id)
+    assert exc.message == expected.message
+    # Grades exception object ``data``, not the wire envelope (compat drops it).
+    assert exc.data == expected.data
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "request_cls, method_name",
+    [(GetTaskRequest, "on_get_task"), (CancelTaskRequest, "on_cancel_task")],
+)
+async def test_create_records_owner_and_scopes_poll(request_cls, method_name):
+    """Real constructor create→poll: owner allowed; sibling/other-tenant denied."""
+    handler = AdCPRequestHandler()
+    owner = PrincipalFactory.make_identity(principal_id=_OWNER, tenant_id=_TENANT, protocol="a2a")
+    sibling = PrincipalFactory.make_identity(principal_id=_SIBLING, tenant_id=_TENANT, protocol="a2a")
+    other_tenant = PrincipalFactory.make_identity(principal_id=_OWNER, tenant_id=_OTHER_TENANT, protocol="a2a")
+    ctx = make_a2a_context(auth_token="test-token", headers={"host": "test.example.com"})
+    params = _make_nl_message("Show me available products in the catalog")
+
+    with patch("src.core.resolved_identity.resolve_identity", return_value=owner):
+        with patch("src.a2a_server.adcp_a2a_server.core_get_products_tool") as mock_products:
+            mock_products.return_value = GetProductsResponse(products=[])
+            created = await handler.on_message_send(params, context=ctx)
+
+    task_id = created.id
+    assert handler._task_owners[task_id] == _TaskOwner(tenant_id=_TENANT, principal_id=_OWNER)
+
+    with a2a_auth_as(handler, owner):
+        task = await getattr(handler, method_name)(request_cls(id=task_id), context=None)
+    assert task.id == task_id
+    if method_name == "on_cancel_task":
+        assert task.status.state == TaskState.TASK_STATE_CANCELED
+    else:
+        assert task.status.state == TaskState.TASK_STATE_COMPLETED
+
+    # Re-seed completed state so deny checks do not depend on cancel mutation.
+    handler.tasks[task_id].status.CopyFrom(TaskStatus(state=TaskState.TASK_STATE_COMPLETED))
+
+    with a2a_auth_as(handler, sibling):
+        with pytest.raises(TaskNotFoundError) as sibling_exc:
+            await getattr(handler, method_name)(request_cls(id=task_id), context=None)
+
+    with a2a_auth_as(handler, other_tenant):
+        with pytest.raises(TaskNotFoundError) as other_exc:
+            await getattr(handler, method_name)(request_cls(id=task_id), context=None)
+
+    with a2a_auth_as(handler, owner):
+        with pytest.raises(TaskNotFoundError) as unknown_exc:
+            await getattr(handler, method_name)(request_cls(id="task_does_not_exist"), context=None)
+
+    _assert_not_found_matches(sibling_exc.value, task_id)
+    _assert_not_found_matches(other_exc.value, task_id)
+    _assert_not_found_matches(unknown_exc.value, "task_does_not_exist")
+    # Deny shape for the owned id matches the canonical not-found from this handler.
+    assert sibling_exc.value.message == other_exc.value.message
+    assert sibling_exc.value.data == other_exc.value.data
 
 
 @pytest.mark.asyncio
@@ -48,13 +138,9 @@ async def test_owner_can_access_owned_in_memory_task(request_cls, method_name):
     handler = _owned_handler()
     identity = PrincipalFactory.make_identity(principal_id=_OWNER, tenant_id=_TENANT, protocol="a2a")
 
-    with (
-        patch.object(handler, "_get_auth_token", return_value="tok") as mock_auth,
-        patch.object(handler, "_resolve_a2a_identity", return_value=identity),
-    ):
+    with a2a_auth_as(handler, identity):
         task = await getattr(handler, method_name)(request_cls(id=_TASK_ID), context=None)
 
-    mock_auth.assert_called_once_with(None)
     assert task.id == _TASK_ID
     if method_name == "on_cancel_task":
         assert task.status.state == TaskState.TASK_STATE_CANCELED
@@ -71,15 +157,18 @@ async def test_sibling_principal_denied_same_as_unknown(request_cls, method_name
     """Same-tenant sibling must not read or cancel — identical to unknown id."""
     handler = _owned_handler()
     sibling = PrincipalFactory.make_identity(principal_id=_SIBLING, tenant_id=_TENANT, protocol="a2a")
+    owner = PrincipalFactory.make_identity(principal_id=_OWNER, tenant_id=_TENANT, protocol="a2a")
 
-    with (
-        patch.object(handler, "_get_auth_token", return_value="tok"),
-        patch.object(handler, "_resolve_a2a_identity", return_value=sibling),
-    ):
-        with pytest.raises(TaskNotFoundError) as exc:
+    with a2a_auth_as(handler, sibling):
+        with pytest.raises(TaskNotFoundError) as deny_exc:
             await getattr(handler, method_name)(request_cls(id=_TASK_ID), context=None)
 
-    assert exc.value.data == {"task_id": _TASK_ID}
+    with a2a_auth_as(handler, owner):
+        with pytest.raises(TaskNotFoundError) as unknown_exc:
+            await getattr(handler, method_name)(request_cls(id="task_does_not_exist"), context=None)
+
+    _assert_not_found_matches(deny_exc.value, _TASK_ID)
+    _assert_not_found_matches(unknown_exc.value, "task_does_not_exist")
     # Sibling denial must not mutate cancel state.
     assert handler.tasks[_TASK_ID].status.state == TaskState.TASK_STATE_COMPLETED
 
@@ -89,51 +178,23 @@ async def test_sibling_principal_denied_same_as_unknown(request_cls, method_name
     "request_cls, method_name",
     [(GetTaskRequest, "on_get_task"), (CancelTaskRequest, "on_cancel_task")],
 )
-async def test_unauthenticated_poller_denied_same_as_unknown(request_cls, method_name):
-    """Auth failure collapses to TaskNotFoundError — no anonymous content oracle."""
+async def test_unauthenticated_poller_raises_invalid_request(request_cls, method_name):
+    """Missing token raises InvalidRequestError — must not collapse to TaskNotFoundError."""
     handler = _owned_handler()
 
-    with (
-        patch.object(handler, "_get_auth_token", return_value=None),
-        patch.object(
-            handler,
-            "_resolve_a2a_identity",
-            side_effect=Exception("Missing authentication token"),
-        ),
-    ):
-        with pytest.raises(TaskNotFoundError) as exc:
+    with patch.object(handler, "_get_auth_token", return_value=None):
+        with pytest.raises(InvalidRequestError):
             await getattr(handler, method_name)(request_cls(id=_TASK_ID), context=None)
 
-    assert exc.value.data == {"task_id": _TASK_ID}
     assert handler.tasks[_TASK_ID].status.state == TaskState.TASK_STATE_COMPLETED
 
 
-@pytest.mark.asyncio
-async def test_ownership_gate_mutation_proof():
-    """If ownership equality is dropped, sibling get leaks; with it, denied.
+def test_resolve_identity_without_principal_id_raises_invalid_request():
+    """Authenticated resolve with no principal_id hits the :290-291 guard."""
+    handler = AdCPRequestHandler()
+    no_principal = PrincipalFactory.make_identity(principal_id=None, tenant_id=_TENANT, protocol="a2a")
+    ctx = make_a2a_context(auth_token="tok", headers={"host": "test.example.com"})
 
-    Plan mutation proof: temporarily serve bare ``self.tasks.get`` (pre-#1702),
-    confirm the sibling leak, then restore the owned helper and confirm deny.
-    """
-    handler = _owned_handler()
-    sibling = PrincipalFactory.make_identity(principal_id=_SIBLING, tenant_id=_TENANT, protocol="a2a")
-
-    def bare_tasks_get(task_id: str, context):  # noqa: ARG001 — mirrors pre-fix signature
-        task = handler.tasks.get(task_id)
-        assert task is not None
-        return task
-
-    with (
-        patch.object(handler, "_get_auth_token", return_value="tok"),
-        patch.object(handler, "_resolve_a2a_identity", return_value=sibling),
-        patch.object(handler, "_get_owned_in_memory_task_or_raise", side_effect=bare_tasks_get),
-    ):
-        leaked = await handler.on_get_task(GetTaskRequest(id=_TASK_ID), context=None)
-    assert leaked is handler.tasks[_TASK_ID]
-
-    with (
-        patch.object(handler, "_get_auth_token", return_value="tok"),
-        patch.object(handler, "_resolve_a2a_identity", return_value=sibling),
-    ):
-        with pytest.raises(TaskNotFoundError):
-            await handler.on_get_task(GetTaskRequest(id=_TASK_ID), context=None)
+    with patch("src.core.resolved_identity.resolve_identity", return_value=no_principal):
+        with pytest.raises(InvalidRequestError, match="invalid or expired"):
+            handler._resolve_a2a_identity("tok", require_valid_token=True, context=ctx)

--- a/tests/unit/test_a2a_task_identity_scope.py
+++ b/tests/unit/test_a2a_task_identity_scope.py
@@ -198,3 +198,38 @@ def test_resolve_identity_without_principal_id_raises_invalid_request():
     with patch("src.core.resolved_identity.resolve_identity", return_value=no_principal):
         with pytest.raises(InvalidRequestError, match="invalid or expired"):
             handler._resolve_a2a_identity("tok", require_valid_token=True, context=ctx)
+
+
+@pytest.mark.asyncio
+async def test_discovery_create_records_anonymous_owner_without_auth():
+    """Unauthenticated discovery records owner from ResolvedIdentity (never None).
+
+    Regression for Integration infra: mocking ``_resolve_a2a_identity`` to return
+    ``None`` passed before create+own co-location, then AttributeError on
+    ``identity.tenant_id``. Production always returns ResolvedIdentity.
+    """
+    from src.core.exceptions import AdCPValidationError
+    from tests.utils.a2a_helpers import create_a2a_message_with_skill
+
+    handler = AdCPRequestHandler()
+    anonymous = PrincipalFactory.make_identity(
+        principal_id=None,
+        tenant_id=_TENANT,
+        tenant=None,
+        protocol="a2a",
+    )
+
+    async def raise_validation(params, identity):
+        raise AdCPValidationError("synthetic discovery failure")
+
+    with patch.object(handler, "_handle_get_products_skill", raise_validation):
+        handler._get_auth_token = lambda context=None: None
+        handler._resolve_a2a_identity = lambda *args, **kwargs: anonymous
+        created = await handler.on_message_send(
+            SendMessageRequest(message=create_a2a_message_with_skill("get_products", {"brief": "test"})),
+            context=make_a2a_context(auth_token=None),
+        )
+
+    assert created.id in handler._task_owners
+    assert handler._task_owners[created.id] == _TaskOwner(tenant_id=_TENANT, principal_id=None)
+    assert created.id in handler.tasks

--- a/tests/unit/test_a2a_task_identity_scope.py
+++ b/tests/unit/test_a2a_task_identity_scope.py
@@ -17,8 +17,6 @@ from unittest.mock import ANY, patch
 
 import pytest
 from a2a.types import (
-    CancelTaskRequest,
-    GetTaskRequest,
     InternalError,
     InvalidRequestError,
     SendMessageRequest,
@@ -38,20 +36,23 @@ from src.a2a_server.adcp_a2a_server import (
 from src.core.exceptions import AdCPTaskNotFoundError, AdCPValidationError
 from src.core.schemas import GetProductsResponse
 from tests.a2a_helpers import (
+    A2A_TEST_HOST_HEADERS,
     OWNED_TASK_ID,
     OWNED_TASK_OTHER_TENANT,
     OWNED_TASK_OWNER,
     OWNED_TASK_OWNER_TOK,
-    OWNED_TASK_SIBLING,
     OWNED_TASK_SIBLING_TOK,
     OWNED_TASK_TENANT,
     TASK_METHOD_MATRIX,
     a2a_auth_as,
     assert_task_not_found_nondisclosure,
+    auth_operation_wire_phrase,
     invoke_owned_task_method,
     make_a2a_context,
+    owned_task_owner_identity,
+    owned_task_sibling_identity,
     seeded_owned_a2a_handler,
-    token_identity_resolver,
+    seeded_owner_sibling_resolver,
 )
 from tests.factories import PrincipalFactory
 from tests.utils.a2a_helpers import create_a2a_text_message
@@ -99,10 +100,14 @@ def test_task_not_found_message_is_literal_contract():
 
 
 def test_safe_task_id_for_log_escapes_and_truncates():
-    """Sanitizer oracle — allowlist + truncate (R5-C2 / R5-N1a)."""
+    """Sanitizer oracle — allowlist + truncate-after-substitute (R5-C2 / R5-N1a)."""
     assert _safe_task_id_for_log("a\nWARNING forged") == "a?WARNING?forged"
     assert _safe_task_id_for_log("x" * 200) == "x" * 100
-    assert "\\" not in _safe_task_id_for_log("A" * 99 + "\r" + "B" * 50)
+    # Exact 100-char prefix with a non-allowlisted char in the truncate window.
+    raw = "A" * 99 + "\r" + "B" * 50
+    sanitized = _safe_task_id_for_log(raw)
+    assert sanitized == "A" * 99 + "?"
+    assert len(sanitized) == 100
 
 
 @pytest.mark.parametrize(
@@ -147,19 +152,15 @@ def test_internal_error_for_sql_normalized_exception_stays_out_of_message():
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "request_cls, method_name",
-    [(GetTaskRequest, "on_get_task"), (CancelTaskRequest, "on_cancel_task")],
+    [(row[0], row[1]) for row in TASK_METHOD_MATRIX],
 )
 async def test_create_records_owner_and_scopes_poll(request_cls, method_name):
     """Real constructor create→poll: owner allowed; sibling/other-tenant denied."""
     handler = AdCPRequestHandler()
-    owner = PrincipalFactory.make_identity(principal_id=OWNED_TASK_OWNER, tenant_id=OWNED_TASK_TENANT, protocol="a2a")
-    sibling = PrincipalFactory.make_identity(
-        principal_id=OWNED_TASK_SIBLING, tenant_id=OWNED_TASK_TENANT, protocol="a2a"
-    )
-    other_tenant = PrincipalFactory.make_identity(
-        principal_id=OWNED_TASK_OWNER, tenant_id=OWNED_TASK_OTHER_TENANT, protocol="a2a"
-    )
-    ctx = make_a2a_context(auth_token="test-token", headers={"host": "test.example.com"})
+    owner = owned_task_owner_identity()
+    sibling = owned_task_sibling_identity()
+    other_tenant = owned_task_owner_identity(tenant_id=OWNED_TASK_OTHER_TENANT)
+    ctx = make_a2a_context(auth_token="test-token", headers=A2A_TEST_HOST_HEADERS)
     params = SendMessageRequest(message=create_a2a_text_message("Show me available products in the catalog"))
 
     with patch("src.core.resolved_identity.resolve_identity", return_value=owner):
@@ -209,9 +210,7 @@ async def test_create_records_owner_and_scopes_poll(request_cls, method_name):
 async def test_owner_can_access_owned_in_memory_task(request_cls, method_name):
     """The recorded owner authenticates and is served / can cancel."""
     handler = seeded_owned_a2a_handler()
-    identity = PrincipalFactory.make_identity(
-        principal_id=OWNED_TASK_OWNER, tenant_id=OWNED_TASK_TENANT, protocol="a2a"
-    )
+    identity = owned_task_owner_identity()
 
     with a2a_auth_as(handler, identity):
         task = await invoke_owned_task_method(handler, method_name, request_cls, OWNED_TASK_ID)
@@ -226,19 +225,14 @@ async def test_owner_can_access_owned_in_memory_task(request_cls, method_name):
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "request_cls, method_name, operation",
-    [
-        (GetTaskRequest, "on_get_task", "get_task"),
-        (CancelTaskRequest, "on_cancel_task", "cancel_task"),
-    ],
+    [(row[0], row[1], row[3]) for row in TASK_METHOD_MATRIX],
 )
 async def test_sibling_principal_denied_same_as_unknown(request_cls, method_name, operation, caplog):
     """Same-tenant sibling must not read or cancel — identical to unknown id."""
     forged_id = f"{OWNED_TASK_ID}\nWARNING forged"
     handler = seeded_owned_a2a_handler(task_id=forged_id)
-    sibling = PrincipalFactory.make_identity(
-        principal_id=OWNED_TASK_SIBLING, tenant_id=OWNED_TASK_TENANT, protocol="a2a"
-    )
-    owner = PrincipalFactory.make_identity(principal_id=OWNED_TASK_OWNER, tenant_id=OWNED_TASK_TENANT, protocol="a2a")
+    sibling = owned_task_sibling_identity()
+    owner = owned_task_owner_identity()
 
     with a2a_auth_as(handler, sibling):
         with patch("src.a2a_server.adcp_a2a_server.record_boundary_error") as record_error:
@@ -281,10 +275,7 @@ async def test_sibling_principal_denied_same_as_unknown(request_cls, method_name
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "request_cls, method_name, wire_message",
-    [
-        (GetTaskRequest, "on_get_task", "get task failed"),
-        (CancelTaskRequest, "on_cancel_task", "cancel task failed"),
-    ],
+    [(row[0], row[1], auth_operation_wire_phrase(row[3])) for row in TASK_METHOD_MATRIX],
 )
 async def test_auth_infra_failure_is_internal_error_not_task_not_found(request_cls, method_name, wire_message):
     """DB/infra failure during identity resolve must not collapse to TaskNotFoundError.
@@ -328,23 +319,14 @@ async def test_sibling_denied_via_real_auth_token_path(request_cls, method_name)
     alone would stay green.
     """
     handler = seeded_owned_a2a_handler()
-    owner = PrincipalFactory.make_identity(principal_id=OWNED_TASK_OWNER, tenant_id=OWNED_TASK_TENANT, protocol="a2a")
-    sibling = PrincipalFactory.make_identity(
-        principal_id=OWNED_TASK_SIBLING, tenant_id=OWNED_TASK_TENANT, protocol="a2a"
-    )
-    resolve = token_identity_resolver(
-        {
-            OWNED_TASK_SIBLING_TOK: sibling,
-            OWNED_TASK_OWNER_TOK: owner,
-        }
-    )
+    resolve = seeded_owner_sibling_resolver()
 
     with patch("src.core.resolved_identity.resolve_identity", side_effect=resolve):
-        sibling_ctx = make_a2a_context(auth_token=OWNED_TASK_SIBLING_TOK, headers={"host": "test.example.com"})
+        sibling_ctx = make_a2a_context(auth_token=OWNED_TASK_SIBLING_TOK, headers=A2A_TEST_HOST_HEADERS)
         with pytest.raises(TaskNotFoundError) as deny_exc:
             await getattr(handler, method_name)(request_cls(id=OWNED_TASK_ID), context=sibling_ctx)
 
-        owner_ctx = make_a2a_context(auth_token=OWNED_TASK_OWNER_TOK, headers={"host": "test.example.com"})
+        owner_ctx = make_a2a_context(auth_token=OWNED_TASK_OWNER_TOK, headers=A2A_TEST_HOST_HEADERS)
         with pytest.raises(TaskNotFoundError) as unknown_exc:
             await getattr(handler, method_name)(request_cls(id="task_does_not_exist"), context=owner_ctx)
 
@@ -399,7 +381,7 @@ async def test_auth_resolve_failure_leaves_no_orphan_push_config():
         message=create_a2a_message_with_skill("get_products", {"brief": "test"}),
         configuration=SendMessageConfiguration(task_push_notification_config=push),
     )
-    ctx = make_a2a_context(auth_token="tok", headers={"host": "test.example.com"})
+    ctx = make_a2a_context(auth_token="tok", headers=A2A_TEST_HOST_HEADERS)
 
     with (
         patch.object(handler, "_get_auth_token", return_value="tok"),
@@ -425,7 +407,7 @@ def test_resolve_identity_without_principal_id_raises_invalid_request():
     """Authenticated resolve with no principal_id hits the no-principal guard."""
     handler = AdCPRequestHandler()
     no_principal = PrincipalFactory.make_identity(principal_id=None, tenant_id=OWNED_TASK_TENANT, protocol="a2a")
-    ctx = make_a2a_context(auth_token="tok", headers={"host": "test.example.com"})
+    ctx = make_a2a_context(auth_token="tok", headers=A2A_TEST_HOST_HEADERS)
 
     with patch("src.core.resolved_identity.resolve_identity", return_value=no_principal):
         with pytest.raises(InvalidRequestError, match="invalid or expired"):

--- a/tests/unit/test_a2a_task_identity_scope.py
+++ b/tests/unit/test_a2a_task_identity_scope.py
@@ -9,7 +9,6 @@ propagate as ``InvalidRequestError`` and do not collapse to not-found.
 
 from __future__ import annotations
 
-import uuid
 from unittest.mock import patch
 
 import pytest
@@ -18,11 +17,7 @@ from a2a.types import (
     GetTaskRequest,
     InternalError,
     InvalidRequestError,
-    Message,
-    Part,
-    Role,
     SendMessageRequest,
-    Task,
     TaskNotFoundError,
     TaskState,
     TaskStatus,
@@ -30,40 +25,54 @@ from a2a.types import (
 from sqlalchemy.exc import OperationalError
 
 from src.a2a_server.adcp_a2a_server import AdCPRequestHandler, _TaskOwner
+from src.core.exceptions import AdCPTaskNotFoundError
 from src.core.schemas import GetProductsResponse
-from tests.a2a_helpers import a2a_auth_as, make_a2a_context
+from tests.a2a_helpers import (
+    OWNED_TASK_ID,
+    OWNED_TASK_OWNER,
+    OWNED_TASK_OWNER_TOK,
+    OWNED_TASK_SIBLING,
+    OWNED_TASK_SIBLING_TOK,
+    OWNED_TASK_TENANT,
+    a2a_auth_as,
+    make_a2a_context,
+    seeded_owned_a2a_handler,
+    token_identity_resolver,
+)
 from tests.factories import PrincipalFactory
+from tests.utils.a2a_helpers import create_a2a_text_message
 
-_TENANT = "tenant_a"
-_OWNER = "principal_owner"
-_SIBLING = "principal_sibling"
+_TENANT = OWNED_TASK_TENANT
+_OWNER = OWNED_TASK_OWNER
+_SIBLING = OWNED_TASK_SIBLING
 _OTHER_TENANT = "tenant_b"
-_TASK_ID = "task_owned_abc"
+_TASK_ID = OWNED_TASK_ID
 
-
-def _owned_handler() -> AdCPRequestHandler:
-    handler = AdCPRequestHandler.__new__(AdCPRequestHandler)
-    done = Task(id=_TASK_ID, status=TaskStatus(state=TaskState.TASK_STATE_COMPLETED))
-    handler.tasks = {_TASK_ID: done}
-    handler._task_owners = {_TASK_ID: _TaskOwner(tenant_id=_TENANT, principal_id=_OWNER)}
-    return handler
-
-
-def _make_nl_message(text: str) -> SendMessageRequest:
-    message = Message(
-        message_id=str(uuid.uuid4()),
-        role=Role.ROLE_USER,
-    )
-    message.parts.append(Part(text=text))
-    return SendMessageRequest(message=message)
+# Op ids passed to ``_authenticate`` — wire phrases must stay underscore-free.
+_AUTH_OPERATION_IDS = (
+    "get_task",
+    "cancel_task",
+    "get_push_notification_config",
+    "set_push_notification_config",
+    "list_push_notification_configs",
+    "delete_push_notification_config",
+)
 
 
 def _assert_not_found_matches(exc: TaskNotFoundError, task_id: str) -> None:
-    """Grades the exception object (not the JSON-RPC wire envelope)."""
-    expected = AdCPRequestHandler._task_not_found(task_id)
-    assert exc.message == expected.message
+    """Grades the exception object (not the JSON-RPC wire envelope).
+
+    Literal message/data — never call ``_task_not_found`` for the expected side
+    (both sides would move together and hide an identity leak in the envelope).
+    """
+    assert exc.message == f"Task not found: {task_id}"
     # Grades exception object ``data``, not the wire envelope (compat drops it).
-    assert exc.data == expected.data
+    assert exc.data == {"task_id": task_id}
+    blob = f"{exc.message}{exc.data!s}"
+    assert _TENANT not in blob
+    assert _OWNER not in blob
+    assert _SIBLING not in blob
+    assert "leaked_tenant" not in blob
 
 
 @pytest.mark.asyncio
@@ -78,7 +87,7 @@ async def test_create_records_owner_and_scopes_poll(request_cls, method_name):
     sibling = PrincipalFactory.make_identity(principal_id=_SIBLING, tenant_id=_TENANT, protocol="a2a")
     other_tenant = PrincipalFactory.make_identity(principal_id=_OWNER, tenant_id=_OTHER_TENANT, protocol="a2a")
     ctx = make_a2a_context(auth_token="test-token", headers={"host": "test.example.com"})
-    params = _make_nl_message("Show me available products in the catalog")
+    params = SendMessageRequest(message=create_a2a_text_message("Show me available products in the catalog"))
 
     with patch("src.core.resolved_identity.resolve_identity", return_value=owner):
         with patch("src.a2a_server.adcp_a2a_server.core_get_products_tool") as mock_products:
@@ -126,7 +135,7 @@ async def test_create_records_owner_and_scopes_poll(request_cls, method_name):
 )
 async def test_owner_can_access_owned_in_memory_task(request_cls, method_name):
     """The recorded owner authenticates and is served / can cancel."""
-    handler = _owned_handler()
+    handler = seeded_owned_a2a_handler()
     identity = PrincipalFactory.make_identity(principal_id=_OWNER, tenant_id=_TENANT, protocol="a2a")
 
     with a2a_auth_as(handler, identity):
@@ -146,13 +155,24 @@ async def test_owner_can_access_owned_in_memory_task(request_cls, method_name):
 )
 async def test_sibling_principal_denied_same_as_unknown(request_cls, method_name):
     """Same-tenant sibling must not read or cancel — identical to unknown id."""
-    handler = _owned_handler()
+    handler = seeded_owned_a2a_handler()
     sibling = PrincipalFactory.make_identity(principal_id=_SIBLING, tenant_id=_TENANT, protocol="a2a")
     owner = PrincipalFactory.make_identity(principal_id=_OWNER, tenant_id=_TENANT, protocol="a2a")
 
     with a2a_auth_as(handler, sibling):
-        with pytest.raises(TaskNotFoundError) as deny_exc:
-            await getattr(handler, method_name)(request_cls(id=_TASK_ID), context=None)
+        with patch("src.a2a_server.adcp_a2a_server.record_boundary_error") as record_error:
+            with pytest.raises(TaskNotFoundError) as deny_exc:
+                await getattr(handler, method_name)(request_cls(id=_TASK_ID), context=None)
+
+    record_error.assert_called_once()
+    call_kwargs = record_error.call_args
+    assert call_kwargs.args[0] == "a2a"
+    assert call_kwargs.args[1] in {"get_task", "cancel_task"}
+    telem = call_kwargs.args[2]
+    assert isinstance(telem, AdCPTaskNotFoundError)
+    assert not isinstance(telem, TaskNotFoundError)
+    assert call_kwargs.kwargs["tenant_id"] == _TENANT
+    assert call_kwargs.kwargs["principal_id"] == _SIBLING
 
     with a2a_auth_as(handler, owner):
         with pytest.raises(TaskNotFoundError) as unknown_exc:
@@ -178,7 +198,7 @@ async def test_auth_infra_failure_is_internal_error_not_task_not_found(request_c
     Mutating the ``_authenticate`` except branch back to ``_task_not_found`` must
     redden this test: buyers see a fixed human-phrase InternalError, not not-found.
     """
-    handler = _owned_handler()
+    handler = seeded_owned_a2a_handler()
 
     with (
         patch.object(handler, "_get_auth_token", return_value="tok"),
@@ -192,9 +212,12 @@ async def test_auth_infra_failure_is_internal_error_not_task_not_found(request_c
             await getattr(handler, method_name)(request_cls(id=_TASK_ID), context=None)
 
     raised = exc_info.value
-    assert not isinstance(raised, TaskNotFoundError)
+    assert type(raised) is InternalError
     assert raised.message == wire_message
     assert "_" not in raised.message
+    # Recovery envelope attached (compat may still flatten ``data`` on the wire).
+    assert raised.data is not None
+    assert "adcp_error" in raised.data
 
 
 @pytest.mark.asyncio
@@ -209,23 +232,22 @@ async def test_sibling_denied_via_real_auth_token_path(request_cls, method_name)
     mutating ``!= expected_owner`` out of the gate reddens this path — unknown-id
     alone would stay green.
     """
-    handler = _owned_handler()
+    handler = seeded_owned_a2a_handler()
     owner = PrincipalFactory.make_identity(principal_id=_OWNER, tenant_id=_TENANT, protocol="a2a")
     sibling = PrincipalFactory.make_identity(principal_id=_SIBLING, tenant_id=_TENANT, protocol="a2a")
-
-    def resolve(*, auth_token: str | None, **_kwargs):
-        if auth_token == "sibling-tok":
-            return sibling
-        if auth_token == "owner-tok":
-            return owner
-        raise AssertionError(f"unexpected token: {auth_token!r}")
+    resolve = token_identity_resolver(
+        {
+            OWNED_TASK_SIBLING_TOK: sibling,
+            OWNED_TASK_OWNER_TOK: owner,
+        }
+    )
 
     with patch("src.core.resolved_identity.resolve_identity", side_effect=resolve):
-        sibling_ctx = make_a2a_context(auth_token="sibling-tok", headers={"host": "test.example.com"})
+        sibling_ctx = make_a2a_context(auth_token=OWNED_TASK_SIBLING_TOK, headers={"host": "test.example.com"})
         with pytest.raises(TaskNotFoundError) as deny_exc:
             await getattr(handler, method_name)(request_cls(id=_TASK_ID), context=sibling_ctx)
 
-        owner_ctx = make_a2a_context(auth_token="owner-tok", headers={"host": "test.example.com"})
+        owner_ctx = make_a2a_context(auth_token=OWNED_TASK_OWNER_TOK, headers={"host": "test.example.com"})
         with pytest.raises(TaskNotFoundError) as unknown_exc:
             await getattr(handler, method_name)(request_cls(id="task_does_not_exist"), context=owner_ctx)
 
@@ -241,7 +263,7 @@ async def test_sibling_denied_via_real_auth_token_path(request_cls, method_name)
 )
 async def test_unauthenticated_poller_raises_invalid_request(request_cls, method_name):
     """Missing token raises InvalidRequestError — must not collapse to TaskNotFoundError."""
-    handler = _owned_handler()
+    handler = seeded_owned_a2a_handler()
 
     with patch.object(handler, "_get_auth_token", return_value=None):
         with pytest.raises(InvalidRequestError):
@@ -251,7 +273,7 @@ async def test_unauthenticated_poller_raises_invalid_request(request_cls, method
 
 
 def test_resolve_identity_without_principal_id_raises_invalid_request():
-    """Authenticated resolve with no principal_id hits the :290-291 guard."""
+    """Authenticated resolve with no principal_id hits the no-principal guard."""
     handler = AdCPRequestHandler()
     no_principal = PrincipalFactory.make_identity(principal_id=None, tenant_id=_TENANT, protocol="a2a")
     ctx = make_a2a_context(auth_token="tok", headers={"host": "test.example.com"})
@@ -259,6 +281,14 @@ def test_resolve_identity_without_principal_id_raises_invalid_request():
     with patch("src.core.resolved_identity.resolve_identity", return_value=no_principal):
         with pytest.raises(InvalidRequestError, match="invalid or expired"):
             handler._resolve_a2a_identity("tok", require_valid_token=True, context=ctx)
+
+
+def test_auth_operation_ids_are_underscore_replaceable():
+    """Op ids passed to ``_authenticate`` must not need a hand-maintained phrase map."""
+    for op_id in _AUTH_OPERATION_IDS:
+        phrase = op_id.replace("_", " ")
+        assert "_" not in phrase
+        assert phrase == " ".join(op_id.split("_"))
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_a2a_task_identity_wire.py
+++ b/tests/unit/test_a2a_task_identity_wire.py
@@ -27,18 +27,12 @@ from tests.a2a_helpers import (
     OWNED_TASK_SIBLING,
     OWNED_TASK_SIBLING_TOK,
     OWNED_TASK_TENANT,
+    assert_wire_task_not_found,
     auth_headers_mapping,
     seeded_owned_a2a_handler,
     token_identity_resolver,
 )
 from tests.factories import PrincipalFactory
-
-_TENANT = OWNED_TASK_TENANT
-_OWNER = OWNED_TASK_OWNER
-_SIBLING = OWNED_TASK_SIBLING
-_TASK_ID = OWNED_TASK_ID
-_OWNER_TOK = OWNED_TASK_OWNER_TOK
-_SIBLING_TOK = OWNED_TASK_SIBLING_TOK
 
 
 class _AuthHeaderContextBuilder(ServerCallContextBuilder):
@@ -86,35 +80,31 @@ def test_sibling_wire_error_matches_unknown_id(method):
     must redden this: sibling would get a result while unknown still errors.
     """
     handler = seeded_owned_a2a_handler()
-    owner = PrincipalFactory.make_identity(principal_id=_OWNER, tenant_id=_TENANT, protocol="a2a")
-    sibling = PrincipalFactory.make_identity(principal_id=_SIBLING, tenant_id=_TENANT, protocol="a2a")
-    resolve = token_identity_resolver({_SIBLING_TOK: sibling, _OWNER_TOK: owner})
+    owner = PrincipalFactory.make_identity(principal_id=OWNED_TASK_OWNER, tenant_id=OWNED_TASK_TENANT, protocol="a2a")
+    sibling = PrincipalFactory.make_identity(
+        principal_id=OWNED_TASK_SIBLING, tenant_id=OWNED_TASK_TENANT, protocol="a2a"
+    )
+    resolve = token_identity_resolver({OWNED_TASK_SIBLING_TOK: sibling, OWNED_TASK_OWNER_TOK: owner})
 
     client = _client_for(handler)
     with (
         patch("src.core.resolved_identity.resolve_identity", side_effect=resolve),
         patch.object(handler, "_log_a2a_operation"),
     ):
-        sibling_body = _post_task(client, method=method, task_id=_TASK_ID, token=_SIBLING_TOK)
-        unknown_body = _post_task(client, method=method, task_id="task_does_not_exist", token=_OWNER_TOK)
-        owner_body = _post_task(client, method=method, task_id=_TASK_ID, token=_OWNER_TOK)
+        sibling_body = _post_task(client, method=method, task_id=OWNED_TASK_ID, token=OWNED_TASK_SIBLING_TOK)
+        unknown_body = _post_task(client, method=method, task_id="task_does_not_exist", token=OWNED_TASK_OWNER_TOK)
+        owner_body = _post_task(client, method=method, task_id=OWNED_TASK_ID, token=OWNED_TASK_OWNER_TOK)
 
     assert "error" in sibling_body
     assert "error" in unknown_body
     assert "result" in owner_body
 
-    sibling_err = sibling_body["error"]
-    unknown_err = unknown_body["error"]
-    # v0.3 compat flattens structured ``data`` to null (#1670); assert both None
-    # today so unequal task_id payloads do not falsely fail when flattening lifts.
-    assert sibling_err["code"] == unknown_err["code"] == -32603
-    assert sibling_err.get("data") is None
-    assert unknown_err.get("data") is None
-    assert sibling_err["message"].startswith("Task not found:")
-    assert unknown_err["message"].startswith("Task not found:")
-    assert _TASK_ID in sibling_err["message"]
-    assert "task_does_not_exist" in unknown_err["message"]
-    assert owner_body["result"]["id"] == _TASK_ID
+    # Exact equality — startswith would miss a suffix identity leak.
+    # v0.3 compat flattens structured data to null (#1670); when that lifts,
+    # the strict xfail in tests/e2e/test_a2a_endpoints_working.py XPASSes.
+    assert_wire_task_not_found(sibling_body["error"], OWNED_TASK_ID)
+    assert_wire_task_not_found(unknown_body["error"], "task_does_not_exist")
+    assert owner_body["result"]["id"] == OWNED_TASK_ID
 
 
 @pytest.mark.parametrize("method", ["tasks/get", "tasks/cancel"])
@@ -123,11 +113,13 @@ def test_unauthenticated_wire_is_auth_failure_not_task_not_found(method):
     handler = seeded_owned_a2a_handler()
     client = _client_for(handler)
     with patch.object(handler, "_log_a2a_operation"):
-        body = _post_task(client, method=method, task_id=_TASK_ID, token=None)
+        body = _post_task(client, method=method, task_id=OWNED_TASK_ID, token=None)
 
     assert "error" in body
     err = body["error"]
     # Compat still uses -32603; distinction from not-found is the message string.
+    # See also the strict xfail sibling grading -32001 when #1670 lands.
     assert err["code"] == -32603
+    assert err["data"] is None
+    assert err["message"] == "Missing authentication token"
     assert "Task not found" not in err["message"]
-    assert "Missing authentication token" in err["message"]

--- a/tests/unit/test_a2a_task_identity_wire.py
+++ b/tests/unit/test_a2a_task_identity_wire.py
@@ -14,21 +14,31 @@ import pytest
 from a2a.server.context import ServerCallContext
 from a2a.server.routes.common import ServerCallContextBuilder
 from a2a.server.routes.jsonrpc_routes import create_jsonrpc_routes
-from a2a.types import Task, TaskState, TaskStatus
 from starlette.applications import Starlette
 from starlette.requests import Request
 from starlette.testclient import TestClient
 
-from src.a2a_server.adcp_a2a_server import AdCPRequestHandler, _TaskOwner
+from src.a2a_server.adcp_a2a_server import AdCPRequestHandler
 from src.core.auth_context import AUTH_CONTEXT_STATE_KEY, AuthContext
+from tests.a2a_helpers import (
+    OWNED_TASK_ID,
+    OWNED_TASK_OWNER,
+    OWNED_TASK_OWNER_TOK,
+    OWNED_TASK_SIBLING,
+    OWNED_TASK_SIBLING_TOK,
+    OWNED_TASK_TENANT,
+    auth_headers_mapping,
+    seeded_owned_a2a_handler,
+    token_identity_resolver,
+)
 from tests.factories import PrincipalFactory
 
-_TENANT = "tenant_a"
-_OWNER = "principal_owner"
-_SIBLING = "principal_sibling"
-_TASK_ID = "task_owned_abc"
-_OWNER_TOK = "owner-tok"
-_SIBLING_TOK = "sibling-tok"
+_TENANT = OWNED_TASK_TENANT
+_OWNER = OWNED_TASK_OWNER
+_SIBLING = OWNED_TASK_SIBLING
+_TASK_ID = OWNED_TASK_ID
+_OWNER_TOK = OWNED_TASK_OWNER_TOK
+_SIBLING_TOK = OWNED_TASK_SIBLING_TOK
 
 
 class _AuthHeaderContextBuilder(ServerCallContextBuilder):
@@ -41,18 +51,10 @@ class _AuthHeaderContextBuilder(ServerCallContextBuilder):
             state={
                 AUTH_CONTEXT_STATE_KEY: AuthContext(
                     auth_token=token,
-                    headers={k.lower(): v for k, v in request.headers.items()},
+                    headers=auth_headers_mapping(dict(request.headers.items())),
                 )
             }
         )
-
-
-def _seeded_handler() -> AdCPRequestHandler:
-    handler = AdCPRequestHandler.__new__(AdCPRequestHandler)
-    handler.tasks = {_TASK_ID: Task(id=_TASK_ID, status=TaskStatus(state=TaskState.TASK_STATE_COMPLETED))}
-    handler._task_owners = {_TASK_ID: _TaskOwner(tenant_id=_TENANT, principal_id=_OWNER)}
-    handler._task_push_configs = {}
-    return handler
 
 
 def _client_for(handler: AdCPRequestHandler) -> TestClient:
@@ -65,11 +67,12 @@ def _client_for(handler: AdCPRequestHandler) -> TestClient:
     return TestClient(Starlette(routes=routes))
 
 
-def _post_task(client: TestClient, *, method: str, task_id: str, token: str) -> dict:
+def _post_task(client: TestClient, *, method: str, task_id: str, token: str | None) -> dict:
+    headers = {"Authorization": f"Bearer {token}"} if token is not None else {}
     response = client.post(
         "/a2a",
         json={"jsonrpc": "2.0", "id": 1, "method": method, "params": {"id": task_id}},
-        headers={"Authorization": f"Bearer {token}"},
+        headers=headers,
     )
     assert response.status_code == 200
     return response.json()
@@ -82,16 +85,10 @@ def test_sibling_wire_error_matches_unknown_id(method):
     Mutating ``!= expected_owner`` out of ``_get_owned_in_memory_task_or_raise``
     must redden this: sibling would get a result while unknown still errors.
     """
-    handler = _seeded_handler()
+    handler = seeded_owned_a2a_handler()
     owner = PrincipalFactory.make_identity(principal_id=_OWNER, tenant_id=_TENANT, protocol="a2a")
     sibling = PrincipalFactory.make_identity(principal_id=_SIBLING, tenant_id=_TENANT, protocol="a2a")
-
-    def resolve(*, auth_token: str | None, **_kwargs):
-        if auth_token == _SIBLING_TOK:
-            return sibling
-        if auth_token == _OWNER_TOK:
-            return owner
-        raise AssertionError(f"unexpected token: {auth_token!r}")
+    resolve = token_identity_resolver({_SIBLING_TOK: sibling, _OWNER_TOK: owner})
 
     client = _client_for(handler)
     with (
@@ -108,10 +105,29 @@ def test_sibling_wire_error_matches_unknown_id(method):
 
     sibling_err = sibling_body["error"]
     unknown_err = unknown_body["error"]
+    # v0.3 compat flattens structured ``data`` to null (#1670); assert both None
+    # today so unequal task_id payloads do not falsely fail when flattening lifts.
     assert sibling_err["code"] == unknown_err["code"] == -32603
-    assert sibling_err.get("data") == unknown_err.get("data")
+    assert sibling_err.get("data") is None
+    assert unknown_err.get("data") is None
     assert sibling_err["message"].startswith("Task not found:")
     assert unknown_err["message"].startswith("Task not found:")
     assert _TASK_ID in sibling_err["message"]
     assert "task_does_not_exist" in unknown_err["message"]
     assert owner_body["result"]["id"] == _TASK_ID
+
+
+@pytest.mark.parametrize("method", ["tasks/get", "tasks/cancel"])
+def test_unauthenticated_wire_is_auth_failure_not_task_not_found(method):
+    """No Authorization → auth-failure shape, distinct from not-found on the wire."""
+    handler = seeded_owned_a2a_handler()
+    client = _client_for(handler)
+    with patch.object(handler, "_log_a2a_operation"):
+        body = _post_task(client, method=method, task_id=_TASK_ID, token=None)
+
+    assert "error" in body
+    err = body["error"]
+    # Compat still uses -32603; distinction from not-found is the message string.
+    assert err["code"] == -32603
+    assert "Task not found" not in err["message"]
+    assert "Missing authentication token" in err["message"]

--- a/tests/unit/test_a2a_task_identity_wire.py
+++ b/tests/unit/test_a2a_task_identity_wire.py
@@ -1,11 +1,12 @@
 """In-process JSON-RPC wire grade for A2A task ownership (#1702 / #1720).
 
 live_server xfails only POST an unknown id — they never hit the owner-compare
-branch. This builds the same create_jsonrpc_routes(..., enable_v0_3_compat=True)
-routing/dispatch/error-shaping path production uses (auth extraction is
-hand-rolled here — no middleware; see ``_AuthHeaderContextBuilder``), seeds an
-owned in-memory task on the handler instance, and asserts sibling denial matches
-unknown-id on the wire (code/message shape).
+branch. Routes through the shared ``build_a2a_jsonrpc_client`` (``tests/a2a_helpers.py``),
+which drives the same ``create_jsonrpc_routes(..., enable_v0_3_compat=True)``
+routing/dispatch/error-shaping path production uses over the harness's
+``x-adcp-auth`` header contract (no middleware — the builder extracts the
+token directly), seeds an owned in-memory task on the handler instance, and
+asserts sibling denial matches unknown-id on the wire (code/message shape).
 """
 
 from __future__ import annotations
@@ -13,55 +14,22 @@ from __future__ import annotations
 from unittest.mock import patch
 
 import pytest
-from a2a.server.context import ServerCallContext
-from a2a.server.routes.common import ServerCallContextBuilder
-from a2a.server.routes.jsonrpc_routes import create_jsonrpc_routes
-from starlette.applications import Starlette
-from starlette.requests import Request
 from starlette.testclient import TestClient
 
-from src.a2a_server.adcp_a2a_server import AdCPRequestHandler
-from src.core.auth_context import AUTH_CONTEXT_STATE_KEY, AuthContext
 from tests.a2a_helpers import (
     OWNED_TASK_ID,
     OWNED_TASK_OWNER_TOK,
     OWNED_TASK_SIBLING_TOK,
     TASK_METHOD_MATRIX,
     assert_wire_task_not_found,
-    auth_headers_mapping,
+    build_a2a_jsonrpc_client,
     seeded_owned_a2a_handler,
     seeded_owner_sibling_resolver,
 )
 
 
-class _AuthHeaderContextBuilder(ServerCallContextBuilder):
-    """Minimal builder: Authorization Bearer → AuthContext (no middleware)."""
-
-    def build(self, request: Request) -> ServerCallContext:
-        auth = request.headers.get("authorization", "")
-        token = auth[7:].strip() if auth.lower().startswith("bearer ") else None
-        return ServerCallContext(
-            state={
-                AUTH_CONTEXT_STATE_KEY: AuthContext(
-                    auth_token=token,
-                    headers=auth_headers_mapping(dict(request.headers.items())),
-                )
-            }
-        )
-
-
-def _client_for(handler: AdCPRequestHandler) -> TestClient:
-    routes = create_jsonrpc_routes(
-        request_handler=handler,
-        rpc_url="/a2a",
-        context_builder=_AuthHeaderContextBuilder(),
-        enable_v0_3_compat=True,
-    )
-    return TestClient(Starlette(routes=routes))
-
-
 def _post_task(client: TestClient, *, method: str, task_id: str, token: str | None) -> dict:
-    headers = {"Authorization": f"Bearer {token}"} if token is not None else {}
+    headers = {"x-adcp-auth": token} if token is not None else {}
     response = client.post(
         "/a2a",
         json={"jsonrpc": "2.0", "id": 1, "method": method, "params": {"id": task_id}},
@@ -81,7 +49,7 @@ def test_sibling_wire_error_matches_unknown_id(method):
     handler = seeded_owned_a2a_handler()
     resolve = seeded_owner_sibling_resolver()
 
-    client = _client_for(handler)
+    client = build_a2a_jsonrpc_client(handler)
     with (
         patch("src.core.resolved_identity.resolve_identity", side_effect=resolve),
         patch.object(handler, "_log_a2a_operation"),
@@ -106,7 +74,7 @@ def test_sibling_wire_error_matches_unknown_id(method):
 def test_unauthenticated_wire_is_auth_failure_not_task_not_found(method):
     """No Authorization → auth-failure shape, distinct from not-found on the wire."""
     handler = seeded_owned_a2a_handler()
-    client = _client_for(handler)
+    client = build_a2a_jsonrpc_client(handler)
     with patch.object(handler, "_log_a2a_operation"):
         body = _post_task(client, method=method, task_id=OWNED_TASK_ID, token=None)
 

--- a/tests/unit/test_a2a_task_identity_wire.py
+++ b/tests/unit/test_a2a_task_identity_wire.py
@@ -1,9 +1,11 @@
 """In-process JSON-RPC wire grade for A2A task ownership (#1702 / #1720).
 
 live_server xfails only POST an unknown id — they never hit the owner-compare
-branch. This builds the same ``create_jsonrpc_routes(..., enable_v0_3_compat=True)``
-path production uses, seeds an owned in-memory task on the handler instance, and
-asserts sibling denial matches unknown-id on the wire (code/message shape).
+branch. This builds the same create_jsonrpc_routes(..., enable_v0_3_compat=True)
+routing/dispatch/error-shaping path production uses (auth extraction is
+hand-rolled here — no middleware; see ``_AuthHeaderContextBuilder``), seeds an
+owned in-memory task on the handler instance, and asserts sibling denial matches
+unknown-id on the wire (code/message shape).
 """
 
 from __future__ import annotations
@@ -27,6 +29,7 @@ from tests.a2a_helpers import (
     OWNED_TASK_SIBLING,
     OWNED_TASK_SIBLING_TOK,
     OWNED_TASK_TENANT,
+    TASK_METHOD_MATRIX,
     assert_wire_task_not_found,
     auth_headers_mapping,
     seeded_owned_a2a_handler,
@@ -72,7 +75,7 @@ def _post_task(client: TestClient, *, method: str, task_id: str, token: str | No
     return response.json()
 
 
-@pytest.mark.parametrize("method", ["tasks/get", "tasks/cancel"])
+@pytest.mark.parametrize("method", [row[2] for row in TASK_METHOD_MATRIX])
 def test_sibling_wire_error_matches_unknown_id(method):
     """Sibling ownership miss and unknown id share wire code/message shape.
 
@@ -107,7 +110,7 @@ def test_sibling_wire_error_matches_unknown_id(method):
     assert owner_body["result"]["id"] == OWNED_TASK_ID
 
 
-@pytest.mark.parametrize("method", ["tasks/get", "tasks/cancel"])
+@pytest.mark.parametrize("method", [row[2] for row in TASK_METHOD_MATRIX])
 def test_unauthenticated_wire_is_auth_failure_not_task_not_found(method):
     """No Authorization → auth-failure shape, distinct from not-found on the wire."""
     handler = seeded_owned_a2a_handler()
@@ -122,4 +125,3 @@ def test_unauthenticated_wire_is_auth_failure_not_task_not_found(method):
     assert err["code"] == -32603
     assert err["data"] is None
     assert err["message"] == "Missing authentication token"
-    assert "Task not found" not in err["message"]

--- a/tests/unit/test_a2a_task_identity_wire.py
+++ b/tests/unit/test_a2a_task_identity_wire.py
@@ -1,12 +1,12 @@
 """In-process JSON-RPC wire grade for A2A task ownership (#1702 / #1720).
 
 live_server xfails only POST an unknown id — they never hit the owner-compare
-branch. Routes through the shared ``build_a2a_jsonrpc_client`` (``tests/a2a_helpers.py``),
-which drives the same ``create_jsonrpc_routes(..., enable_v0_3_compat=True)``
-routing/dispatch/error-shaping path production uses over the harness's
-``x-adcp-auth`` header contract (no middleware — the builder extracts the
-token directly), seeds an owned in-memory task on the handler instance, and
-asserts sibling denial matches unknown-id on the wire (code/message shape).
+branch. Routes through the shared ``post_a2a_task_method`` boundary
+(``tests/a2a_helpers.py``), which drives the same
+``create_jsonrpc_routes(..., enable_v0_3_compat=True)`` path production uses
+over the harness ``x-adcp-auth`` header contract, seeds an owned in-memory
+task on the handler instance, and asserts sibling denial matches unknown-id
+on the wire (code/message shape).
 """
 
 from __future__ import annotations
@@ -14,29 +14,32 @@ from __future__ import annotations
 from unittest.mock import patch
 
 import pytest
-from starlette.testclient import TestClient
 
+from src.a2a_server.adcp_a2a_server import AdCPRequestHandler
 from tests.a2a_helpers import (
     OWNED_TASK_ID,
     OWNED_TASK_OWNER_TOK,
     OWNED_TASK_SIBLING_TOK,
     TASK_METHOD_MATRIX,
+    XAdcpAuthContextBuilder,
+    assert_wire_auth_failure,
     assert_wire_task_not_found,
-    build_a2a_jsonrpc_client,
+    post_a2a_task_method,
     seeded_owned_a2a_handler,
     seeded_owner_sibling_resolver,
 )
 
 
-def _post_task(client: TestClient, *, method: str, task_id: str, token: str | None) -> dict:
+def _post_task(handler: AdCPRequestHandler, *, method: str, task_id: str, token: str | None) -> dict:
+    """Thin wrapper: auth-header shaping only; POST boundary is shared."""
     headers = {"x-adcp-auth": token} if token is not None else {}
-    response = client.post(
-        "/a2a",
-        json={"jsonrpc": "2.0", "id": 1, "method": method, "params": {"id": task_id}},
+    return post_a2a_task_method(
+        handler,
+        method=method,
+        task_id=task_id,
+        context_builder=XAdcpAuthContextBuilder(),
         headers=headers,
     )
-    assert response.status_code == 200
-    return response.json()
 
 
 @pytest.mark.parametrize("method", [row[2] for row in TASK_METHOD_MATRIX])
@@ -49,14 +52,13 @@ def test_sibling_wire_error_matches_unknown_id(method):
     handler = seeded_owned_a2a_handler()
     resolve = seeded_owner_sibling_resolver()
 
-    client = build_a2a_jsonrpc_client(handler)
     with (
         patch("src.core.resolved_identity.resolve_identity", side_effect=resolve),
         patch.object(handler, "_log_a2a_operation"),
     ):
-        sibling_body = _post_task(client, method=method, task_id=OWNED_TASK_ID, token=OWNED_TASK_SIBLING_TOK)
-        unknown_body = _post_task(client, method=method, task_id="task_does_not_exist", token=OWNED_TASK_OWNER_TOK)
-        owner_body = _post_task(client, method=method, task_id=OWNED_TASK_ID, token=OWNED_TASK_OWNER_TOK)
+        sibling_body = _post_task(handler, method=method, task_id=OWNED_TASK_ID, token=OWNED_TASK_SIBLING_TOK)
+        unknown_body = _post_task(handler, method=method, task_id="task_does_not_exist", token=OWNED_TASK_OWNER_TOK)
+        owner_body = _post_task(handler, method=method, task_id=OWNED_TASK_ID, token=OWNED_TASK_OWNER_TOK)
 
     assert "error" in sibling_body
     assert "error" in unknown_body
@@ -74,14 +76,8 @@ def test_sibling_wire_error_matches_unknown_id(method):
 def test_unauthenticated_wire_is_auth_failure_not_task_not_found(method):
     """No Authorization → auth-failure shape, distinct from not-found on the wire."""
     handler = seeded_owned_a2a_handler()
-    client = build_a2a_jsonrpc_client(handler)
     with patch.object(handler, "_log_a2a_operation"):
-        body = _post_task(client, method=method, task_id=OWNED_TASK_ID, token=None)
+        body = _post_task(handler, method=method, task_id=OWNED_TASK_ID, token=None)
 
     assert "error" in body
-    err = body["error"]
-    # Compat still uses -32603; distinction from not-found is the message string.
-    # See also the strict xfail sibling grading -32001 when #1670 lands.
-    assert err["code"] == -32603
-    assert err["data"] is None
-    assert err["message"] == "Missing authentication token"
+    assert_wire_auth_failure(body["error"])

--- a/tests/unit/test_a2a_task_identity_wire.py
+++ b/tests/unit/test_a2a_task_identity_wire.py
@@ -24,18 +24,14 @@ from src.a2a_server.adcp_a2a_server import AdCPRequestHandler
 from src.core.auth_context import AUTH_CONTEXT_STATE_KEY, AuthContext
 from tests.a2a_helpers import (
     OWNED_TASK_ID,
-    OWNED_TASK_OWNER,
     OWNED_TASK_OWNER_TOK,
-    OWNED_TASK_SIBLING,
     OWNED_TASK_SIBLING_TOK,
-    OWNED_TASK_TENANT,
     TASK_METHOD_MATRIX,
     assert_wire_task_not_found,
     auth_headers_mapping,
     seeded_owned_a2a_handler,
-    token_identity_resolver,
+    seeded_owner_sibling_resolver,
 )
-from tests.factories import PrincipalFactory
 
 
 class _AuthHeaderContextBuilder(ServerCallContextBuilder):
@@ -83,11 +79,7 @@ def test_sibling_wire_error_matches_unknown_id(method):
     must redden this: sibling would get a result while unknown still errors.
     """
     handler = seeded_owned_a2a_handler()
-    owner = PrincipalFactory.make_identity(principal_id=OWNED_TASK_OWNER, tenant_id=OWNED_TASK_TENANT, protocol="a2a")
-    sibling = PrincipalFactory.make_identity(
-        principal_id=OWNED_TASK_SIBLING, tenant_id=OWNED_TASK_TENANT, protocol="a2a"
-    )
-    resolve = token_identity_resolver({OWNED_TASK_SIBLING_TOK: sibling, OWNED_TASK_OWNER_TOK: owner})
+    resolve = seeded_owner_sibling_resolver()
 
     client = _client_for(handler)
     with (

--- a/tests/unit/test_a2a_task_identity_wire.py
+++ b/tests/unit/test_a2a_task_identity_wire.py
@@ -11,6 +11,7 @@ on the wire (code/message shape).
 
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -20,7 +21,7 @@ from tests.a2a_helpers import (
     OWNED_TASK_ID,
     OWNED_TASK_OWNER_TOK,
     OWNED_TASK_SIBLING_TOK,
-    TASK_METHOD_MATRIX,
+    TASK_JSONRPC_METHODS,
     XAdcpAuthContextBuilder,
     assert_wire_auth_failure,
     assert_wire_task_not_found,
@@ -30,7 +31,7 @@ from tests.a2a_helpers import (
 )
 
 
-def _post_task(handler: AdCPRequestHandler, *, method: str, task_id: str, token: str | None) -> dict:
+def _post_task(handler: AdCPRequestHandler, *, method: str, task_id: str, token: str | None) -> dict[str, Any]:
     """Thin wrapper: auth-header shaping only; POST boundary is shared."""
     headers = {"x-adcp-auth": token} if token is not None else {}
     return post_a2a_task_method(
@@ -42,7 +43,7 @@ def _post_task(handler: AdCPRequestHandler, *, method: str, task_id: str, token:
     )
 
 
-@pytest.mark.parametrize("method", [row[2] for row in TASK_METHOD_MATRIX])
+@pytest.mark.parametrize("method", TASK_JSONRPC_METHODS)
 def test_sibling_wire_error_matches_unknown_id(method):
     """Sibling ownership miss and unknown id share wire code/message shape.
 
@@ -72,7 +73,7 @@ def test_sibling_wire_error_matches_unknown_id(method):
     assert owner_body["result"]["id"] == OWNED_TASK_ID
 
 
-@pytest.mark.parametrize("method", [row[2] for row in TASK_METHOD_MATRIX])
+@pytest.mark.parametrize("method", TASK_JSONRPC_METHODS)
 def test_unauthenticated_wire_is_auth_failure_not_task_not_found(method):
     """No Authorization → auth-failure shape, distinct from not-found on the wire."""
     handler = seeded_owned_a2a_handler()

--- a/tests/unit/test_a2a_task_identity_wire.py
+++ b/tests/unit/test_a2a_task_identity_wire.py
@@ -1,0 +1,117 @@
+"""In-process JSON-RPC wire grade for A2A task ownership (#1702 / #1720).
+
+live_server xfails only POST an unknown id — they never hit the owner-compare
+branch. This builds the same ``create_jsonrpc_routes(..., enable_v0_3_compat=True)``
+path production uses, seeds an owned in-memory task on the handler instance, and
+asserts sibling denial matches unknown-id on the wire (code/message shape).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from a2a.server.context import ServerCallContext
+from a2a.server.routes.common import ServerCallContextBuilder
+from a2a.server.routes.jsonrpc_routes import create_jsonrpc_routes
+from a2a.types import Task, TaskState, TaskStatus
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.testclient import TestClient
+
+from src.a2a_server.adcp_a2a_server import AdCPRequestHandler, _TaskOwner
+from src.core.auth_context import AUTH_CONTEXT_STATE_KEY, AuthContext
+from tests.factories import PrincipalFactory
+
+_TENANT = "tenant_a"
+_OWNER = "principal_owner"
+_SIBLING = "principal_sibling"
+_TASK_ID = "task_owned_abc"
+_OWNER_TOK = "owner-tok"
+_SIBLING_TOK = "sibling-tok"
+
+
+class _AuthHeaderContextBuilder(ServerCallContextBuilder):
+    """Minimal builder: Authorization Bearer → AuthContext (no middleware)."""
+
+    def build(self, request: Request) -> ServerCallContext:
+        auth = request.headers.get("authorization", "")
+        token = auth[7:].strip() if auth.lower().startswith("bearer ") else None
+        return ServerCallContext(
+            state={
+                AUTH_CONTEXT_STATE_KEY: AuthContext(
+                    auth_token=token,
+                    headers={k.lower(): v for k, v in request.headers.items()},
+                )
+            }
+        )
+
+
+def _seeded_handler() -> AdCPRequestHandler:
+    handler = AdCPRequestHandler.__new__(AdCPRequestHandler)
+    handler.tasks = {_TASK_ID: Task(id=_TASK_ID, status=TaskStatus(state=TaskState.TASK_STATE_COMPLETED))}
+    handler._task_owners = {_TASK_ID: _TaskOwner(tenant_id=_TENANT, principal_id=_OWNER)}
+    handler._task_push_configs = {}
+    return handler
+
+
+def _client_for(handler: AdCPRequestHandler) -> TestClient:
+    routes = create_jsonrpc_routes(
+        request_handler=handler,
+        rpc_url="/a2a",
+        context_builder=_AuthHeaderContextBuilder(),
+        enable_v0_3_compat=True,
+    )
+    return TestClient(Starlette(routes=routes))
+
+
+def _post_task(client: TestClient, *, method: str, task_id: str, token: str) -> dict:
+    response = client.post(
+        "/a2a",
+        json={"jsonrpc": "2.0", "id": 1, "method": method, "params": {"id": task_id}},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert response.status_code == 200
+    return response.json()
+
+
+@pytest.mark.parametrize("method", ["tasks/get", "tasks/cancel"])
+def test_sibling_wire_error_matches_unknown_id(method):
+    """Sibling ownership miss and unknown id share wire code/message shape.
+
+    Mutating ``!= expected_owner`` out of ``_get_owned_in_memory_task_or_raise``
+    must redden this: sibling would get a result while unknown still errors.
+    """
+    handler = _seeded_handler()
+    owner = PrincipalFactory.make_identity(principal_id=_OWNER, tenant_id=_TENANT, protocol="a2a")
+    sibling = PrincipalFactory.make_identity(principal_id=_SIBLING, tenant_id=_TENANT, protocol="a2a")
+
+    def resolve(*, auth_token: str | None, **_kwargs):
+        if auth_token == _SIBLING_TOK:
+            return sibling
+        if auth_token == _OWNER_TOK:
+            return owner
+        raise AssertionError(f"unexpected token: {auth_token!r}")
+
+    client = _client_for(handler)
+    with (
+        patch("src.core.resolved_identity.resolve_identity", side_effect=resolve),
+        patch.object(handler, "_log_a2a_operation"),
+    ):
+        sibling_body = _post_task(client, method=method, task_id=_TASK_ID, token=_SIBLING_TOK)
+        unknown_body = _post_task(client, method=method, task_id="task_does_not_exist", token=_OWNER_TOK)
+        owner_body = _post_task(client, method=method, task_id=_TASK_ID, token=_OWNER_TOK)
+
+    assert "error" in sibling_body
+    assert "error" in unknown_body
+    assert "result" in owner_body
+
+    sibling_err = sibling_body["error"]
+    unknown_err = unknown_body["error"]
+    assert sibling_err["code"] == unknown_err["code"] == -32603
+    assert sibling_err.get("data") == unknown_err.get("data")
+    assert sibling_err["message"].startswith("Task not found:")
+    assert unknown_err["message"].startswith("Task not found:")
+    assert _TASK_ID in sibling_err["message"]
+    assert "task_does_not_exist" in unknown_err["message"]
+    assert owner_body["result"]["id"] == _TASK_ID

--- a/tests/unit/test_adcp_exceptions.py
+++ b/tests/unit/test_adcp_exceptions.py
@@ -559,15 +559,15 @@ class TestFastAPIExceptionHandlers:
         assert_envelope_shape(response.json(), "INVALID_REQUEST", recovery="correctable")
 
     def test_task_not_found_error_returns_404(self, exc_handler_test_app):
-        """AdCPTaskNotFoundError → 404, wire INVALID_REQUEST, correctable.
+        """AdCPTaskNotFoundError → 404, wire REFERENCE_NOT_FOUND, correctable.
 
-        TASK_NOT_FOUND translates to INVALID_REQUEST at the boundary;
-        recovery=correctable distinguishes it from the base (terminal).
+        TASK_NOT_FOUND translates to REFERENCE_NOT_FOUND at the boundary
+        (AdCP 3.1.1); recovery=correctable distinguishes it from the base (terminal).
         """
         client = TestClient(exc_handler_test_app, raise_server_exceptions=False)
         response = client.get("/test-exc/task-not-found")
         assert response.status_code == 404
-        assert_envelope_shape(response.json(), "INVALID_REQUEST", recovery="correctable")
+        assert_envelope_shape(response.json(), "REFERENCE_NOT_FOUND", recovery="correctable")
 
     def test_adapter_error_returns_502(self, exc_handler_test_app):
         """AdCPAdapterError raised in a route must return 502."""

--- a/tests/unit/test_adcp_exceptions.py
+++ b/tests/unit/test_adcp_exceptions.py
@@ -548,15 +548,16 @@ class TestFastAPIExceptionHandlers:
         assert_envelope_shape(response.json(), "CREATIVE_NOT_FOUND", recovery="correctable")
 
     def test_format_not_found_error_returns_404(self, exc_handler_test_app):
-        """AdCPFormatNotFoundError → 404, wire INVALID_REQUEST, correctable.
+        """AdCPFormatNotFoundError → 404, wire REFERENCE_NOT_FOUND, correctable.
 
-        FORMAT_NOT_FOUND translates to INVALID_REQUEST at the boundary;
-        recovery=correctable distinguishes it from the base (terminal).
+        FORMAT_NOT_FOUND translates to REFERENCE_NOT_FOUND at the boundary
+        (AdCP 3.1.1), the same generic inaccessible-reference code its
+        structural twin TASK_NOT_FOUND uses below — one category, one code.
         """
         client = TestClient(exc_handler_test_app, raise_server_exceptions=False)
         response = client.get("/test-exc/format-not-found")
         assert response.status_code == 404
-        assert_envelope_shape(response.json(), "INVALID_REQUEST", recovery="correctable")
+        assert_envelope_shape(response.json(), "REFERENCE_NOT_FOUND", recovery="correctable")
 
     def test_task_not_found_error_returns_404(self, exc_handler_test_app):
         """AdCPTaskNotFoundError → 404, wire REFERENCE_NOT_FOUND, correctable.

--- a/tests/unit/test_architecture_a2a_test_uses_factory.py
+++ b/tests/unit/test_architecture_a2a_test_uses_factory.py
@@ -1,7 +1,7 @@
 """Structural guard: A2A test files must use PrincipalFactory.make_identity, not inline ResolvedIdentity.
 
 Inline ``ResolvedIdentity(...)`` constructions in A2A test files (``tests/unit/test_a2a*.py``,
-``tests/integration/test_a2a*.py``) bypass the single source of truth at
+``tests/integration/test_a2a*.py``, ``tests/e2e/test_a2a*.py``) bypass the single source of truth at
 ``tests.factories.principal.PrincipalFactory.make_identity``. Each inline construction is
 a future drift point — the factory's signature can evolve (e.g., new spec-mandated fields)
 without inline callers tracking the change.
@@ -25,7 +25,11 @@ from tests.unit._architecture_helpers import iter_call_expressions
 def _a2a_test_files() -> list[Path]:
     repo_root = Path(__file__).resolve().parents[2]
     paths: list[Path] = []
-    for pattern in ("tests/unit/test_a2a*.py", "tests/integration/test_a2a*.py"):
+    for pattern in (
+        "tests/unit/test_a2a*.py",
+        "tests/integration/test_a2a*.py",
+        "tests/e2e/test_a2a*.py",
+    ):
         paths.extend(repo_root.glob(pattern))
     return paths
 

--- a/tests/unit/test_architecture_a2a_test_uses_factory.py
+++ b/tests/unit/test_architecture_a2a_test_uses_factory.py
@@ -61,3 +61,22 @@ def test_a2a_test_files_use_principal_factory_make_identity():
         f"Found {len(violations)} inline ResolvedIdentity(...) construction(s) in "
         f"A2A test files. Replace with PrincipalFactory.make_identity(...):\n  " + "\n  ".join(violations)
     )
+
+
+@pytest.mark.arch_guard
+def test_find_resolved_identity_calls_self_test(tmp_path: Path) -> None:
+    """Matcher self-test for the A2A factory guard (R5-N5b)."""
+    positive = tmp_path / "test_a2a_probe.py"
+    positive.write_text(
+        "from src.core.resolved_identity import ResolvedIdentity\n"
+        "import src.core.resolved_identity as mod\n"
+        "ResolvedIdentity(principal_id='a')\n"
+        "mod.ResolvedIdentity(principal_id='b')\n"
+    )
+    assert _find_resolved_identity_calls(positive) == [3, 4]
+
+    negative = tmp_path / "test_a2a_factory.py"
+    negative.write_text(
+        "from tests.factories.principal import PrincipalFactory\nPrincipalFactory.make_identity(principal_id='a')\n"
+    )
+    assert _find_resolved_identity_calls(negative) == []

--- a/tests/unit/test_architecture_a2a_test_uses_factory.py
+++ b/tests/unit/test_architecture_a2a_test_uses_factory.py
@@ -25,12 +25,9 @@ from tests.unit._architecture_helpers import iter_call_expressions
 def _a2a_test_files() -> list[Path]:
     repo_root = Path(__file__).resolve().parents[2]
     paths: list[Path] = []
-    for pattern in (
-        "tests/unit/test_a2a*.py",
-        "tests/integration/test_a2a*.py",
-        "tests/e2e/test_a2a*.py",
-    ):
-        paths.extend(repo_root.glob(pattern))
+    for suite in ("unit", "integration", "e2e"):
+        # Recursive: depth ≥ 2 ``test_a2a*.py`` must not escape the guard.
+        paths.extend((repo_root / "tests" / suite).rglob("test_a2a*.py"))
     return paths
 
 

--- a/tests/unit/test_architecture_e2e_rest_escape_hatches.py
+++ b/tests/unit/test_architecture_e2e_rest_escape_hatches.py
@@ -440,6 +440,14 @@ EXPECTED_UNSUPPORTED_DECLARATIONS: frozenset[tuple[str, str, str]] = frozenset(
             "live stack always serves the agent catalog; an empty catalog cannot be realized over e2e",
         ),
         ("tests/harness/creative_formats.py", "_validate_registry_formats", "<dynamic>"),
+        # The A2A task store lives on the handler instance inside the server
+        # process; over e2e that process is not ours, so no test-side seed can
+        # place a task in it. Ownership is graded in-process instead (#1780).
+        (
+            "tests/harness/_base.py",
+            "seed_a2a_task",
+            "in-process handler memory",
+        ),
     }
 )
 

--- a/tests/unit/test_architecture_e2e_rest_escape_hatches.py
+++ b/tests/unit/test_architecture_e2e_rest_escape_hatches.py
@@ -440,14 +440,6 @@ EXPECTED_UNSUPPORTED_DECLARATIONS: frozenset[tuple[str, str, str]] = frozenset(
             "live stack always serves the agent catalog; an empty catalog cannot be realized over e2e",
         ),
         ("tests/harness/creative_formats.py", "_validate_registry_formats", "<dynamic>"),
-        # The A2A task store lives on the handler instance inside the server
-        # process; over e2e that process is not ours, so no test-side seed can
-        # place a task in it. Ownership is graded in-process instead (#1780).
-        (
-            "tests/harness/_base.py",
-            "seed_a2a_task",
-            "in-process handler memory",
-        ),
     }
 )
 

--- a/tests/unit/test_architecture_error_recovery_enum_conformance.py
+++ b/tests/unit/test_architecture_error_recovery_enum_conformance.py
@@ -212,7 +212,7 @@ def test_internal_only_codes_are_documented() -> None:
 # The two spec codes the SDK helper table has not caught up to; the pinned enum
 # defines both (CREATIVE_NOT_FOUND correctable, CONFIGURATION_ERROR terminal),
 # so they are wire codes src can emit and must therefore be classified.
-_SUPPLEMENT_WIRE_CODES = frozenset({"CREATIVE_NOT_FOUND", "CONFIGURATION_ERROR"})
+_SUPPLEMENT_WIRE_CODES = frozenset({"CREATIVE_NOT_FOUND", "CONFIGURATION_ERROR", "REFERENCE_NOT_FOUND"})
 
 
 def _src_recovery_by_wire_code() -> dict[str, str]:
@@ -306,7 +306,7 @@ def test_wire_standard_codes_carry_no_classification() -> None:
         "define belongs in _SPEC_DEMOTED_CODES with a reason, not in the wire set."
     )
 
-    # The invariant the whole of salesagent-pldmk.4 exists to make definitional:
+    # The invariant graded in #1702 exists to make definitional:
     # every code that can reach the wire has a pinned recovery classification, so
     # no lookup falls back to an authored default (invariant I6, "recovery is
     # derived, never authored"). src enforces this at import with a raise; this
@@ -320,9 +320,9 @@ def test_wire_standard_codes_carry_no_classification() -> None:
         f"The recovery table must be TOTAL over the wire set."
     )
 
-    assert len(WIRE_STANDARD_CODES) == 39, (
-        f"WIRE_STANDARD_CODES has {len(WIRE_STANDARD_CODES)} entries, not 39 (38 SDK "
-        f"+ 2 supplement - 1 demoted). If the SDK pin moves, the demoted-set comment "
+    assert len(WIRE_STANDARD_CODES) == 40, (
+        f"WIRE_STANDARD_CODES has {len(WIRE_STANDARD_CODES)} entries, not 40 (38 SDK "
+        f"+ 3 supplement - 1 demoted). If the SDK pin moves, the demoted-set comment "
         f"in src/core/exceptions.py is where the reason lives; update it there."
     )
 
@@ -449,7 +449,7 @@ def test_assert_envelope_shape_keeps_the_caller_literal_for_unclassified_codes()
     expectation — the derivation adds a check, it does not replace the caller's.
 
     ``NOT_SUPPORTED`` is used here as a code the pin is SILENT on — which is
-    exactly why salesagent-pldmk.4 removed it from the wire surface, via
+    exactly why #1602 removed it from the wire surface, via
     ``_SPEC_DEMOTED_CODES``. It is no longer emittable, and
     ``wire_advisory`` now subscripts rather than falling back, because the wire
     set is total over the recovery table by construction. What survives, and what

--- a/tests/unit/test_architecture_measurement_floors.py
+++ b/tests/unit/test_architecture_measurement_floors.py
@@ -70,6 +70,7 @@ EXPECTED_WIRED_ROUTES: frozenset[str] = frozenset(
         "uc011-list",
         "uc011-sync",
         "uc018-list",
+        "A2A-TASK-OWNERSHIP",
     }
 )
 

--- a/tests/unit/test_architecture_no_error_code_kwarg_in_impl.py
+++ b/tests/unit/test_architecture_no_error_code_kwarg_in_impl.py
@@ -1,15 +1,22 @@
-"""Guard: error_code= must not bypass the typed AdCPError hierarchy.
+"""Guard: error_code=/recovery= must not bypass the typed AdCPError hierarchy.
 
 The wire error code is the identity of a typed AdCPError subclass. Passing
-``error_code=`` to an ``AdCP*Error(...)`` constructor bypasses that hierarchy and
-can leak a code that is neither standard nor mapped (the original A1 defect). The
-only sanctioned override is ``AdCPError.synthesize(error_code=...)``, used by the two
-boundary helpers that must construct a wire code the class hierarchy does not model.
+``error_code=`` or ``recovery=`` to an ``AdCP*Error(...)`` constructor bypasses
+that hierarchy (or redundantly restates the class default). The only sanctioned
+override is ``AdCPError.synthesize(error_code=..., recovery=...)``, used by the
+two boundary helpers that must construct a wire code the class hierarchy does
+not model.
 
-This guard scans ``src/core/`` and ``src/adapters/`` for any call that passes
-``error_code=`` to an ``AdCP*Error`` constructor OR to ``.synthesize()``. After the
-error-emission migration, the only such calls are the two ``synthesize()`` sites —
-pinned in the allowlist so a new bypass (or a new synthesize caller) fails the build.
+This guard scans ``src/core/``, ``src/adapters/``, and ``src/a2a_server/`` for any
+call that passes ``error_code=`` to an ``AdCP*Error`` constructor OR to
+``.synthesize()``. After the error-emission migration, the only such calls are
+the two ``synthesize()`` sites — pinned in the allowlist so a new bypass (or a
+new synthesize caller) fails the build.
+
+``recovery=`` on constructors is enforced for ``src/a2a_server/`` only (zero
+tolerance after dropping the redundant SSRF-site kwarg). Repo-wide recovery=
+ratchet on ``src/core`` / ``src/adapters`` is a separate follow-up — many sites
+legitimately override class defaults today.
 """
 
 import ast
@@ -20,6 +27,7 @@ from tests.unit._architecture_helpers import assert_violations_match_allowlist, 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCAN_DIRS = [REPO_ROOT / "src" / "core", REPO_ROOT / "src" / "adapters", REPO_ROOT / "src" / "a2a_server"]
+A2A_SERVER_DIR = REPO_ROOT / "src" / "a2a_server"
 
 # The only sanctioned error_code= sites: the two boundary helpers that call
 # AdCPError.synthesize(). Keyed by (relative_path, enclosing_function_name) so the
@@ -39,6 +47,10 @@ def _func_targets_adcp_error_or_synthesize(func: ast.expr) -> bool:
             return True
         return func.attr.startswith("AdCP") and func.attr.endswith("Error")
     return False
+
+
+def _func_is_synthesize(func: ast.expr) -> bool:
+    return isinstance(func, ast.Attribute) and func.attr == "synthesize"
 
 
 def _call_has_error_code_in_details(call: ast.Call) -> bool:
@@ -84,6 +96,28 @@ def _find_error_code_kwargs() -> list[tuple[str, str, int]]:
     ]
 
 
+def _find_a2a_recovery_kwargs() -> list[tuple[str, str, int]]:
+    """Find recovery= on AdCP*Error constructors under a2a_server (synthesize exempt)."""
+    hits: list[tuple[str, str, int]] = []
+    for py_file in A2A_SERVER_DIR.rglob("*.py"):
+        try:
+            tree = ast.parse(py_file.read_text(), filename=str(py_file))
+        except SyntaxError:
+            continue
+        rel_path = str(py_file.relative_to(REPO_ROOT))
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            for child in iter_call_expressions(node):
+                if not _func_targets_adcp_error_or_synthesize(child.func):
+                    continue
+                if _func_is_synthesize(child.func):
+                    continue
+                if any(kw.arg == "recovery" for kw in child.keywords):
+                    hits.append((rel_path, node.name, child.lineno))
+    return hits
+
+
 def _find_error_code_in_details() -> list[tuple[str, str, int]]:
     """Find details={"error_code": ...} smuggling on AdCP*Error calls. (relative_path, function, lineno)."""
     return [
@@ -123,6 +157,14 @@ class TestNoErrorCodeKwargInImpl:
         all_sites = {(rel, func) for rel, func, _ in _find_error_code_kwargs()}
         msg = f"error_code= sites changed.\nFound: {sorted(all_sites)}\nAllowlist: {sorted(KNOWN_VIOLATIONS)}"
         assert all_sites == KNOWN_VIOLATIONS, msg
+
+    def test_no_recovery_kwargs_in_a2a_server_constructors(self):
+        """a2a_server AdCP*Error constructors must not hand-write recovery= (R5-F2)."""
+        sites = [f"  {rel}:{lineno} in {func}()" for rel, func, lineno in _find_a2a_recovery_kwargs()]
+        assert not sites, (
+            f"Found {len(sites)} recovery= site(s) on AdCP*Error constructors in a2a_server. "
+            "Use the class default; do not hand-write recovery=:\n" + "\n".join(sites)
+        )
 
 
 class TestNoErrorCodeInDetails:

--- a/tests/unit/test_architecture_no_error_code_kwarg_in_impl.py
+++ b/tests/unit/test_architecture_no_error_code_kwarg_in_impl.py
@@ -14,16 +14,21 @@ the two ``synthesize()`` sites — pinned in the allowlist so a new bypass (or a
 new synthesize caller) fails the build.
 
 ``recovery=`` on constructors is enforced for ``src/a2a_server/`` only (zero
-tolerance after dropping the redundant SSRF-site kwarg). Repo-wide recovery=
-ratchet on ``src/core`` / ``src/adapters`` is a separate follow-up — many sites
-legitimately override class defaults today.
+tolerance after dropping the redundant SSRF-site kwarg). Repo-wide ``recovery=``
+ratchet on ``src/core`` / ``src/adapters`` is out of scope for #1720 — tracked
+in #1676 (webhook scrub) and a future core/adapters guard widen; do not expand
+this PR into that sweep.
 """
 
 import ast
 from collections.abc import Iterator
 from pathlib import Path
 
-from tests.unit._architecture_helpers import assert_violations_match_allowlist, iter_call_expressions
+from tests.unit._architecture_helpers import (
+    assert_detector_catches_ast_snippets,
+    assert_violations_match_allowlist,
+    iter_call_expressions,
+)
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCAN_DIRS = [REPO_ROOT / "src" / "core", REPO_ROOT / "src" / "adapters", REPO_ROOT / "src" / "a2a_server"]
@@ -164,6 +169,34 @@ class TestNoErrorCodeKwargInImpl:
         assert not sites, (
             f"Found {len(sites)} recovery= site(s) on AdCP*Error constructors in a2a_server. "
             "Use the class default; do not hand-write recovery=:\n" + "\n".join(sites)
+        )
+
+    def test_recovery_kwarg_detector_self_test(self) -> None:
+        """Guard must redden when recovery= appears on an AdCP*Error constructor."""
+
+        def _find_recovery_in_module(tree: ast.Module) -> list[int]:
+            hits: list[int] = []
+            for node in ast.walk(tree):
+                if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    continue
+                for child in iter_call_expressions(node):
+                    if not _func_targets_adcp_error_or_synthesize(child.func):
+                        continue
+                    if _func_is_synthesize(child.func):
+                        continue
+                    if any(kw.arg == "recovery" for kw in child.keywords):
+                        hits.append(child.lineno)
+            return hits
+
+        assert_detector_catches_ast_snippets(
+            _find_recovery_in_module,
+            snippets={
+                "hand_written_recovery": (
+                    "def bad():\n"
+                    "    from src.core.exceptions import AdCPError\n"
+                    "    AdCPError(message='x', recovery='transient')\n"
+                ),
+            },
         )
 
 

--- a/tests/unit/test_architecture_no_error_code_kwarg_in_impl.py
+++ b/tests/unit/test_architecture_no_error_code_kwarg_in_impl.py
@@ -19,7 +19,7 @@ from pathlib import Path
 from tests.unit._architecture_helpers import assert_violations_match_allowlist, iter_call_expressions
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-SCAN_DIRS = [REPO_ROOT / "src" / "core", REPO_ROOT / "src" / "adapters"]
+SCAN_DIRS = [REPO_ROOT / "src" / "core", REPO_ROOT / "src" / "adapters", REPO_ROOT / "src" / "a2a_server"]
 
 # The only sanctioned error_code= sites: the two boundary helpers that call
 # AdCPError.synthesize(). Keyed by (relative_path, enclosing_function_name) so the

--- a/tests/unit/test_architecture_resolved_identity_inline_cap.py
+++ b/tests/unit/test_architecture_resolved_identity_inline_cap.py
@@ -16,9 +16,9 @@ those files at their current count via a per-file cap dict that can only
 shrink. New files with inline sites fail immediately; existing files with
 fewer sites force the cap down to match (no silent regressions).
 
-A2A test files are skipped here because the stricter A2A-only guard already
-enforces zero on them — including A2A files in this dict would double-cap
-them.
+A2A ``test_a2a*.py`` files are skipped here because the stricter A2A-only
+guard already enforces zero on them — including A2A files in this dict would
+double-cap them. ``test_architecture_a2a*`` helpers stay under this cap guard.
 """
 
 from __future__ import annotations
@@ -114,14 +114,14 @@ def _rel(path: Path) -> str:
 def _is_a2a_test_file(path: Path) -> bool:
     """A2A test files are governed by the stricter zero-tolerance factory guard.
 
-    Path-aware: unit/integration/e2e ``test_a2a*`` (and architecture a2a guards)
-    are skipped here so the factory guard owns them at zero tolerance.
+    Path-aware: unit/integration/e2e ``test_a2a*`` are skipped here so the
+    factory guard owns them at zero tolerance. Architecture helpers named
+    ``test_architecture_a2a*`` stay under THIS cap guard (the factory guard's
+    ``test_a2a*`` glob never matches that prefix — R5-F1).
     Use repo-relative prefixes — never ``"unit" in path.parts`` on an absolute
     path (any ancestor named ``unit``/``integration``/``e2e`` would fail open).
     """
     name = path.name
-    if name.startswith("test_architecture_a2a"):
-        return True
     if not name.startswith("test_a2a"):
         return False
     return _rel(path).startswith(("tests/unit/", "tests/integration/", "tests/e2e/"))
@@ -194,3 +194,35 @@ def test_resolved_identity_caps_only_shrink() -> None:
         _count_inline_resolved_identity,
         repo_root=_REPO_ROOT,
     )
+
+
+@pytest.mark.arch_guard
+def test_is_a2a_test_file_anchored_rel_not_ancestor_name() -> None:
+    """Fail-open regression: only repo-relative suite prefixes count (R5-N5b)."""
+    assert _is_a2a_test_file(_REPO_ROOT / "tests" / "unit" / "test_a2a_x.py") is True
+    assert _is_a2a_test_file(_REPO_ROOT / "tests" / "bdd" / "test_a2a_x.py") is False
+    assert _is_a2a_test_file(_REPO_ROOT / "tests" / "unit" / "test_architecture_a2a_x.py") is False
+
+
+@pytest.mark.arch_guard
+def test_count_inline_resolved_identity_self_test(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Matcher self-test: detects direct + attribute calls; factory yields 0 (R5-N5b)."""
+    # Point scan helper's a2a predicate off so tmp files are counted.
+    monkeypatch.setattr(
+        "tests.unit.test_architecture_resolved_identity_inline_cap._is_a2a_test_file",
+        lambda _p: False,
+    )
+    positive = tmp_path / "probe.py"
+    positive.write_text(
+        "from src.core.resolved_identity import ResolvedIdentity\n"
+        "import src.core.resolved_identity as mod\n"
+        "ResolvedIdentity(principal_id='a')\n"
+        "mod.ResolvedIdentity(principal_id='b')\n"
+    )
+    assert _count_inline_resolved_identity(positive) == [3, 4]
+
+    negative = tmp_path / "factory_probe.py"
+    negative.write_text(
+        "from tests.factories.principal import PrincipalFactory\nPrincipalFactory.make_identity(principal_id='a')\n"
+    )
+    assert _count_inline_resolved_identity(negative) == []

--- a/tests/unit/test_architecture_resolved_identity_inline_cap.py
+++ b/tests/unit/test_architecture_resolved_identity_inline_cap.py
@@ -69,7 +69,6 @@ RESOLVED_IDENTITY_PER_FILE_CAP: dict[str, int] = {
     "tests/integration/test_update_media_buy_persistence.py": 1,
     "tests/unit/test_adcp_25_creative_management.py": 1,
     "tests/unit/test_auth_consistency.py": 3,
-    "tests/unit/test_auth_context_middleware_population.py": 0,
     "tests/unit/test_auth_requirements.py": 6,
     "tests/unit/test_authorized_properties_behavioral.py": 2,
     "tests/unit/test_brand_manifest_policy.py": 1,
@@ -101,19 +100,31 @@ RESOLVED_IDENTITY_PER_FILE_CAP: dict[str, int] = {
 }
 
 
+# Anchor scan paths on REPO_ROOT so the guard works from any cwd
+# (matches pattern from VALUE_ERROR_PER_FILE_CAP / Pattern A guards).
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCAN_DIRS = [_REPO_ROOT / "tests"]
+
+
+def _rel(path: Path) -> str:
+    """Return the path relative to repo root, with forward slashes."""
+    return str(path.relative_to(_REPO_ROOT)).replace("\\", "/")
+
+
 def _is_a2a_test_file(path: Path) -> bool:
     """A2A test files are governed by the stricter zero-tolerance factory guard.
 
     Path-aware: unit/integration/e2e ``test_a2a*`` (and architecture a2a guards)
     are skipped here so the factory guard owns them at zero tolerance.
+    Use repo-relative prefixes — never ``"unit" in path.parts`` on an absolute
+    path (any ancestor named ``unit``/``integration``/``e2e`` would fail open).
     """
     name = path.name
     if name.startswith("test_architecture_a2a"):
         return True
     if not name.startswith("test_a2a"):
         return False
-    parts = path.parts
-    return "unit" in parts or "integration" in parts or "e2e" in parts
+    return _rel(path).startswith(("tests/unit/", "tests/integration/", "tests/e2e/"))
 
 
 def _count_inline_resolved_identity(filepath: Path) -> list[int]:
@@ -139,17 +150,6 @@ def _count_inline_resolved_identity(filepath: Path) -> list[int]:
         elif isinstance(func, ast.Attribute) and func.attr == "ResolvedIdentity":
             lines.append(node.lineno)
     return lines
-
-
-# Anchor scan paths on REPO_ROOT so the guard works from any cwd
-# (matches pattern from VALUE_ERROR_PER_FILE_CAP / Pattern A guards).
-_REPO_ROOT = Path(__file__).resolve().parents[2]
-_SCAN_DIRS = [_REPO_ROOT / "tests"]
-
-
-def _rel(path: Path) -> str:
-    """Return the path relative to repo root, with forward slashes."""
-    return str(path.relative_to(_REPO_ROOT)).replace("\\", "/")
 
 
 from tests.unit._per_file_cap_guard import (

--- a/tests/unit/test_architecture_resolved_identity_inline_cap.py
+++ b/tests/unit/test_architecture_resolved_identity_inline_cap.py
@@ -102,9 +102,18 @@ RESOLVED_IDENTITY_PER_FILE_CAP: dict[str, int] = {
 
 
 def _is_a2a_test_file(path: Path) -> bool:
-    """A2A test files are governed by the stricter zero-tolerance guard."""
+    """A2A test files are governed by the stricter zero-tolerance factory guard.
+
+    Path-aware: unit/integration/e2e ``test_a2a*`` (and architecture a2a guards)
+    are skipped here so the factory guard owns them at zero tolerance.
+    """
     name = path.name
-    return name.startswith("test_a2a") or name.startswith("test_architecture_a2a")
+    if name.startswith("test_architecture_a2a"):
+        return True
+    if not name.startswith("test_a2a"):
+        return False
+    parts = path.parts
+    return "unit" in parts or "integration" in parts or "e2e" in parts
 
 
 def _count_inline_resolved_identity(filepath: Path) -> list[int]:

--- a/tests/unit/test_error_code_mapping.py
+++ b/tests/unit/test_error_code_mapping.py
@@ -1,15 +1,13 @@
-"""Tests for the error code mapping from internal codes to SDK STANDARD_ERROR_CODES.
+"""Tests for the error code mapping from internal codes to wire-standard codes.
 
 Verifies that:
 1. ERROR_CODE_MAPPING exists and maps all known non-standard codes
-2. Every mapped target is in STANDARD_ERROR_CODES
+2. Every mapped target is in WIRE_STANDARD_CODES (SDK + pinned-spec supplement)
 3. INTERNAL_CODES set exists for codes that never reach the wire
 4. All AdCPError subclass error_code attributes are either standard or internal
 """
 
-from adcp.server.helpers import STANDARD_ERROR_CODES
-
-from src.core.exceptions import ERROR_CODE_MAPPING, INTERNAL_CODES, AdCPError
+from src.core.exceptions import ERROR_CODE_MAPPING, INTERNAL_CODES, WIRE_STANDARD_CODES, AdCPError
 
 
 class TestErrorCodeMapping:
@@ -20,29 +18,34 @@ class TestErrorCodeMapping:
         assert len(ERROR_CODE_MAPPING) > 0, "Mapping must not be empty"
 
     def test_all_targets_are_standard(self):
-        """Every mapped-to code must be in SDK STANDARD_ERROR_CODES."""
-        std = set(STANDARD_ERROR_CODES)
-        bad = {k: v for k, v in ERROR_CODE_MAPPING.items() if v not in std}
-        assert not bad, f"Mapping targets not in STANDARD_ERROR_CODES: {bad}"
+        """Every mapped-to code must be in WIRE_STANDARD_CODES.
+
+        Authority matches ``exceptions.py``: SDK ``STANDARD_ERROR_CODES`` plus
+        the pinned-spec supplement (e.g. ``REFERENCE_NOT_FOUND``). Targets that
+        are supplement-only are still wire-legal for buyers.
+        """
+        wire = set(WIRE_STANDARD_CODES)
+        bad = {k: v for k, v in ERROR_CODE_MAPPING.items() if v not in wire}
+        assert not bad, f"Mapping targets not in WIRE_STANDARD_CODES: {bad}"
 
     def test_internal_codes_exist(self):
         assert isinstance(INTERNAL_CODES, frozenset)
         assert len(INTERNAL_CODES) > 0, "Internal codes set must not be empty"
 
     def test_internal_codes_overlap_with_mapping_have_wire_safe_targets(self):
-        """Internal codes that also appear in the mapping must translate to STANDARD targets.
+        """Internal codes that also appear in the mapping must translate to wire targets.
 
         INTERNAL_CODES documents codes that should never reach the wire as-is.
         ERROR_CODE_MAPPING is the safety net: if an internal code escapes to a
         boundary (base-class raise instead of a specific subclass), the mapping
-        translates it to STANDARD_ERROR_CODES. Overlap is intentional — it
+        translates it to ``WIRE_STANDARD_CODES``. Overlap is intentional — it
         means "this code is internal AND has a wire-safe fallback if it leaks".
         Both invariants must hold for every overlap entry.
         """
-        std = set(STANDARD_ERROR_CODES)
+        wire = set(WIRE_STANDARD_CODES)
         overlap = set(ERROR_CODE_MAPPING.keys()) & INTERNAL_CODES
-        unsafe = {code: ERROR_CODE_MAPPING[code] for code in overlap if ERROR_CODE_MAPPING[code] not in std}
-        assert not unsafe, f"Internal codes in mapping must translate to STANDARD targets: {unsafe}"
+        unsafe = {code: ERROR_CODE_MAPPING[code] for code in overlap if ERROR_CODE_MAPPING[code] not in wire}
+        assert not unsafe, f"Internal codes in mapping must translate to WIRE_STANDARD_CODES targets: {unsafe}"
 
     def test_class_error_codes_are_standard_or_internal(self):
         """Every AdCPError subclass _default_error_code must be standard, internal, or spec-required.
@@ -51,8 +54,6 @@ class TestErrorCodeMapping:
         ). The public ``error_code`` is an instance attribute
         set in ``__init__`` and is not present on the class object.
         """
-        from src.core.exceptions import WIRE_STANDARD_CODES
-
         # Spec-required codes not yet in WIRE_STANDARD_CODES' supplement
         spec_codes = {"BILLING_NOT_SUPPORTED"}
         allowed = set(WIRE_STANDARD_CODES) | INTERNAL_CODES | spec_codes

--- a/tests/unit/test_error_format_consistency.py
+++ b/tests/unit/test_error_format_consistency.py
@@ -737,7 +737,7 @@ class TestErrorCodeVocabularyConsistency:
         "PRODUCT_NOT_FOUND",  # SDK standard: AdCPProductNotFoundError
         "SESSION_NOT_FOUND",  # SDK standard: AdCPContextNotFoundError (unresolvable context_id)
         "CREATIVE_NOT_FOUND",  # Spec supplement: AdCPCreativeNotFoundError (wire passthrough via WIRE_STANDARD_CODES)
-        "FORMAT_NOT_FOUND",  # Internal: AdCPFormatNotFoundError (wire → INVALID_REQUEST)
+        "FORMAT_NOT_FOUND",  # Internal: AdCPFormatNotFoundError (wire → REFERENCE_NOT_FOUND)
         "TASK_NOT_FOUND",  # Internal: AdCPTaskNotFoundError (wire → REFERENCE_NOT_FOUND)
         "BUDGET_TOO_LOW",  # SDK standard: AdCPBudgetTooLowError
         "UNSUPPORTED_FEATURE",  # SDK standard: AdCPCapabilityNotSupportedError

--- a/tests/unit/test_error_format_consistency.py
+++ b/tests/unit/test_error_format_consistency.py
@@ -738,7 +738,7 @@ class TestErrorCodeVocabularyConsistency:
         "SESSION_NOT_FOUND",  # SDK standard: AdCPContextNotFoundError (unresolvable context_id)
         "CREATIVE_NOT_FOUND",  # Spec supplement: AdCPCreativeNotFoundError (wire passthrough via WIRE_STANDARD_CODES)
         "FORMAT_NOT_FOUND",  # Internal: AdCPFormatNotFoundError (wire → INVALID_REQUEST)
-        "TASK_NOT_FOUND",  # Internal: AdCPTaskNotFoundError (wire → INVALID_REQUEST)
+        "TASK_NOT_FOUND",  # Internal: AdCPTaskNotFoundError (wire → REFERENCE_NOT_FOUND)
         "BUDGET_TOO_LOW",  # SDK standard: AdCPBudgetTooLowError
         "UNSUPPORTED_FEATURE",  # SDK standard: AdCPCapabilityNotSupportedError
         "IDEMPOTENCY_CONFLICT",  # SDK standard: AdCPIdempotencyConflictError

--- a/tests/unit/test_get_media_buys.py
+++ b/tests/unit/test_get_media_buys.py
@@ -38,39 +38,38 @@ from src.core.tools.media_buy_list import (
     _map_creative_status,
     _resolve_status_filter,
 )
+from tests.factories import PrincipalFactory
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
 
-_TESTING_CONTEXT_UNSET = object()
-
-
 def make_identity(
     tenant_id="tenant_1",
     principal_id="principal_1",
     tenant=None,
-    testing_context=_TESTING_CONTEXT_UNSET,
+    testing_context=PrincipalFactory.UNSET,
 ):
     """Create a ResolvedIdentity for testing.
 
     Omitting ``testing_context`` keeps the factory default (populated
     ``AdCPTestContext``). Pass ``testing_context=None`` explicitly for anonymous.
-    """
-    from tests.factories import PrincipalFactory
 
+    Defaults to ``PrincipalFactory.UNSET`` (rather than a second, locally
+    minted sentinel) so this wrapper's omitted-vs-explicit-``None`` handling
+    stays byte-identical to the factory's own — one spelling for "caller
+    didn't pass this" across both layers.
+    """
     if tenant is None:
         tenant = {"tenant_id": tenant_id, "adapter_type": "mock"}
-    kwargs: dict = {
-        "principal_id": principal_id,
-        "tenant_id": tenant_id,
-        "tenant": tenant,
-        "protocol": "mcp",
-    }
-    if testing_context is not _TESTING_CONTEXT_UNSET:
-        kwargs["testing_context"] = testing_context
-    return PrincipalFactory.make_identity(**kwargs)
+    return PrincipalFactory.make_identity(
+        principal_id=principal_id,
+        tenant_id=tenant_id,
+        tenant=tenant,
+        protocol="mcp",
+        testing_context=testing_context,
+    )
 
 
 def make_media_buy(

--- a/tests/unit/test_get_media_buys.py
+++ b/tests/unit/test_get_media_buys.py
@@ -44,24 +44,33 @@ from src.core.tools.media_buy_list import (
 # ---------------------------------------------------------------------------
 
 
+_TESTING_CONTEXT_UNSET = object()
+
+
 def make_identity(
     tenant_id="tenant_1",
     principal_id="principal_1",
     tenant=None,
-    testing_context=None,
+    testing_context=_TESTING_CONTEXT_UNSET,
 ):
-    """Create a ResolvedIdentity for testing."""
+    """Create a ResolvedIdentity for testing.
+
+    Omitting ``testing_context`` keeps the factory default (populated
+    ``AdCPTestContext``). Pass ``testing_context=None`` explicitly for anonymous.
+    """
     from tests.factories import PrincipalFactory
 
     if tenant is None:
         tenant = {"tenant_id": tenant_id, "adapter_type": "mock"}
-    return PrincipalFactory.make_identity(
-        principal_id=principal_id,
-        tenant_id=tenant_id,
-        tenant=tenant,
-        protocol="mcp",
-        testing_context=testing_context,
-    )
+    kwargs: dict = {
+        "principal_id": principal_id,
+        "tenant_id": tenant_id,
+        "tenant": tenant,
+        "protocol": "mcp",
+    }
+    if testing_context is not _TESTING_CONTEXT_UNSET:
+        kwargs["testing_context"] = testing_context
+    return PrincipalFactory.make_identity(**kwargs)
 
 
 def make_media_buy(


### PR DESCRIPTION
## Summary
- Close the A2A in-memory `tasks/get` auth bypass on current `main`: record `(tenant_id, principal_id)` at create and require auth-first ownership before serving.
- Apply the same gate to `tasks/cancel` via a shared `_get_owned_in_memory_task_or_raise` helper (DRY; no existence oracle — wrong principal → same `TaskNotFoundError` as unknown id; unauthenticated → auth-failure shape, deliberately distinct).
- Unit + in-process JSON-RPC wire tests pin owner allow, sibling deny, unauthenticated deny, infra InternalError recovery, and mutation proofs.

## Spec-Grounding
- **AdCP 3.1.1** `by-layer/L1/security.mdx` § Agent and Account Isolation (normative sales-agent MUST): bind state on create, verify on access, fail closed with a body that MUST NOT distinguish unauthorized from not-found. `:1045` contemplates transport-native `tasks/*` on the same authenticated channel. One inferential step: `:173` enumerates media buys / creatives / idempotency / session ids and does not name an A2A task handle literally — treating in-memory task handles as "every piece of state" is that inference.
- **A2A §3.3.2** names "Attempting to access a task created by another user" as its own scenario.
- No graded step at AdCP 3.1.1 targets the transport-native JSON-RPC `tasks/*` surface (0 of 198 storyboards); the equivalent invariant is graded on the AdCP `get_task_status`/`list_tasks` tool paths (8 steps, expecting `REFERENCE_NOT_FOUND`), which this repo does not implement. Wire code still `-32603` with `data: null` under v0.3 compat (#1670). Sender-side `error.recovery` MUST is graded elsewhere in the corpus (20 path assertions).
- Not-found shape kept as `TaskNotFoundError` (main contract from #1648).

## Non-goals / notes
- Independent of open PR #1544 (PM override): durable `resolve_durable_task_outcome` is contract sample only; later merge conflicts OK.
- Scrub (`audit_workflow_step_failure` / raw `str(exc)`): covered by open #1676 — **not** folded here.
- BDD harness substrate for live `@a2a` ownership scenarios deferred to #1780.

## Test plan
- [x] `uv run pytest tests/unit/test_a2a_task_identity_scope.py tests/unit/test_a2a_task_identity_wire.py`
- [x] Tip CI green (fail-fast)

Closes #1702
