### PR TITLE
feat(skills): ticket-start and prime for per-ticket worktree setup and session orientation

### DIFF
--- a/.claude/skills/prime/SKILL.md
+++ b/.claude/skills/prime/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: prime
+description: >
+  Orient a fresh session against the tickets in this worktree before any plan is
+  written: read them, ground them in the pinned AdCP version, and measure what
+  BDD coverage actually exists. Use at the start of every session in a ticket
+  worktree, including after compaction.
+---
+
+# Prime
+
+Produces a **falsifiable orientation** for the tickets in this worktree, then
+stops. No plan, no code — the point is to know what is true before proposing
+anything.
+
+## This skill does not restate the rules
+
+`CLAUDE.md` and `tests/CLAUDE.md` are already loaded in every session. They own
+the architecture patterns, the test-integrity policy, the DRY invariant and the
+spec-grounding gate. **Do not summarise them here or in your output.**
+
+A second copy of a rule drifts from the first, and drifted guidance in this repo
+has repeatedly sent people at the wrong thing: a stale comment blaming
+"generic-step shadowing" pointed at a bug fixed weeks earlier and cost about a
+week; a ledger mis-cited its own graduation three separate times; a memory note
+asserting a macOS/Linux duplication skew caused a legitimate ratchet improvement
+to be reverted three times before anyone measured it.
+
+So: rules live in `CLAUDE.md`. This skill produces only what is
+**ticket-specific and dynamic** — things that change per ticket and can be
+checked.
+
+## Steps
+
+### 1. Read the tickets
+
+```bash
+cat TICKETS
+gh issue view <n> --repo prebid/salesagent --comments
+```
+
+Read the comments, not just the body. In this repo the sharpest constraint is
+often in a comment — and several issues carry a `Measured on: <branch> @ <sha>`
+header. **If it does, grep that tree, not yours.** Four issues were once
+declared false-premise because someone grepped only the checked-out branch; the
+symbols were real, on the branch the author measured. Before writing "X does not
+exist", run `git log --all -S"X" --oneline`.
+
+### 2. Ground against the pinned AdCP version
+
+Resolve the pin, do not assume it:
+
+```bash
+grep -n 'adcp==' pyproject.toml
+grep -n 'targets AdCP spec' docs/adcp-spec-version.md
+```
+
+Then read the spec at that version — the worktree at `~/projects/adcp` is
+usually checked out somewhere else, so always go through `git show`:
+
+```bash
+cd ~/projects/adcp && git show v<PIN>:dist/schemas/<PIN>/<area>/<file>.json
+cd ~/projects/adcp && git show v<PIN>:dist/docs/<PIN>/building/implementation/<tool>.mdx
+```
+
+For protocol behaviour, record the **exact sentence** that mandates it and
+whether a conformance storyboard grades it — check
+`dist/compliance/<PIN>/` and say "ungraded" if nothing does. The installed SDK
+is a cross-check, never the authority.
+
+### 3. Measure the BDD coverage that exists
+
+This is the part nothing else tells you. For the ticket's use case:
+
+```bash
+ls tests/bdd/features/BR-UC-*<area>*.feature
+grep -c '^  Scenario' tests/bdd/features/BR-UC-<n>-*.feature
+grep -n '@T-UC-<n>' tests/bdd/features/BR-UC-<n>-*.feature | head -20
+grep -n 'T-UC-<n>' tests/bdd/conftest.py | head          # xfail routing
+grep -c '^tests/bdd/' tests/bdd/e2e_rest_known_failures.txt
+```
+
+Report **numbers**: how many scenarios, how many currently xfailed and why, how
+many sit in the e2e_rest ledger. "N scenarios, M xfailed, 2 ledgered" is
+checkable; "there is good coverage" is not.
+
+If the ticket implies graduating an xfail, read
+`.claude/rules/workflows/xpass-graduation.md` **now**, in full, before planning.
+
+### 4. Note who will grade the work
+
+Name them and point at their definitions — do not summarise their practices,
+for the drift reason above:
+
+```bash
+ls .claude/agents/ 2>/dev/null
+```
+
+The `code-review` skill fans out reviewers covering DRY, testing, layering,
+consistency, AdCP grounding, ratcheting allowlists and BDD grounding. Read the
+relevant one's definition before writing code it will judge.
+
+### 5. Note the tools that are not obvious
+
+- `.agent-index/` — generated `.pyi` stubs. Read these **before** scanning the
+  tree; a full-tree grep for a symbol they already index is wasted work.
+- `ast-grep` for structural queries; plain `grep` for text.
+- `saci test {unit,integration,bdd} <path|-k>` runs slices on the CI box.
+  `saci run` is the full gate. **`saci run` silently attaches to an in-flight
+  run for the same worktree** — if you have just committed, check the box
+  actually has your change before trusting a green result.
+- `make quality` is the local gate. It rewrites `.duplication-baseline` when
+  duplication genuinely drops; that is the ratchet working, not drift.
+
+### 6. Write the orientation down
+
+Into the ticket's bead if one exists, else `.claude/research/<ticket>.md`:
+
+- the spec citation and whether it is graded
+- the coverage numbers from step 3
+- which files the change will touch
+- **the Core Invariant** — one sentence naming what must stay true
+- open questions that would change the approach
+
+Then **stop and report**. Do not plan or implement until the orientation is
+agreed.
+
+## Anti-patterns
+
+- Restating `CLAUDE.md` instead of measuring this ticket
+- Asserting a symbol is absent from one branch's `src/`
+- Reporting prose where a count would be checkable
+- Planning inside this skill — orientation first, agreement, then a plan

--- a/.claude/skills/ticket-start/SKILL.md
+++ b/.claude/skills/ticket-start/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: ticket-start
+description: >
+  Start work on one or more GitHub tickets: branch off freshly-fetched
+  origin/main, create a sibling worktree, and give it an isolated beads
+  database. Use when picking up a ticket or a small batch of related tickets.
+  Follow with /prime to orient in the new worktree.
+---
+
+# Ticket Start
+
+Sets up the workspace for a ticket. Does no research and writes no code — that
+is `/prime`'s job, and it runs in the new worktree where the context belongs.
+
+## Usage
+
+```bash
+.claude/skills/ticket-start/ticket-start.sh 1776
+.claude/skills/ticket-start/ticket-start.sh 1776 1781      # a related batch
+```
+
+The first ticket names the branch and the worktree. Pass several only when they
+are genuinely one change — otherwise start them separately so each gets its own
+PR.
+
+## What it does
+
+1. **Validates every ticket first.** A typo'd number fails before anything is
+   created, so you never end up with a half-made worktree named after nothing.
+2. **Fetches `origin/main` and branches off that** — not local `main`, which is
+   stale in every worktree in this repo and is the usual cause of a "why is this
+   diff so large" PR.
+3. **Creates a sibling worktree** at `../salesagent-<ticket>`.
+4. **Seeds an isolated beads DB** into `.beads-local/` with `sqlite3 .backup`.
+   `cp` is wrong here: the shared DB is normally live with a WAL sidecar and a
+   plain copy can capture a torn page.
+5. **Writes `.envrc`** exporting `BEADS_DB`, with the mirror-back command baked
+   in — see the warning below.
+6. **Writes `TICKETS`** so `/prime` needs no arguments.
+
+## The beads warning, because it has already cost work
+
+`bd` resolves its database through `git-common-dir`, so without isolation every
+worktree writes the **shared** database and parallel agents clobber each other.
+That is why this exists.
+
+But isolated is not the same as disposable. Tickets you create or close in a
+worktree live **only** in that worktree until mirrored. On PR #1728 six tickets —
+including the entire deferral record for one ticket — existed nowhere else and
+were caught by hand minutes before teardown.
+
+So `.envrc` carries the mirror command, and you run it before you finish:
+
+```bash
+bd export --id "<ids>" -o /tmp/beads-mirror-<ticket>.jsonl
+cd <main-checkout> && env -u BEADS_DB bd import -i /tmp/beads-mirror-<ticket>.jsonl
+```
+
+`env -u BEADS_DB` is load-bearing. `cd` alone does **not** escape the exported
+variable — you will silently write back into the worktree DB you were trying to
+escape.
+
+## What it deliberately does not do
+
+- **Remove worktrees.** Never scripted. Removing a worktree is a decision with
+  no undo; do it yourself when you are sure.
+- **Touch the shared `.beads/`.** It reads it to seed, and never writes it.
+- **Run `bd sync`.** It is destructive in this repo and has lost tickets before.
+
+## Next
+
+```
+cd ../salesagent-<ticket>
+/prime
+```

--- a/.claude/skills/ticket-start/ticket-start.sh
+++ b/.claude/skills/ticket-start/ticket-start.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+# Create an isolated worktree for one or more GitHub tickets.
+#
+#   .claude/skills/ticket-start/ticket-start.sh 1776 1781
+#
+# Branches off freshly-fetched origin/main (NOT local main, which is stale in
+# every worktree here), creates a sibling worktree, and gives it its own beads
+# database so parallel agents cannot corrupt the shared one.
+#
+# Prints a `cd` line on stdout; everything else goes to stderr, so this is
+# safe to wrap:  cd "$(ticket-start.sh 1776)"
+
+set -eo pipefail
+
+say() { printf '%s\n' "$*" >&2; }
+die() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
+
+[ $# -ge 1 ] || die "usage: ticket-start.sh <issue-number> [issue-number ...]"
+command -v gh >/dev/null || die "gh CLI not found"
+command -v sqlite3 >/dev/null || die "sqlite3 not found (needed for a WAL-safe beads seed)"
+
+# This script lives at <worktree>/.claude/skills/ticket-start/ — three levels up.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SRC_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+cd "$SRC_ROOT"
+
+# The CANONICAL checkout — the parent of the shared .git dir — not whichever
+# worktree this happens to be invoked from. Seeding beads from a sibling
+# worktree would copy that worktree's isolated (or empty) DB instead of the
+# shared one, and the mirror-back command would point at the wrong place.
+MAIN_ROOT="$(cd "$(git rev-parse --git-common-dir)/.." && pwd)"
+
+REPO="$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null || echo prebid/salesagent)"
+
+# ── Validate every ticket BEFORE creating anything ────────────────────────────
+TITLES=()
+for n in "$@"; do
+  [[ "$n" =~ ^[0-9]+$ ]] || die "'$n' is not an issue number"
+  t="$(gh issue view "$n" --repo "$REPO" --json title --jq .title 2>/dev/null)" \
+    || die "issue #$n not found in $REPO"
+  TITLES+=("#$n $t")
+  say "  #$n  $t"
+done
+
+# ── Branch name: slug of the FIRST ticket, so it reads in a PR list ───────────
+PRIMARY="$1"
+SLUG="$(gh issue view "$PRIMARY" --repo "$REPO" --json title --jq .title \
+        | tr '[:upper:]' '[:lower:]' \
+        | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//' \
+        | cut -c1-48 | sed -E 's/-+$//')"
+BRANCH="fix/${PRIMARY}-${SLUG}"
+WT="$(dirname "$SRC_ROOT")/salesagent-${PRIMARY}"
+
+git show-ref --verify --quiet "refs/heads/$BRANCH" && die "branch $BRANCH already exists"
+[ -e "$WT" ] && die "$WT already exists — pick another ticket or remove it yourself (never scripted)"
+
+say ""
+say "Fetching origin/main…"
+git fetch origin main >/dev/null 2>&1 || die "git fetch failed"
+BASE="$(git rev-parse --short origin/main)"
+
+git worktree add -b "$BRANCH" "$WT" origin/main >/dev/null 2>&1 \
+  || die "git worktree add failed"
+say "Worktree  $WT"
+say "Branch    $BRANCH  (off origin/main @ $BASE)"
+
+# ── Beads isolation ───────────────────────────────────────────────────────────
+# bd resolves its DB via git-common-dir, so WITHOUT this every worktree writes
+# the shared main database and parallel agents clobber each other.
+SHARED_DB="$MAIN_ROOT/.beads/beads.db"
+mkdir -p "$WT/.beads-local"
+if [ -f "$SHARED_DB" ]; then
+  # .backup, not cp: the shared DB is usually live with a WAL sidecar, and a
+  # plain copy can capture a torn page.
+  sqlite3 "$SHARED_DB" ".backup '$WT/.beads-local/beads.db'" \
+    || die "failed to seed the local beads DB"
+  say "Beads     seeded from $SHARED_DB (sqlite .backup)"
+else
+  say "Beads     no shared DB found — starting empty"
+fi
+
+MIRROR="cd $MAIN_ROOT && env -u BEADS_DB bd import -i /tmp/beads-mirror-${PRIMARY}.jsonl"
+
+cat > "$WT/.envrc" <<ENVRC
+# Per-worktree beads DB. bd otherwise resolves via git-common-dir and would
+# mutate the SHARED database that every other worktree is also using.
+export BEADS_DB="\$PWD/.beads-local/beads.db"
+
+# ⚠ ISOLATED, NOT DISPOSABLE. Tickets created or closed here exist ONLY in this
+# file until you mirror them back. This has already cost real work: a full
+# deferral record survived only because it was noticed by hand before teardown.
+#
+# Mirror before you finish (ids: whatever you created/closed here):
+#   bd export --id "<ids>" -o /tmp/beads-mirror-${PRIMARY}.jsonl
+#   $MIRROR
+#
+# 'env -u BEADS_DB' is load-bearing — cd alone does NOT escape this export.
+ENVRC
+
+printf '%s\n' "${TITLES[@]}" > "$WT/TICKETS"
+say "Tickets   $WT/TICKETS"
+
+if command -v direnv >/dev/null; then
+  (cd "$WT" && direnv allow) >/dev/null 2>&1 || say "  (run 'direnv allow' in the worktree)"
+else
+  say "  direnv not installed — export BEADS_DB manually, or source .envrc"
+fi
+
+say ""
+say "Next:  cd $WT  &&  /prime"
+printf '%s\n' "$WT"


### PR DESCRIPTION
Two skills for the ticket → worktree → session loop. Split because they are different lifecycle moments: `ticket-start` runs once per ticket, `prime` runs every session in that worktree — including after every compaction, which is exactly when orientation gets lost.

## `/ticket-start <issue numbers>`

Validates every ticket **before** creating anything (a typo'd number fails before you own a half-made worktree), branches off freshly-fetched `origin/main` rather than local `main`, adds a sibling worktree, and gives it an isolated beads database.

The beads part is why this is a script and not a checklist. `bd` resolves its DB through `git-common-dir`, so without isolation every worktree writes the shared one and parallel agents clobber each other. Two details that are easy to get wrong and are handled here:

- the seed uses `sqlite3 .backup`, not `cp` — the shared DB is normally live with a WAL sidecar and a plain copy can capture a torn page
- it seeds from the **canonical checkout** (parent of the shared `.git`), not from whichever worktree invoked it, which would otherwise copy a sibling's isolated or empty DB

The `.envrc` it writes says **ISOLATED, NOT DISPOSABLE** and carries the mirror-back command. The existing wording — *"disposable, not synced back"* — is true of the file and false of the tickets in it: on #1728, six tickets including one ticket's entire deferral record existed nowhere else and were caught by hand before teardown. `env -u BEADS_DB` is spelled out because `cd` alone does not escape the export.

It deliberately never removes a worktree and never runs `bd sync`.

## `/prime`

Produces a falsifiable orientation for the tickets in the worktree, then stops — no plan, no code.

The important constraint is what it **doesn't** do: it does not restate `CLAUDE.md`, which is already loaded every session. A second copy of a rule drifts from the first, and drifted guidance in this repo has repeatedly sent people at the wrong thing — a stale comment blaming step-shadowing pointed at a bug fixed weeks earlier and cost about a week; a ledger mis-cited its own graduation three separate times; a memory note asserting a macOS duplication skew caused a legitimate ratchet improvement to be reverted three times before anyone measured it.

So it covers only what is ticket-specific and checkable:

- the tickets **and their comments** — the sharpest constraint is often in a comment, and several carry a `Measured on: <branch> @ <sha>` header meaning *grep that tree, not yours*
- the resolved AdCP pin, with the literal `git show v<PIN>:` command, plus whether a conformance storyboard grades the behaviour
- BDD coverage as **counts** — scenarios, xfails, ledger entries — because a number can be verified and "there is good coverage" cannot
- who will review it, by pointing at agent definitions rather than summarising their practices
- the non-obvious tooling: `.agent-index/` before tree scans, `ast-grep` for structural queries, and that **`saci run` silently attaches to an in-flight run for the same worktree** — a green result can belong to a tree without your commit

## Verification

`ticket-start` was run end to end against #1776. Its first run surfaced the seed-source bug fixed above. Error paths checked: no arguments, non-numeric argument, nonexistent issue, pre-existing branch, pre-existing worktree path.

No production code, no test changes.
