### PR TITLE
fix: grade creative-sync GEMINI misconfig as X_PREBID seller-specific advisory

### DIFF
--- a/src/core/tools/creatives/_assignments.py
+++ b/src/core/tools/creatives/_assignments.py
@@ -340,7 +340,7 @@ def _process_assignments(
             # PACKAGE_NOT_FOUND; per-condition parity is tracked in GH #1598).
             message = "; ".join(sorted(set(errors.values())))
             code = "CREATIVE_NOT_FOUND" if creative_id in not_found_creative_ids else "VALIDATION_ERROR"
-            entry = _failed_sync_result(creative_id, message, code=code)
+            entry = _failed_sync_result(creative_id, message, recovery="correctable", code=code)
             entry.assignment_errors = errors
         results.append(entry)
 

--- a/src/core/tools/creatives/_processing.py
+++ b/src/core/tools/creatives/_processing.py
@@ -29,6 +29,7 @@ from ._assets import _build_creative_data, _extract_message_from_assets, _extrac
 
 if TYPE_CHECKING:
     from src.core.database.repositories.creative import CreativeRepository
+    from src.core.schemas import FormatId
 
 logger = logging.getLogger(__name__)
 
@@ -83,7 +84,7 @@ def _check_gemini_key_or_advisory(
     creative_id: str,
     *,
     action_verb: str,
-    creative_format: Any,
+    creative_format: FormatId,
 ) -> str | SyncCreativeResult:
     """Return the GEMINI API key, or a missing-key advisory result.
 
@@ -95,7 +96,7 @@ def _check_gemini_key_or_advisory(
     gemini_api_key = get_config().gemini_api_key
     if gemini_api_key:
         return gemini_api_key
-    error_msg = f"Cannot {action_verb} generative creative {creative_format}: GEMINI_API_KEY not configured"
+    error_msg = f"Cannot {action_verb} generative creative {creative_format.id}: GEMINI_API_KEY not configured"
     logger.error(f"[sync_creatives] {error_msg}")
     return _gemini_key_missing_result(creative_id, error_msg)
 
@@ -453,7 +454,7 @@ def _update_existing_creative(
                     # Creative agent should have generated previews but didn't
                     error_msg = f"Preview generation failed for {existing_creative.creative_id}: no previews returned and no media_url provided"
                     logger.error(f"[sync_creatives] {error_msg}")
-                    return (_failed_sync_result(existing_creative.creative_id, error_msg), False)
+                    return (_failed_sync_result(existing_creative.creative_id, error_msg, recovery="transient"), False)
 
         except AdCPConfigurationError as config_error:
             # Residual non-GEMINI configuration errors (GEMINI missing returns early
@@ -741,7 +742,7 @@ def _create_new_creative(
                         # Creative agent should have generated previews but didn't
                         error_msg = f"Preview generation failed for {creative_id}: no previews returned and no media_url provided"
                         logger.error(f"[sync_creatives] {error_msg}")
-                        return (_failed_sync_result(creative_id, error_msg), False)
+                        return (_failed_sync_result(creative_id, error_msg, recovery="transient"), False)
 
         except AdCPConfigurationError as config_error:
             # Residual non-GEMINI configuration errors (GEMINI missing returns early

--- a/src/core/tools/creatives/_processing.py
+++ b/src/core/tools/creatives/_processing.py
@@ -85,15 +85,17 @@ def _check_gemini_key_or_advisory(
     *,
     action_verb: str,
     creative_format: FormatId,
+    tenant: dict[str, Any],
 ) -> str | SyncCreativeResult:
     """Return the GEMINI API key, or a missing-key advisory result.
 
-    Shared by the update and create generative branches so config lookup,
-    message assembly, and logging stay in one place.
+    Prefer the tenant/account key (DB-backed, harness-controllable) and fall
+    back to the process-global settings key so a tenant that configured its
+    own key is not blocked by a missing server-wide ``GEMINI_API_KEY``.
     """
     from src.core.config import get_config
 
-    gemini_api_key = get_config().gemini_api_key
+    gemini_api_key = tenant.get("gemini_api_key") or get_config().gemini_api_key
     if gemini_api_key:
         return gemini_api_key
     error_msg = f"Cannot {action_verb} generative creative {creative_format.id}: GEMINI_API_KEY not configured"
@@ -247,6 +249,7 @@ def _update_existing_creative(
                         existing_creative.creative_id,
                         action_verb="update",
                         creative_format=creative_format,
+                        tenant=tenant,
                     )
                     if isinstance(gemini_or_advisory, SyncCreativeResult):
                         return (gemini_or_advisory, False)
@@ -454,7 +457,15 @@ def _update_existing_creative(
                     # Creative agent should have generated previews but didn't
                     error_msg = f"Preview generation failed for {existing_creative.creative_id}: no previews returned and no media_url provided"
                     logger.error(f"[sync_creatives] {error_msg}")
-                    return (_failed_sync_result(existing_creative.creative_id, error_msg, recovery="transient"), False)
+                    return (
+                        _failed_sync_result(
+                            existing_creative.creative_id,
+                            error_msg,
+                            code="SERVICE_UNAVAILABLE",
+                            recovery="transient",
+                        ),
+                        False,
+                    )
 
         except AdCPConfigurationError as config_error:
             # Residual non-GEMINI configuration errors (GEMINI missing returns early
@@ -567,6 +578,7 @@ def _create_new_creative(
                         creative_id,
                         action_verb="build",
                         creative_format=creative_format,
+                        tenant=tenant,
                     )
                     if isinstance(gemini_or_advisory, SyncCreativeResult):
                         return (gemini_or_advisory, False)
@@ -742,7 +754,15 @@ def _create_new_creative(
                         # Creative agent should have generated previews but didn't
                         error_msg = f"Preview generation failed for {creative_id}: no previews returned and no media_url provided"
                         logger.error(f"[sync_creatives] {error_msg}")
-                        return (_failed_sync_result(creative_id, error_msg, recovery="transient"), False)
+                        return (
+                            _failed_sync_result(
+                                creative_id,
+                                error_msg,
+                                code="SERVICE_UNAVAILABLE",
+                                recovery="transient",
+                            ),
+                            False,
+                        )
 
         except AdCPConfigurationError as config_error:
             # Residual non-GEMINI configuration errors (GEMINI missing returns early

--- a/src/core/tools/creatives/_processing.py
+++ b/src/core/tools/creatives/_processing.py
@@ -86,6 +86,16 @@ def _failed_sync_result(
     )
 
 
+def _service_unavailable_result(creative_id: str, error_msg: str) -> SyncCreativeResult:
+    """Per-creative advisory for transient creative-agent / preview outages."""
+    return _failed_sync_result(
+        creative_id,
+        error_msg,
+        code="SERVICE_UNAVAILABLE",
+        recovery="transient",
+    )
+
+
 def _check_gemini_key_or_advisory(
     creative_id: str,
     *,
@@ -93,16 +103,15 @@ def _check_gemini_key_or_advisory(
     creative_format: _FormatIdLike,
     tenant: dict[str, Any],
 ) -> str | SyncCreativeResult:
-    """Return the GEMINI API key, or a missing-key advisory result.
+    """Return the account-scoped GEMINI API key, or a missing-key advisory result.
 
-    Policy: tenant/account key first (DB column / admin AI settings), then
-    process-global ``get_config().gemini_api_key``. A tenant that configured
-    its own key must not be blocked by a missing server-wide env key — same
-    tenant-then-platform order as ``src/services/ai/factory.py``.
+    Policy: sole source is the tenant/account key (DB column / admin AI
+    settings via the tenant dict). Process-global ``get_config().gemini_api_key``
+    is intentionally not consulted — a keyless seller on a server that injects
+    ``GEMINI_API_KEY`` into the process must still see the misconfiguration
+    advisory (multi-tenant isolation; e2e_rest can clear the DB row alone).
     """
-    from src.core.config import get_config
-
-    gemini_api_key = tenant.get("gemini_api_key") or get_config().gemini_api_key
+    gemini_api_key = tenant.get("gemini_api_key")
     if gemini_api_key:
         return gemini_api_key
     error_msg = f"Cannot {action_verb} generative creative {creative_format.id}: GEMINI_API_KEY not configured"
@@ -465,12 +474,7 @@ def _update_existing_creative(
                     error_msg = f"Preview generation failed for {existing_creative.creative_id}: no previews returned and no media_url provided"
                     logger.error(f"[sync_creatives] {error_msg}")
                     return (
-                        _failed_sync_result(
-                            existing_creative.creative_id,
-                            error_msg,
-                            code="SERVICE_UNAVAILABLE",
-                            recovery="transient",
-                        ),
+                        _service_unavailable_result(existing_creative.creative_id, error_msg),
                         False,
                     )
 
@@ -762,12 +766,7 @@ def _create_new_creative(
                         error_msg = f"Preview generation failed for {creative_id}: no previews returned and no media_url provided"
                         logger.error(f"[sync_creatives] {error_msg}")
                         return (
-                            _failed_sync_result(
-                                creative_id,
-                                error_msg,
-                                code="SERVICE_UNAVAILABLE",
-                                recovery="transient",
-                            ),
+                            _service_unavailable_result(creative_id, error_msg),
                             False,
                         )
 

--- a/src/core/tools/creatives/_processing.py
+++ b/src/core/tools/creatives/_processing.py
@@ -79,6 +79,27 @@ def _failed_sync_result(
     )
 
 
+def _check_gemini_key_or_advisory(
+    creative_id: str,
+    *,
+    action_verb: str,
+    creative_format: Any,
+) -> str | SyncCreativeResult:
+    """Return the GEMINI API key, or a missing-key advisory result.
+
+    Shared by the update and create generative branches so config lookup,
+    message assembly, and logging stay in one place.
+    """
+    from src.core.config import get_config
+
+    gemini_api_key = get_config().gemini_api_key
+    if gemini_api_key:
+        return gemini_api_key
+    error_msg = f"Cannot {action_verb} generative creative {creative_format}: GEMINI_API_KEY not configured"
+    logger.error(f"[sync_creatives] {error_msg}")
+    return _gemini_key_missing_result(creative_id, error_msg)
+
+
 def _update_existing_creative(
     creative: CreativeAsset,
     existing_creative: Any,
@@ -221,18 +242,14 @@ def _update_existing_creative(
                         f"checking for Gemini API key"
                     )
 
-                    # Get Gemini API key from config
-                    from src.core.config import get_config
-
-                    config = get_config()
-                    gemini_api_key = config.gemini_api_key
-
-                    if not gemini_api_key:
-                        error_msg = (
-                            f"Cannot update generative creative {creative_format}: GEMINI_API_KEY not configured"
-                        )
-                        logger.error(f"[sync_creatives] {error_msg}")
-                        return (_gemini_key_missing_result(existing_creative.creative_id, error_msg), False)
+                    gemini_or_advisory = _check_gemini_key_or_advisory(
+                        existing_creative.creative_id,
+                        action_verb="update",
+                        creative_format=creative_format,
+                    )
+                    if isinstance(gemini_or_advisory, SyncCreativeResult):
+                        return (gemini_or_advisory, False)
+                    gemini_api_key = gemini_or_advisory
 
                     # Extract message/brief from assets or inputs
                     message = _extract_message_from_assets(creative)
@@ -545,16 +562,14 @@ def _create_new_creative(
                         f"[sync_creatives] Detected generative format: {creative_format}, checking for Gemini API key"
                     )
 
-                    # Get Gemini API key from config
-                    from src.core.config import get_config
-
-                    config = get_config()
-                    gemini_api_key = config.gemini_api_key
-
-                    if not gemini_api_key:
-                        error_msg = f"Cannot build generative creative {creative_format}: GEMINI_API_KEY not configured"
-                        logger.error(f"[sync_creatives] {error_msg}")
-                        return (_gemini_key_missing_result(creative_id, error_msg), False)
+                    gemini_or_advisory = _check_gemini_key_or_advisory(
+                        creative_id,
+                        action_verb="build",
+                        creative_format=creative_format,
+                    )
+                    if isinstance(gemini_or_advisory, SyncCreativeResult):
+                        return (gemini_or_advisory, False)
+                    gemini_api_key = gemini_or_advisory
 
                     # Extract message/brief from assets or inputs
                     message = _extract_message_from_assets(creative)

--- a/src/core/tools/creatives/_processing.py
+++ b/src/core/tools/creatives/_processing.py
@@ -33,6 +33,21 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+_GEMINI_KEY_MISSING_SUGGESTION = "Ask the seller to configure GEMINI_API_KEY in their agent settings"
+
+
+def _failed_sync_result_from_error(creative_id: str, error: AdCPErrorDetail) -> SyncCreativeResult:
+    """Wrap a per-creative advisory Error in a failed SyncCreativeResult."""
+    return SyncCreativeResult(
+        creative_id=creative_id,
+        action="failed",
+        errors=[error],
+        review_feedback=None,
+        assigned_to=None,
+        assignment_errors=None,
+    )
+
+
 def _failed_sync_result(
     creative_id: str,
     error_msg: str,
@@ -426,7 +441,9 @@ def _update_existing_creative(
         except AdCPConfigurationError as config_error:
             # Server-side misconfiguration (e.g. GEMINI_API_KEY missing) is terminal
             # and admin-fixable — not a transient creative-agent outage. Surface it
-            # honestly so the buyer does not retry a misconfiguration.
+            # honestly so the buyer does not retry a misconfiguration. Use a
+            # platform-specific code (not CONFIGURATION_ERROR) so the advisory
+            # stays inside a success artifact without inverting wire-placement MUST.
             error_msg = str(config_error)
             logger.error(
                 "[sync_creatives] %s for update of %s", error_msg, existing_creative.creative_id, exc_info=True
@@ -716,7 +733,9 @@ def _create_new_creative(
         except AdCPConfigurationError as config_error:
             # Server-side misconfiguration (e.g. GEMINI_API_KEY missing) is terminal
             # and admin-fixable — not a transient creative-agent outage. Surface it
-            # honestly so the buyer does not retry a misconfiguration.
+            # honestly so the buyer does not retry a misconfiguration. Use a
+            # platform-specific code (not CONFIGURATION_ERROR) so the advisory
+            # stays inside a success artifact without inverting wire-placement MUST.
             error_msg = str(config_error)
             logger.error("[sync_creatives] %s - rejecting creative %s", error_msg, creative_id, exc_info=True)
             return (_failed_sync_result(creative_id, error_msg, code="CONFIGURATION_ERROR"), False)

--- a/src/core/tools/creatives/_processing.py
+++ b/src/core/tools/creatives/_processing.py
@@ -18,9 +18,11 @@ from adcp.types import CreativeAsset
 from adcp.types import Error as AdCPErrorDetail
 from pydantic import BaseModel
 
-from src.core.exceptions import RecoveryHint
+from src.core.exceptions import AdCPConfigurationError, RecoveryHint
 from src.core.helpers import _extract_format_info, _validate_creative_assets
+from src.core.helpers.outbound_error_mapping import raise_mapped_outbound_error
 from src.core.schemas import CreativeStatusEnum, SyncCreativeResult
+from src.core.security.outbound_http import OperatorEndpoint, OutboundError
 from src.core.validation_helpers import run_async_in_sync_context
 
 from ._assets import _build_creative_data, _extract_message_from_assets, _extract_url_from_assets
@@ -530,6 +532,36 @@ def _update_existing_creative(
                         False,
                     )
 
+        except AdCPConfigurationError as config_error:
+            # Seller-side misconfiguration raised by the dial/registry (not the
+            # GEMINI early-return path, which uses _gemini_key_missing_result).
+            # CONFIGURATION_ERROR / terminal — buyer must not retry.
+            error_msg = str(config_error)
+            logger.error(
+                "[sync_creatives] %s for update of %s",
+                error_msg,
+                existing_creative.creative_id,
+                exc_info=True,
+            )
+            return (
+                _failed_sync_result(
+                    existing_creative.creative_id,
+                    error_msg,
+                    recovery="terminal",
+                    code="CONFIGURATION_ERROR",
+                ),
+                False,
+            )
+        except OutboundError as outbound_error:
+            # A refused/undeliverable egress request is already classified by the
+            # seam — do not launder into the generic "Retry recommended" transient
+            # message below. raise_mapped_outbound_error always raises; the mapped
+            # AdCPError propagates to _sync.py's per-creative except AdCPError.
+            raise_mapped_outbound_error(
+                outbound_error,
+                provenance=OperatorEndpoint("the creative agent"),
+                logger=logger,
+            )
         except Exception as validation_error:
             # Creative agent validation failed for update (network error, agent down, etc.)
             # Do NOT update the creative - it needs validation before acceptance
@@ -809,6 +841,36 @@ def _create_new_creative(
                             False,
                         )
 
+        except AdCPConfigurationError as config_error:
+            # Seller-side misconfiguration raised by the dial/registry (not the
+            # GEMINI early-return path, which uses _gemini_key_missing_result).
+            # CONFIGURATION_ERROR / terminal — buyer must not retry.
+            error_msg = str(config_error)
+            logger.error(
+                "[sync_creatives] %s - rejecting creative %s",
+                error_msg,
+                creative_id,
+                exc_info=True,
+            )
+            return (
+                _failed_sync_result(
+                    creative_id,
+                    error_msg,
+                    recovery="terminal",
+                    code="CONFIGURATION_ERROR",
+                ),
+                False,
+            )
+        except OutboundError as outbound_error:
+            # A refused/undeliverable egress request is already classified by the
+            # seam — do not launder into the generic "Retry recommended" transient
+            # message below. raise_mapped_outbound_error always raises; the mapped
+            # AdCPError propagates to _sync.py's per-creative except AdCPError.
+            raise_mapped_outbound_error(
+                outbound_error,
+                provenance=OperatorEndpoint("the creative agent"),
+                logger=logger,
+            )
         except Exception as validation_error:
             # Creative agent validation failed (network error, agent down, etc.)
             # Do NOT store the creative - it needs validation before acceptance

--- a/src/core/tools/creatives/_processing.py
+++ b/src/core/tools/creatives/_processing.py
@@ -12,7 +12,7 @@ import logging
 import time
 import uuid
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Protocol, cast
 
 from adcp.types import CreativeAsset
 from pydantic import BaseModel
@@ -29,12 +29,18 @@ from ._assets import _build_creative_data, _extract_message_from_assets, _extrac
 
 if TYPE_CHECKING:
     from src.core.database.repositories.creative import CreativeRepository
-    from src.core.schemas import FormatId
+
+
+class _FormatIdLike(Protocol):
+    """SDK FormatId / FormatReferenceStructuredObject / repo FormatId — all expose ``.id``."""
+
+    id: str
+
 
 logger = logging.getLogger(__name__)
 
 
-_GEMINI_KEY_MISSING_SUGGESTION = "Ask the seller to configure GEMINI_API_KEY in their agent settings"
+_GEMINI_KEY_MISSING_SUGGESTION = "Ask the seller to configure a Gemini API key for this account"
 
 
 def _failed_sync_result_from_error(creative_id: str, error: AdCPErrorDetail) -> SyncCreativeResult:
@@ -84,14 +90,15 @@ def _check_gemini_key_or_advisory(
     creative_id: str,
     *,
     action_verb: str,
-    creative_format: FormatId,
+    creative_format: _FormatIdLike,
     tenant: dict[str, Any],
 ) -> str | SyncCreativeResult:
     """Return the GEMINI API key, or a missing-key advisory result.
 
-    Prefer the tenant/account key (DB-backed, harness-controllable) and fall
-    back to the process-global settings key so a tenant that configured its
-    own key is not blocked by a missing server-wide ``GEMINI_API_KEY``.
+    Policy: tenant/account key first (DB column / admin AI settings), then
+    process-global ``get_config().gemini_api_key``. A tenant that configured
+    its own key must not be blocked by a missing server-wide env key — same
+    tenant-then-platform order as ``src/services/ai/factory.py``.
     """
     from src.core.config import get_config
 
@@ -99,7 +106,7 @@ def _check_gemini_key_or_advisory(
     if gemini_api_key:
         return gemini_api_key
     error_msg = f"Cannot {action_verb} generative creative {creative_format.id}: GEMINI_API_KEY not configured"
-    logger.error(f"[sync_creatives] {error_msg}")
+    logger.error("[sync_creatives] %s (creative %s)", error_msg, creative_id)
     return _gemini_key_missing_result(creative_id, error_msg)
 
 

--- a/src/core/tools/creatives/_processing.py
+++ b/src/core/tools/creatives/_processing.py
@@ -96,6 +96,27 @@ def _service_unavailable_result(creative_id: str, error_msg: str) -> SyncCreativ
     )
 
 
+def _account_gemini_api_key(tenant: dict[str, Any]) -> str | None:
+    """Resolve the account Gemini key the same way admin AI review does.
+
+    Prefer ``ai_config.api_key`` (what the current admin AI-settings UI writes),
+    then the legacy ``gemini_api_key`` column. Never consult process-global
+    ``get_config().gemini_api_key`` — a keyless seller on a server that injects
+    ``GEMINI_API_KEY`` must still see the misconfiguration advisory.
+    """
+    ai_config = tenant.get("ai_config")
+    if isinstance(ai_config, dict):
+        ai_key = ai_config.get("api_key")
+        if ai_key:
+            return str(ai_key)
+    elif ai_config is not None:
+        ai_key = getattr(ai_config, "api_key", None)
+        if ai_key:
+            return str(ai_key)
+    legacy = tenant.get("gemini_api_key")
+    return str(legacy) if legacy else None
+
+
 def _check_gemini_key_or_advisory(
     creative_id: str,
     *,
@@ -105,13 +126,11 @@ def _check_gemini_key_or_advisory(
 ) -> str | SyncCreativeResult:
     """Return the account-scoped GEMINI API key, or a missing-key advisory result.
 
-    Policy: sole source is the tenant/account key (DB column / admin AI
-    settings via the tenant dict). Process-global ``get_config().gemini_api_key``
-    is intentionally not consulted — a keyless seller on a server that injects
-    ``GEMINI_API_KEY`` into the process must still see the misconfiguration
-    advisory (multi-tenant isolation; e2e_rest can clear the DB row alone).
+    Policy: sole sources are account AI settings (``ai_config.api_key``) then the
+    legacy ``gemini_api_key`` column on the tenant dict. Process-global
+    ``get_config().gemini_api_key`` is intentionally not consulted.
     """
-    gemini_api_key = tenant.get("gemini_api_key")
+    gemini_api_key = _account_gemini_api_key(tenant)
     if gemini_api_key:
         return gemini_api_key
     error_msg = f"Cannot {action_verb} generative creative {creative_format.id}: GEMINI_API_KEY not configured"

--- a/src/core/tools/creatives/_processing.py
+++ b/src/core/tools/creatives/_processing.py
@@ -15,14 +15,12 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, Protocol, cast
 
 from adcp.types import CreativeAsset
+from adcp.types import Error as AdCPErrorDetail
 from pydantic import BaseModel
 
-from src.core.exceptions import AdCPConfigurationError, wire_advisory
-from src.core.format_resolver import find_format, is_agent_backed, is_generative
+from src.core.exceptions import RecoveryHint
 from src.core.helpers import _extract_format_info, _validate_creative_assets
-from src.core.helpers.outbound_error_mapping import raise_mapped_outbound_error
 from src.core.schemas import CreativeStatusEnum, SyncCreativeResult
-from src.core.security.outbound_http import OperatorEndpoint, OutboundError
 from src.core.validation_helpers import run_async_in_sync_context
 
 from ._assets import _build_creative_data, _extract_message_from_assets, _extract_url_from_assets
@@ -59,30 +57,60 @@ def _failed_sync_result(
     creative_id: str,
     error_msg: str,
     *,
-    code: str = "SERVICE_UNAVAILABLE",
+    recovery: RecoveryHint,
+    code: str,
+    suggestion: str | None = None,
     field: str | None = None,
 ) -> SyncCreativeResult:
     """Build a SyncCreativeResult for a failed creative sync operation.
 
-    The CODE is the choice; the recovery follows from it. ``wire_advisory``
-    derives the buyer-facing retry classification from the pinned enumMetadata,
-    so a call site says what happened and the retry signal follows — for EVERY
-    call site now: the last hand-forwarded recovery went with the constructor
-    kwarg. Pass the condition-specific code: ``CONFIGURATION_ERROR`` for a
-    seller-side misconfiguration (pinned terminal — the buyer must not retry),
-    ``CREATIVE_NOT_FOUND`` for an assignment referencing an unknown creative_id
-    (matching the strict-mode ``AdCPCreativeNotFoundError`` raise since
-    287c93099), ``VALIDATION_ERROR`` for other buyer-correctable causes. The
-    default ``SERVICE_UNAVAILABLE`` (pinned transient) covers a creative agent
-    that is simply down.
+    ``code`` and ``recovery`` are both required keyword-only classifications —
+    a compile error at every call site — because ``error-handling.mdx``
+    (AdCP 3.1.1) requires senders to populate ``error.recovery`` on every
+    error, and a thought-through ``recovery`` must not ride a defaulted
+    unrelated ``code`` (e.g. ``SERVICE_UNAVAILABLE`` + ``correctable``).
+
+    ``transient`` distinguishes a retriable failure (creative agent down) from
+    ``correctable`` (buyer-fixable input) or ``terminal`` (server
+    misconfiguration — retrying cannot fix it). Pair ``SERVICE_UNAVAILABLE``
+    with ``recovery="transient"`` per the pinned enum. ``CONFIGURATION_ERROR``
+    is a wire-standard code but must not be used in payload advisories: the
+    enum requires flipped transport failure markers for that code, and
+    advisories live inside a successful ``sync_creatives`` artifact.
+    Misconfiguration advisories (e.g. missing GEMINI) use
+    ``_gemini_key_missing_result`` (seller-specific
+    ``X_PREBID_CREATIVE_GEMINI_KEY_MISSING`` + ``recovery="terminal"`` — AdCP
+    3.1.1 ``transport-errors.mdx`` § Seller-Specific Error Codes MUST:
+    ``X_{VENDOR}_{CODE}``). Buyer-correctable per-item failures pass the
+    condition-specific code: ``CREATIVE_NOT_FOUND`` for an assignment
+    referencing an unknown creative_id (matching the strict-mode
+    ``AdCPCreativeNotFoundError`` raise since 287c93099), ``VALIDATION_ERROR``
+    for other correctable causes.
+
+    Prefer ``to_wire_error_code(...)`` (not raw ``AdCPError.error_code`` or
+    ``wire_error_code``) when threading a typed exception into ``code`` —
+    advisories serialize verbatim and must not leak INTERNAL_CODES.
     """
-    return SyncCreativeResult(
-        creative_id=creative_id,
-        action="failed",
-        errors=[wire_advisory(code, error_msg, field=field)],
-        review_feedback=None,
-        assigned_to=None,
-        assignment_errors=None,
+    return _failed_sync_result_from_error(
+        creative_id,
+        AdCPErrorDetail(  # structural-guard: advisory per-creative result in SyncCreativeResult.errors[]
+            code=code,
+            message=error_msg,
+            recovery=recovery,
+            suggestion=suggestion,
+            field=field,
+        ),
+    )
+
+
+def _gemini_key_missing_result(creative_id: str, error_msg: str) -> SyncCreativeResult:
+    """Per-creative advisory for missing GEMINI_API_KEY (seller-specific code + terminal)."""
+    return _failed_sync_result(
+        creative_id,
+        error_msg,
+        code="X_PREBID_CREATIVE_GEMINI_KEY_MISSING",
+        recovery="terminal",
+        suggestion=_GEMINI_KEY_MISSING_SUGGESTION,
     )
 
 
@@ -267,13 +295,18 @@ def _update_existing_creative(
             # Use pre-fetched formats (fetched outside transaction at function start)
             # This avoids async HTTP calls inside savepoint
 
-            # ONE answer to "same format?", from format_resolver — not a local
-            # `==` over the model, which compares Python CLASSES as well as
-            # values and so missed every format the A2A path pre-upgraded.
-            format_obj = find_format(creative_format, all_formats)
+            # Find matching format
+            format_obj = None
+            for fmt in all_formats:
+                if fmt.format_id == creative_format:
+                    format_obj = fmt
+                    break
 
-            if format_obj and is_agent_backed(format_obj):
-                if is_generative(format_obj):
+            if format_obj and format_obj.agent_url:
+                # Check if format is generative (has output_format_ids)
+                is_generative = bool(getattr(format_obj, "output_format_ids", None))
+
+                if is_generative:
                     # Generative creative update - rebuild using AI
                     logger.info(
                         f"[sync_creatives] Detected generative format update: {creative_format}, "
@@ -497,27 +530,6 @@ def _update_existing_creative(
                         False,
                     )
 
-        except AdCPConfigurationError as config_error:
-            # Residual non-GEMINI configuration errors (GEMINI missing returns early
-            # above). Keep a generic terminal advisory — do not remap to the
-            # GEMINI-specific platform code.
-            error_msg = str(config_error)
-            logger.error(
-                "[sync_creatives] %s for update of %s", error_msg, existing_creative.creative_id, exc_info=True
-            )
-            return (_failed_sync_result(existing_creative.creative_id, error_msg, code="CONFIGURATION_ERROR"), False)
-        except OutboundError as outbound_error:
-            # A refused/undeliverable egress request is already correctly classified
-            # by the seam — delegate rather than laundering it into the generic
-            # "Retry recommended" transient message below. raise_mapped_outbound_error
-            # always raises; the mapped AdCPError propagates out of this function to
-            # _sync.py's per-creative `except AdCPError as e:` handler, which already
-            # forwards a typed error's own code/recovery onto the per-item result.
-            raise_mapped_outbound_error(
-                outbound_error,
-                provenance=OperatorEndpoint("the creative agent"),
-                logger=logger,
-            )
         except Exception as validation_error:
             # Creative agent validation failed for update (network error, agent down, etc.)
             # Do NOT update the creative - it needs validation before acceptance
@@ -529,7 +541,10 @@ def _update_existing_creative(
                 f"[sync_creatives] {error_msg} for update of {existing_creative.creative_id}",
                 exc_info=True,
             )
-            return (_failed_sync_result(existing_creative.creative_id, error_msg), False)
+            return (
+                _service_unavailable_result(existing_creative.creative_id, error_msg),
+                False,
+            )
 
     # In full upsert, consider all fields as changed
     changes.extend(["url", "click_url", "width", "height", "duration"])
@@ -592,13 +607,18 @@ def _create_new_creative(
             # Use pre-fetched formats (fetched outside transaction at function start)
             # This avoids async HTTP calls inside savepoint
 
-            # ONE answer to "same format?", from format_resolver — not a local
-            # `==` over the model, which compares Python CLASSES as well as
-            # values and so missed every format the A2A path pre-upgraded.
-            format_obj = find_format(creative_format, all_formats)
+            # Find matching format
+            format_obj = None
+            for fmt in all_formats:
+                if fmt.format_id == creative_format:
+                    format_obj = fmt
+                    break
 
-            if format_obj and is_agent_backed(format_obj):
-                if is_generative(format_obj):
+            if format_obj and format_obj.agent_url:
+                # Check if format is generative (has output_format_ids)
+                is_generative = bool(getattr(format_obj, "output_format_ids", None))
+
+                if is_generative:
                     # Generative creative - call build_creative
                     logger.info(
                         f"[sync_creatives] Detected generative format: {creative_format}, checking for Gemini API key"
@@ -789,25 +809,6 @@ def _create_new_creative(
                             False,
                         )
 
-        except AdCPConfigurationError as config_error:
-            # Residual non-GEMINI configuration errors (GEMINI missing returns early
-            # above). Keep a generic terminal advisory — do not remap to the
-            # GEMINI-specific platform code.
-            error_msg = str(config_error)
-            logger.error("[sync_creatives] %s - rejecting creative %s", error_msg, creative_id, exc_info=True)
-            return (_failed_sync_result(creative_id, error_msg, code="CONFIGURATION_ERROR"), False)
-        except OutboundError as outbound_error:
-            # A refused/undeliverable egress request is already correctly classified
-            # by the seam — delegate rather than laundering it into the generic
-            # "Retry recommended" transient message below. raise_mapped_outbound_error
-            # always raises; the mapped AdCPError propagates out of this function to
-            # _sync.py's per-creative `except AdCPError as e:` handler, which already
-            # forwards a typed error's own code/recovery onto the per-item result.
-            raise_mapped_outbound_error(
-                outbound_error,
-                provenance=OperatorEndpoint("the creative agent"),
-                logger=logger,
-            )
         except Exception as validation_error:
             # Creative agent validation failed (network error, agent down, etc.)
             # Do NOT store the creative - it needs validation before acceptance
@@ -819,7 +820,10 @@ def _create_new_creative(
                 f"[sync_creatives] {error_msg} - rejecting creative {creative_id}",
                 exc_info=True,
             )
-            return (_failed_sync_result(creative_id, error_msg), False)
+            return (
+                _service_unavailable_result(creative_id, error_msg),
+                False,
+            )
 
     # Determine creative status based on approval mode
 

--- a/src/core/tools/creatives/_processing.py
+++ b/src/core/tools/creatives/_processing.py
@@ -232,7 +232,7 @@ def _update_existing_creative(
                             f"Cannot update generative creative {creative_format}: GEMINI_API_KEY not configured"
                         )
                         logger.error(f"[sync_creatives] {error_msg}")
-                        raise AdCPConfigurationError(error_msg)
+                        return (_gemini_key_missing_result(existing_creative.creative_id, error_msg), False)
 
                     # Extract message/brief from assets or inputs
                     message = _extract_message_from_assets(creative)
@@ -439,11 +439,9 @@ def _update_existing_creative(
                     return (_failed_sync_result(existing_creative.creative_id, error_msg), False)
 
         except AdCPConfigurationError as config_error:
-            # Server-side misconfiguration (e.g. GEMINI_API_KEY missing) is terminal
-            # and admin-fixable — not a transient creative-agent outage. Surface it
-            # honestly so the buyer does not retry a misconfiguration. Use a
-            # platform-specific code (not CONFIGURATION_ERROR) so the advisory
-            # stays inside a success artifact without inverting wire-placement MUST.
+            # Residual non-GEMINI configuration errors (GEMINI missing returns early
+            # above). Keep a generic terminal advisory — do not remap to the
+            # GEMINI-specific platform code.
             error_msg = str(config_error)
             logger.error(
                 "[sync_creatives] %s for update of %s", error_msg, existing_creative.creative_id, exc_info=True
@@ -556,7 +554,7 @@ def _create_new_creative(
                     if not gemini_api_key:
                         error_msg = f"Cannot build generative creative {creative_format}: GEMINI_API_KEY not configured"
                         logger.error(f"[sync_creatives] {error_msg}")
-                        raise AdCPConfigurationError(error_msg)
+                        return (_gemini_key_missing_result(creative_id, error_msg), False)
 
                     # Extract message/brief from assets or inputs
                     message = _extract_message_from_assets(creative)
@@ -731,11 +729,9 @@ def _create_new_creative(
                         return (_failed_sync_result(creative_id, error_msg), False)
 
         except AdCPConfigurationError as config_error:
-            # Server-side misconfiguration (e.g. GEMINI_API_KEY missing) is terminal
-            # and admin-fixable — not a transient creative-agent outage. Surface it
-            # honestly so the buyer does not retry a misconfiguration. Use a
-            # platform-specific code (not CONFIGURATION_ERROR) so the advisory
-            # stays inside a success artifact without inverting wire-placement MUST.
+            # Residual non-GEMINI configuration errors (GEMINI missing returns early
+            # above). Keep a generic terminal advisory — do not remap to the
+            # GEMINI-specific platform code.
             error_msg = str(config_error)
             logger.error("[sync_creatives] %s - rejecting creative %s", error_msg, creative_id, exc_info=True)
             return (_failed_sync_result(creative_id, error_msg, code="CONFIGURATION_ERROR"), False)

--- a/src/core/tools/creatives/_sync.py
+++ b/src/core/tools/creatives/_sync.py
@@ -25,7 +25,12 @@ from src.core.webhook_validator import webhook_url_for_log
 from src.core.webhooks.registration import accept_push_notification_config
 
 from ._assignments import _process_assignments
-from ._processing import _create_new_creative, _failed_sync_result, _update_existing_creative
+from ._processing import (
+    _create_new_creative,
+    _failed_sync_result,
+    _service_unavailable_result,
+    _update_existing_creative,
+)
 from ._validation import _get_field, _validate_creative_input, check_provenance_required
 from ._workflow import _audit_log_sync, _create_sync_workflow_steps, _send_creative_notifications
 
@@ -415,14 +420,7 @@ def _sync_creatives_impl(
                     {"creative_id": creative_id, "name": _get_field(raw_creative, "name"), "error": error_msg}
                 )
                 failed_count += 1
-                results.append(
-                    _failed_sync_result(
-                        creative_id,
-                        error_msg,
-                        code="SERVICE_UNAVAILABLE",
-                        recovery="transient",
-                    )
-                )
+                results.append(_service_unavailable_result(creative_id, error_msg))
 
         # Archive creatives not in the sync payload when delete_missing=True
         if delete_missing:

--- a/src/core/tools/creatives/_sync.py
+++ b/src/core/tools/creatives/_sync.py
@@ -21,8 +21,7 @@ from src.core.helpers import log_tool_activity
 from src.core.resolved_identity import ResolvedIdentity
 from src.core.schemas import SyncCreativeResult, SyncCreativesResponse
 from src.core.validation_helpers import format_validation_error, run_async_in_sync_context
-from src.core.webhook_validator import webhook_url_for_log
-from src.core.webhooks.registration import accept_push_notification_config
+from src.core.webhook_validator import reject_unsafe_webhook_registration_url, webhook_url_for_log
 
 from ._assignments import _process_assignments
 from ._processing import (
@@ -54,7 +53,7 @@ def _sync_creatives_impl(
     delete_missing: bool = False,
     dry_run: bool = False,
     validation_mode: str = "strict",
-    push_notification_config: PushNotificationConfig | None = None,
+    push_notification_config: PushNotificationConfig | dict | None = None,
     context: ContextObject | dict | None = None,
     identity: ResolvedIdentity | None = None,
 ) -> SyncCreativesResponse:
@@ -104,26 +103,18 @@ def _sync_creatives_impl(
     identity = require_identity(identity, context=context)
     tenant = require_tenant(identity, context=context)
 
-    # Registration SSRF gate on the buyer-supplied webhook URL, taken HERE: before
-    # any DB / workflow write stashes the URL, and before the per-creative loop,
-    # whose per-item `try` would turn this correctable VALIDATION_ERROR into a
-    # per-item transient failure and tell the buyer to retry a URL that will never
-    # be allowed. The AI-review callback fires from a background worker, so ingest
-    # is the only gate with a request left to refuse into.
-    #
-    # Deliberately the no-DNS registration gate (gh-#1697), NOT the outbound seam's
-    # validate_url (gh-#1589): validate_url always resolves, so at registration it
-    # would reject a buyer whose hostname has not yet propagated. The seam stays the
-    # SEND-time gate and re-checks with DNS when the callback is actually dialed —
-    # so no second address check belongs on this path.
+    # Registration SSRF gate before any DB / workflow writes that stash the URL.
     webhook_url = None
     if push_notification_config:
-        registration = accept_push_notification_config(
-            push_notification_config,
-            field_prefix="push_notification_config",
+        if isinstance(push_notification_config, dict):
+            webhook_url = push_notification_config.get("url")
+        else:
+            webhook_url = str(push_notification_config.url) if push_notification_config.url else None
+        reject_unsafe_webhook_registration_url(
+            webhook_url,
+            field="push_notification_config.url",
             context=context,
         )
-        webhook_url = registration.url
         if webhook_url is not None and str(webhook_url).strip():
             # Log scheme+host+path only — never credentials / full auth blob.
             logger.info(
@@ -175,7 +166,7 @@ def _sync_creatives_impl(
             )
 
         # Process each creative with proper transaction isolation
-        for creative_index, raw_creative in enumerate(creatives):
+        for raw_creative in creatives:
             try:
                 # Normalize to CreativeAsset model (handles dicts from A2A raw, BaseModel subclasses)
                 if isinstance(raw_creative, CreativeAsset):
@@ -190,7 +181,7 @@ def _sync_creatives_impl(
 
                 # Validate the creative against schema and business rules
                 try:
-                    validated_creative = _validate_creative_input(creative, registry, principal_id, creative_index)
+                    validated_creative = _validate_creative_input(creative, registry, principal_id)
                     format_value = validated_creative.format
 
                 except (ValidationError, ValueError) as validation_error:
@@ -394,22 +385,17 @@ def _sync_creatives_impl(
                     {"creative_id": creative_id, "name": _get_field(raw_creative, "name"), "error": error_msg}
                 )
                 failed_count += 1
-                # Carry the typed error's OWN classification onto the per-item
-                # result. The default is SERVICE_UNAVAILABLE — now paired with the
-                # pin's `transient` rather than left empty — which for a
-                # correctable error reports the SELLER as unavailable for a
-                # problem in the buyer's own document, and drops the `field` that
-                # says which input to fix. That matters most for an egress
-                # refusal, whose message deliberately says nothing.
-                # The recovery is no longer forwarded: it derives from the code in
-                # wire_advisory, and the raise sites that used to hand-type a
-                # contradicting terminal no longer can.
+                # e.recovery is correctable/terminal here (transient re-raises above) —
+                # thread the typed error's own classification through.
                 results.append(
                     _failed_sync_result(
                         creative_id,
                         error_msg,
-                        code=e.error_code,
-                        field=getattr(e, "field", None),
+                        # to_wire_error_code (not e.error_code / e.wire_error_code):
+                        # advisories serialize verbatim and must not leak INTERNAL_CODES.
+                        code=to_wire_error_code(e.error_code),
+                        recovery=e.recovery,
+                        field=e.field,
                     )
                 )
             except Exception as e:

--- a/src/core/tools/creatives/_sync.py
+++ b/src/core/tools/creatives/_sync.py
@@ -21,7 +21,8 @@ from src.core.helpers import log_tool_activity
 from src.core.resolved_identity import ResolvedIdentity
 from src.core.schemas import SyncCreativeResult, SyncCreativesResponse
 from src.core.validation_helpers import format_validation_error, run_async_in_sync_context
-from src.core.webhook_validator import reject_unsafe_webhook_registration_url, webhook_url_for_log
+from src.core.webhook_validator import webhook_url_for_log
+from src.core.webhooks.registration import accept_push_notification_config
 
 from ._assignments import _process_assignments
 from ._processing import (
@@ -103,18 +104,26 @@ def _sync_creatives_impl(
     identity = require_identity(identity, context=context)
     tenant = require_tenant(identity, context=context)
 
-    # Registration SSRF gate before any DB / workflow writes that stash the URL.
+    # Registration SSRF gate on the buyer-supplied webhook URL, taken HERE: before
+    # any DB / workflow write stashes the URL, and before the per-creative loop,
+    # whose per-item `try` would turn this correctable VALIDATION_ERROR into a
+    # per-item transient failure and tell the buyer to retry a URL that will never
+    # be allowed. The AI-review callback fires from a background worker, so ingest
+    # is the only gate with a request left to refuse into.
+    #
+    # Deliberately the no-DNS registration gate (gh-#1697), NOT the outbound seam's
+    # validate_url (gh-#1589): validate_url always resolves, so at registration it
+    # would reject a buyer whose hostname has not yet propagated. The seam stays the
+    # SEND-time gate and re-checks with DNS when the callback is actually dialed —
+    # so no second address check belongs on this path.
     webhook_url = None
     if push_notification_config:
-        if isinstance(push_notification_config, dict):
-            webhook_url = push_notification_config.get("url")
-        else:
-            webhook_url = str(push_notification_config.url) if push_notification_config.url else None
-        reject_unsafe_webhook_registration_url(
-            webhook_url,
-            field="push_notification_config.url",
+        registration = accept_push_notification_config(
+            push_notification_config,
+            field_prefix="push_notification_config",
             context=context,
         )
+        webhook_url = registration.url
         if webhook_url is not None and str(webhook_url).strip():
             # Log scheme+host+path only — never credentials / full auth blob.
             logger.info(

--- a/src/core/tools/creatives/_sync.py
+++ b/src/core/tools/creatives/_sync.py
@@ -11,7 +11,12 @@ from pydantic import BaseModel
 
 from src.core.auth import require_identity, require_principal_id, require_tenant
 from src.core.database.repositories.uow import CreativeUoW
-from src.core.exceptions import AdCPError
+from src.core.exceptions import (
+    VALIDATION_ERROR_SUGGESTION,
+    AdCPError,
+    first_validation_error_field,
+    to_wire_error_code,
+)
 from src.core.helpers import log_tool_activity
 from src.core.resolved_identity import ResolvedIdentity
 from src.core.schemas import SyncCreativeResult, SyncCreativesResponse
@@ -187,8 +192,12 @@ def _sync_creatives_impl(
                     # Creative failed validation - add to failed list
                     creative_id = creative.creative_id or "unknown"
                     # Format ValidationError nicely for clients, pass through ValueError as-is
+                    field: str | None = None
+                    suggestion: str | None = None
                     if isinstance(validation_error, ValidationError):
                         error_msg = format_validation_error(validation_error, context=f"creative {creative_id}")
+                        field = first_validation_error_field(validation_error)
+                        suggestion = VALIDATION_ERROR_SUGGESTION
                     else:
                         error_msg = str(validation_error)
                     failed_creatives.append({"creative_id": creative_id, "error": error_msg})
@@ -199,6 +208,8 @@ def _sync_creatives_impl(
                             error_msg,
                             code="VALIDATION_ERROR",
                             recovery="correctable",
+                            field=field,
+                            suggestion=suggestion,
                         )
                     )
                     continue  # Skip to next creative

--- a/src/core/tools/creatives/_sync.py
+++ b/src/core/tools/creatives/_sync.py
@@ -193,7 +193,7 @@ def _sync_creatives_impl(
                         error_msg = str(validation_error)
                     failed_creatives.append({"creative_id": creative_id, "error": error_msg})
                     failed_count += 1
-                    results.append(_failed_sync_result(creative_id, error_msg))
+                    results.append(_failed_sync_result(creative_id, error_msg, recovery="correctable"))
                     continue  # Skip to next creative
 
                 # Check provenance requirement (EU AI Act Article 50)
@@ -397,7 +397,7 @@ def _sync_creatives_impl(
                     {"creative_id": creative_id, "name": _get_field(raw_creative, "name"), "error": error_msg}
                 )
                 failed_count += 1
-                results.append(_failed_sync_result(creative_id, error_msg))
+                results.append(_failed_sync_result(creative_id, error_msg, recovery="transient"))
 
         # Archive creatives not in the sync payload when delete_missing=True
         if delete_missing:

--- a/src/core/tools/creatives/_sync.py
+++ b/src/core/tools/creatives/_sync.py
@@ -117,12 +117,14 @@ def _sync_creatives_impl(
     # SEND-time gate and re-checks with DNS when the callback is actually dialed —
     # so no second address check belongs on this path.
     webhook_url = None
+    normalized_push_notification_config: PushNotificationConfig | None = None
     if push_notification_config:
         registration = accept_push_notification_config(
             push_notification_config,
             field_prefix="push_notification_config",
             context=context,
         )
+        normalized_push_notification_config = registration
         webhook_url = registration.url
         if webhook_url is not None and str(webhook_url).strip():
             # Log scheme+host+path only — never credentials / full auth blob.
@@ -459,7 +461,7 @@ def _sync_creatives_impl(
             principal_id=principal_id,
             tenant=tenant,
             approval_mode=approval_mode,
-            push_notification_config=push_notification_config,
+            push_notification_config=normalized_push_notification_config,
             context=context,
             identity=identity,
         )

--- a/src/core/tools/creatives/_sync.py
+++ b/src/core/tools/creatives/_sync.py
@@ -124,7 +124,7 @@ def _sync_creatives_impl(
             field_prefix="push_notification_config",
             context=context,
         )
-        normalized_push_notification_config = registration
+        normalized_push_notification_config = registration.config
         webhook_url = registration.url
         if webhook_url is not None and str(webhook_url).strip():
             # Log scheme+host+path only — never credentials / full auth blob.

--- a/src/core/tools/creatives/_sync.py
+++ b/src/core/tools/creatives/_sync.py
@@ -193,7 +193,14 @@ def _sync_creatives_impl(
                         error_msg = str(validation_error)
                     failed_creatives.append({"creative_id": creative_id, "error": error_msg})
                     failed_count += 1
-                    results.append(_failed_sync_result(creative_id, error_msg, recovery="correctable"))
+                    results.append(
+                        _failed_sync_result(
+                            creative_id,
+                            error_msg,
+                            code="VALIDATION_ERROR",
+                            recovery="correctable",
+                        )
+                    )
                     continue  # Skip to next creative
 
                 # Check provenance requirement (EU AI Act Article 50)
@@ -397,7 +404,14 @@ def _sync_creatives_impl(
                     {"creative_id": creative_id, "name": _get_field(raw_creative, "name"), "error": error_msg}
                 )
                 failed_count += 1
-                results.append(_failed_sync_result(creative_id, error_msg, recovery="transient"))
+                results.append(
+                    _failed_sync_result(
+                        creative_id,
+                        error_msg,
+                        code="SERVICE_UNAVAILABLE",
+                        recovery="transient",
+                    )
+                )
 
         # Archive creatives not in the sync payload when delete_missing=True
         if delete_missing:

--- a/src/core/tools/creatives/_workflow.py
+++ b/src/core/tools/creatives/_workflow.py
@@ -20,7 +20,7 @@ def _create_sync_workflow_steps(
     principal_id: str,
     tenant: dict[str, Any],
     approval_mode: str,
-    push_notification_config: PushNotificationConfig | None,
+    push_notification_config: PushNotificationConfig | dict[str, object] | None,
     context: ContextObject | dict | None,
     identity: ResolvedIdentity | None = None,
 ) -> None:

--- a/src/core/tools/creatives/_workflow.py
+++ b/src/core/tools/creatives/_workflow.py
@@ -20,7 +20,7 @@ def _create_sync_workflow_steps(
     principal_id: str,
     tenant: dict[str, Any],
     approval_mode: str,
-    push_notification_config: PushNotificationConfig | dict[str, object] | None,
+    push_notification_config: PushNotificationConfig | None,
     context: ContextObject | dict | None,
     identity: ResolvedIdentity | None = None,
 ) -> None:

--- a/src/core/utils/tenant_utils.py
+++ b/src/core/utils/tenant_utils.py
@@ -53,6 +53,9 @@ def serialize_tenant_to_dict(tenant: Tenant) -> dict[str, Any]:
         "account_approval_mode": tenant.account_approval_mode,
         "supported_billing": safe_json_loads(tenant.supported_billing, None),
         "gemini_api_key": tenant.gemini_api_key,
+        # Admin AI-settings UI writes here; creative-sync key resolution prefers
+        # ai_config.api_key over the legacy gemini_api_key column (#1831 / #1835).
+        "ai_config": tenant.ai_config,
         "creative_review_criteria": tenant.creative_review_criteria,
         "brand_manifest_policy": tenant.brand_manifest_policy,
         "advertising_policy": safe_json_loads(tenant.advertising_policy, None),

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -487,7 +487,8 @@ and so cannot catch a serialization regression.
 |-----------|------------------------|-------|
 | REST | HTTP JSON body (`response.json()`) | Real wire; equals `raw_response.json()`. |
 | MCP  | `ToolResult.structured_content` (real wire) | Stored by `_run_mcp_client`. |
-| A2A  | Full artifact DataPart (real wire) | Stored by `_run_a2a_handler` before the `message`/`success` strip, so top-level envelope fields are present. |
+| A2A  | Full artifact DataPart (real wire), or a `model_dump()` proxy for envs blocked on a documented real-dispatch bug | Stored by `_run_a2a_handler` before the `message`/`success` strip (real wire), so top-level envelope fields are present. Envs that instead call the `_raw()` wrapper directly (e.g. `CreativeSyncEnv`) set `envelope["wire_response_is_proxy"] = True` — check that flag before treating `wire_response` as a genuine A2A-framing check. |
+| IMPL | `None` (no wire by definition) | Serialize the typed `payload` (`model_dump(mode="json")`) — exercises the production serializer, not transport framing. |
 
 See
 `tests/integration/test_harness_wire_response.py` (verifies that the field is

--- a/tests/bdd/conftest.py
+++ b/tests/bdd/conftest.py
@@ -1312,11 +1312,6 @@ def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
                 "_SyntheticError, spec expects structured AdCPError with suggestion "
                 "(preview-failure path, _processing.py:712-737)"
             ),
-            "T-UC-006-ext-i": (
-                "SPEC-PRODUCTION GAP: production returns plain-string errors[] via "
-                "_SyntheticError, spec expects structured AdCPError with suggestion "
-                "(GEMINI_API_KEY not configured path)"
-            ),
             # Creative unchanged: production returns action "updated" not "unchanged"
             "T-UC-006-main-unchanged": (
                 "SPEC-PRODUCTION GAP: production returns action 'updated', "

--- a/tests/bdd/features/BR-UC-006-sync-creatives.feature
+++ b/tests/bdd/features/BR-UC-006-sync-creatives.feature
@@ -282,7 +282,7 @@ Feature: BR-UC-006 Sync Creative Assets
     # POST-F2, POST-F3
     # --- ext-i: CREATIVE_GEMINI_KEY_MISSING ---
 
-  @T-UC-006-ext-i @extension @ext-i @error @account
+  @T-UC-006-ext-i @extension @ext-i @error @gemini-advisory
   Scenario: Gemini key missing — generative creative without config
     Given the Buyer is authenticated with a valid principal_id
     And a creative with a generative format (output_format_ids present)

--- a/tests/bdd/features/BR-UC-006-sync-creatives.feature
+++ b/tests/bdd/features/BR-UC-006-sync-creatives.feature
@@ -280,7 +280,7 @@ Feature: BR-UC-006 Sync Creative Assets
     And the error should include a "suggestion" field
     And the suggestion should contain "media_url"
     # POST-F2, POST-F3
-    # --- ext-i: CREATIVE_GEMINI_KEY_MISSING ---
+    # --- ext-i: X_PREBID_CREATIVE_GEMINI_KEY_MISSING ---
 
   @T-UC-006-ext-i @extension @ext-i @error @gemini-advisory
   Scenario: Gemini key missing — generative creative without config
@@ -289,7 +289,7 @@ Feature: BR-UC-006 Sync Creative Assets
     And the Seller Agent does not have GEMINI_API_KEY configured
     When the Buyer Agent syncs the creative
     Then the creative should have action "failed"
-    And the error code should be "CREATIVE_GEMINI_KEY_MISSING"
+    And the error code should be "X_PREBID_CREATIVE_GEMINI_KEY_MISSING"
     And the error recovery should be "terminal"
     And the error message should contain "GEMINI_API_KEY"
     And the error should include a "suggestion" field
@@ -829,7 +829,7 @@ Feature: BR-UC-006 Sync Creative Assets
       | static_creative                 | no output_format_ids               | any assets                             | standard processing          |
       | generative_with_prompt          | output_format_ids present          | message asset with prompt text         | generative build with prompt |
       | generative_create_name_fallback | output_format_ids present (create) | no prompt assets or inputs             | generative build with name   |
-      | generative_no_gemini_key        | output_format_ids present          | message asset but no GEMINI_API_KEY    | CREATIVE_GEMINI_KEY_MISSING  |
+      | generative_no_gemini_key        | output_format_ids present          | message asset but no GEMINI_API_KEY    | X_PREBID_CREATIVE_GEMINI_KEY_MISSING  |
 
   @T-UC-006-partition-assignment-pkg @partition @assignment-package
   Scenario Outline: Assignment package validation — <partition>

--- a/tests/bdd/features/BR-UC-006-sync-creatives.feature
+++ b/tests/bdd/features/BR-UC-006-sync-creatives.feature
@@ -282,6 +282,12 @@ Feature: BR-UC-006 Sync Creative Assets
     # POST-F2, POST-F3
     # --- ext-i: X_PREBID_CREATIVE_GEMINI_KEY_MISSING ---
 
+  # @source repo=adcp ref=v3.1.1 path=dist/docs/3.1.1/building/operating/transport-errors.mdx
+  #   Seller-Specific Error Codes — non-standard codes MUST match X_{VENDOR}_{CODE}.
+  # @source repo=adcp ref=v3.1.1 path=dist/schemas/3.1.1/enums/error-code.json
+  #   recovery binding; CONFIGURATION_ERROR requires flipped transport failure markers
+  #   (not valid inside a 200 sync_creatives advisory). No pinned storyboard step grades
+  #   this condition's code/recovery (position creatives[].errors[0].code is graded elsewhere).
   @T-UC-006-ext-i @extension @ext-i @error @gemini-advisory
   Scenario: Gemini key missing — generative creative without config
     Given the Buyer is authenticated with a valid principal_id
@@ -825,11 +831,11 @@ Feature: BR-UC-006 Sync Creative Assets
     # --- assignment_package partitions ---
 
     Examples: Generative partitions
-      | partition                       | format_type                        | prompt_source                          | outcome                      |
-      | static_creative                 | no output_format_ids               | any assets                             | standard processing          |
-      | generative_with_prompt          | output_format_ids present          | message asset with prompt text         | generative build with prompt |
-      | generative_create_name_fallback | output_format_ids present (create) | no prompt assets or inputs             | generative build with name   |
-      | generative_no_gemini_key        | output_format_ids present          | message asset but no GEMINI_API_KEY    | X_PREBID_CREATIVE_GEMINI_KEY_MISSING  |
+      | partition                       | format_type                        | prompt_source                          | outcome                              |
+      | static_creative                 | no output_format_ids               | any assets                             | standard processing                  |
+      | generative_with_prompt          | output_format_ids present          | message asset with prompt text         | generative build with prompt         |
+      | generative_create_name_fallback | output_format_ids present (create) | no prompt assets or inputs             | generative build with name           |
+      | generative_no_gemini_key        | output_format_ids present          | message asset but no GEMINI_API_KEY    | X_PREBID_CREATIVE_GEMINI_KEY_MISSING |
 
   @T-UC-006-partition-assignment-pkg @partition @assignment-package
   Scenario Outline: Assignment package validation — <partition>

--- a/tests/bdd/features/BR-UC-006-sync-creatives.feature
+++ b/tests/bdd/features/BR-UC-006-sync-creatives.feature
@@ -282,7 +282,7 @@ Feature: BR-UC-006 Sync Creative Assets
     # POST-F2, POST-F3
     # --- ext-i: CREATIVE_GEMINI_KEY_MISSING ---
 
-  @T-UC-006-ext-i @extension @ext-i @error
+  @T-UC-006-ext-i @extension @ext-i @error @account
   Scenario: Gemini key missing — generative creative without config
     Given the Buyer is authenticated with a valid principal_id
     And a creative with a generative format (output_format_ids present)

--- a/tests/bdd/features/BR-UC-006-sync-creatives.feature
+++ b/tests/bdd/features/BR-UC-006-sync-creatives.feature
@@ -290,6 +290,7 @@ Feature: BR-UC-006 Sync Creative Assets
     When the Buyer Agent syncs the creative
     Then the creative should have action "failed"
     And the error code should be "CREATIVE_GEMINI_KEY_MISSING"
+    And the error recovery should be "terminal"
     And the error message should contain "GEMINI_API_KEY"
     And the error should include a "suggestion" field
     And the suggestion should contain "seller"

--- a/tests/bdd/steps/_outcome_helpers.py
+++ b/tests/bdd/steps/_outcome_helpers.py
@@ -215,7 +215,10 @@ def payload_or_none(ctx: dict) -> object | None:
     """
     result = ctx.get("result")
     if not isinstance(result, TransportResult):
-        return ctx.get("self_dispatched_response")
+        # Legacy/harness-only fallback: a few direct helper tests and older
+        # self-dispatching steps still populate ``ctx["response"]`` without a
+        # ``TransportResult`` wrapper. Prefer the newer explicit key first.
+        return ctx.get("self_dispatched_response", ctx.get("response"))
     return result.payload
 
 

--- a/tests/bdd/steps/domain/uc006_sync_creatives.py
+++ b/tests/bdd/steps/domain/uc006_sync_creatives.py
@@ -1598,7 +1598,7 @@ def then_uc006_result_should_be(ctx: dict, outcome: str) -> None:
         "CREATIVE_FORMAT_UNKNOWN",
         "CREATIVE_AGENT_UNREACHABLE",
         "CREATIVE_NAME_EMPTY",
-        "CREATIVE_GEMINI_KEY_MISSING",
+        "X_PREBID_CREATIVE_GEMINI_KEY_MISSING",
     ):
         _assert_per_creative_failure(ctx, outcome)
     elif outcome == "assignment updated":
@@ -2161,7 +2161,7 @@ def _infer_error_code_from_message(msg: str) -> str:
     """Map production error strings to spec error codes."""
     lower = msg.lower()
     if "gemini_api_key" in lower and "not configured" in lower:
-        return "CREATIVE_GEMINI_KEY_MISSING"
+        return "X_PREBID_CREATIVE_GEMINI_KEY_MISSING"
     if "preview" in lower and ("failed" in lower or "no preview" in lower):
         return "CREATIVE_PREVIEW_FAILED"
     if "format" in lower and "required" in lower:

--- a/tests/bdd/steps/domain/uc006_sync_creatives.py
+++ b/tests/bdd/steps/domain/uc006_sync_creatives.py
@@ -1497,8 +1497,11 @@ def _assert_per_creative_failure(ctx: dict, expected_code: str) -> None:
     """Assert a per-creative failure with the expected error code.
 
     Prefers production ``errors[].code`` on a failed SyncCreativeResult, then
-    falls back to message inference / ``ctx["error"]``.
+    falls back to message inference / ``ctx["error"]``. Typed production codes
+    hard-assert equality (no soft-xfail on mismatch).
     """
+    from adcp.types import Error as AdCPErrorDetail
+
     from src.core.exceptions import AdCPError
 
     resp = payload_or_none(ctx)
@@ -1511,14 +1514,12 @@ def _assert_per_creative_failure(ctx: dict, expected_code: str) -> None:
                 errs = getattr(r, "errors", None) or []
                 if errs:
                     first = errs[0]
-                    production_code = getattr(first, "code", None)
-                    if production_code == expected_code:
-                        return
-                    if production_code:
-                        pytest.xfail(
-                            f"SPEC-PRODUCTION GAP: expected {expected_code}, got "
-                            f"errors[0].code={production_code!r} from {first!r}"
+                    production_code = first.code if isinstance(first, AdCPErrorDetail) else getattr(first, "code", None)
+                    if production_code is not None:
+                        assert production_code == expected_code, (
+                            f"Expected errors[0].code={expected_code!r}, got {production_code!r} from {first!r}"
                         )
+                        return
                     inferred = _infer_error_code_from_message(str(first))
                     if inferred == expected_code:
                         return
@@ -2124,12 +2125,13 @@ def _promote_creative_errors_to_ctx(ctx: dict, errs: list) -> None:
     Prefer the typed production Error (``code`` / ``suggestion`` / ``recovery``)
     when present. Older plain-string advisories fall back to message inference.
     """
+    from adcp.types import Error as AdCPErrorDetail
+
     if not errs:
         return
 
     first = errs[0]
-    production_code = getattr(first, "code", None)
-    if production_code and not isinstance(first, (str, Exception)):
+    if isinstance(first, AdCPErrorDetail):
         # Real adcp.types.Error — Then steps already understand .code/.message/.suggestion
         ctx["error"] = first
         return
@@ -2170,10 +2172,16 @@ def _infer_error_code_from_message(msg: str) -> str:
 
 
 def _infer_suggestion_from_message(msg: str) -> str | None:
-    """Extract or generate a suggestion from a production error message."""
+    """Fallback suggestion for plain-string advisories (typed Errors promote as-is).
+
+    GEMINI path: reuse the production constant so inference cannot drift from
+    ``_gemini_key_missing_result`` once typed advisories are the primary path.
+    """
+    from src.core.tools.creatives._processing import _GEMINI_KEY_MISSING_SUGGESTION
+
     lower = msg.lower()
     if "gemini_api_key" in lower:
-        return "Ask the seller to configure GEMINI_API_KEY in their agent settings"
+        return _GEMINI_KEY_MISSING_SUGGESTION
     if "preview" in lower:
         return "Provide a media_url for the creative"
     return None

--- a/tests/bdd/steps/domain/uc006_sync_creatives.py
+++ b/tests/bdd/steps/domain/uc006_sync_creatives.py
@@ -2174,14 +2174,13 @@ def _infer_error_code_from_message(msg: str) -> str:
 def _infer_suggestion_from_message(msg: str) -> str | None:
     """Fallback suggestion for plain-string advisories (typed Errors promote as-is).
 
-    GEMINI path: reuse the production constant so inference cannot drift from
-    ``_gemini_key_missing_result`` once typed advisories are the primary path.
+    GEMINI path: pin the same buyer-facing literal as
+    ``tests.helpers.creative_test_helpers._EXPECTED_GEMINI_KEY_MISSING_SUGGESTION``
+    (independent of the production constant so drift still fails pins).
     """
-    from src.core.tools.creatives._processing import _GEMINI_KEY_MISSING_SUGGESTION
-
     lower = msg.lower()
     if "gemini_api_key" in lower:
-        return _GEMINI_KEY_MISSING_SUGGESTION
+        return "Ask the seller to configure a Gemini API key for this account"
     if "preview" in lower:
         return "Provide a media_url for the creative"
     return None

--- a/tests/bdd/steps/domain/uc006_sync_creatives.py
+++ b/tests/bdd/steps/domain/uc006_sync_creatives.py
@@ -1496,7 +1496,8 @@ def _get_assignment_from_db(ctx: dict) -> object:
 def _assert_per_creative_failure(ctx: dict, expected_code: str) -> None:
     """Assert a per-creative failure with the expected error code.
 
-    Checks SyncCreativeResult.action=="failed" first, then falls back to ctx["error"].
+    Prefers production ``errors[].code`` on a failed SyncCreativeResult, then
+    falls back to message inference / ``ctx["error"]``.
     """
     from src.core.exceptions import AdCPError
 
@@ -1509,19 +1510,30 @@ def _assert_per_creative_failure(ctx: dict, expected_code: str) -> None:
             if action_str == "failed":
                 errs = getattr(r, "errors", None) or []
                 if errs:
-                    inferred = _infer_error_code_from_message(str(errs[0]))
+                    first = errs[0]
+                    production_code = getattr(first, "code", None)
+                    if production_code == expected_code:
+                        return
+                    if production_code:
+                        pytest.xfail(
+                            f"SPEC-PRODUCTION GAP: expected {expected_code}, got "
+                            f"errors[0].code={production_code!r} from {first!r}"
+                        )
+                    inferred = _infer_error_code_from_message(str(first))
                     if inferred == expected_code:
                         return
                     pytest.xfail(
                         f"SPEC-PRODUCTION GAP: expected {expected_code}, inferred '{inferred}' "
-                        f"from error message: {errs[0]}"
+                        f"from error message: {first}"
                     )
     if error is not None:
         if isinstance(error, AdCPError) and error.error_code == expected_code:
             return
+        err_code = getattr(error, "code", None) or getattr(error, "error_code", None)
+        if err_code == expected_code:
+            return
         pytest.xfail(
-            f"SPEC-PRODUCTION GAP: expected {expected_code}, got "
-            f"{type(error).__name__}(code={getattr(error, 'error_code', '?')}): {error}"
+            f"SPEC-PRODUCTION GAP: expected {expected_code}, got {type(error).__name__}(code={err_code!r}): {error}"
         )
     pytest.xfail(f"SPEC-PRODUCTION GAP: expected {expected_code} but no error occurred. Response: {resp}")
 
@@ -2109,15 +2121,20 @@ def then_creative_action_failed(ctx: dict) -> None:
 def _promote_creative_errors_to_ctx(ctx: dict, errs: list) -> None:
     """Promote SyncCreativeResult.errors[] to ctx["error"] for downstream Then steps.
 
-    Production stores per-creative failures as plain strings in errors[]. Some
-    error strings contain structured info (e.g. "GEMINI_API_KEY not configured")
-    that downstream steps can parse. We wrap the first error as a synthetic object
-    with error_code/message/suggestion derived from the string content.
+    Prefer the typed production Error (``code`` / ``suggestion`` / ``recovery``)
+    when present. Older plain-string advisories fall back to message inference.
     """
     if not errs:
         return
 
-    first_err = str(errs[0])
+    first = errs[0]
+    production_code = getattr(first, "code", None)
+    if production_code and not isinstance(first, (str, Exception)):
+        # Real adcp.types.Error — Then steps already understand .code/.message/.suggestion
+        ctx["error"] = first
+        return
+
+    first_err = str(first)
     error_code = _infer_error_code_from_message(first_err)
     suggestion = _infer_suggestion_from_message(first_err)
 

--- a/tests/bdd/steps/domain/uc006_sync_creatives.py
+++ b/tests/bdd/steps/domain/uc006_sync_creatives.py
@@ -29,6 +29,7 @@ from tests.factories.creative_asset import (
     url_spec,
 )
 from tests.factories.principal import PrincipalFactory
+from tests.helpers.creative_test_helpers import _EXPECTED_GEMINI_KEY_MISSING_SUGGESTION
 
 # ═══════════════════════════════════════════════════════════════════════
 # E2E format helpers — real creative agent data for Docker transport
@@ -2174,13 +2175,13 @@ def _infer_error_code_from_message(msg: str) -> str:
 def _infer_suggestion_from_message(msg: str) -> str | None:
     """Fallback suggestion for plain-string advisories (typed Errors promote as-is).
 
-    GEMINI path: pin the same buyer-facing literal as
-    ``tests.helpers.creative_test_helpers._EXPECTED_GEMINI_KEY_MISSING_SUGGESTION``
-    (independent of the production constant so drift still fails pins).
+    GEMINI path: return the shared test-side pin
+    ``_EXPECTED_GEMINI_KEY_MISSING_SUGGESTION`` (independent of the production
+    constant so drift still fails pins).
     """
     lower = msg.lower()
     if "gemini_api_key" in lower:
-        return "Ask the seller to configure a Gemini API key for this account"
+        return _EXPECTED_GEMINI_KEY_MISSING_SUGGESTION
     if "preview" in lower:
         return "Provide a media_url for the creative"
     return None

--- a/tests/bdd/steps/domain/uc006_sync_creatives.py
+++ b/tests/bdd/steps/domain/uc006_sync_creatives.py
@@ -1524,9 +1524,8 @@ def _assert_per_creative_failure(ctx: dict, expected_code: str) -> None:
                     inferred = _infer_error_code_from_message(str(first))
                     if inferred == expected_code:
                         return
-                    pytest.xfail(
-                        f"SPEC-PRODUCTION GAP: expected {expected_code}, inferred '{inferred}' "
-                        f"from error message: {first}"
+                    raise AssertionError(
+                        f"Expected errors[0].code={expected_code!r}, inferred {inferred!r} from error message: {first}"
                     )
     if error is not None:
         if isinstance(error, AdCPError) and error.error_code == expected_code:
@@ -1534,10 +1533,10 @@ def _assert_per_creative_failure(ctx: dict, expected_code: str) -> None:
         err_code = getattr(error, "code", None) or getattr(error, "error_code", None)
         if err_code == expected_code:
             return
-        pytest.xfail(
-            f"SPEC-PRODUCTION GAP: expected {expected_code}, got {type(error).__name__}(code={err_code!r}): {error}"
+        raise AssertionError(
+            f"Expected error code={expected_code!r}, got {type(error).__name__}(code={err_code!r}): {error}"
         )
-    pytest.xfail(f"SPEC-PRODUCTION GAP: expected {expected_code} but no error occurred. Response: {resp}")
+    raise AssertionError(f"Expected error code={expected_code!r} but no error occurred. Response: {resp}")
 
 
 @then(parsers.parse('the result should be "{outcome}"'))

--- a/tests/bdd/steps/domain/uc006_sync_creatives.py
+++ b/tests/bdd/steps/domain/uc006_sync_creatives.py
@@ -4514,9 +4514,9 @@ def given_creative_with_generative_format(ctx: dict) -> None:
 
 @given("the Seller Agent does not have GEMINI_API_KEY configured")
 def given_no_gemini_api_key(ctx: dict) -> None:
-    """Remove GEMINI_API_KEY from the config mock."""
+    """Remove GEMINI_API_KEY from the config mock (impl-only on e2e)."""
     env = ctx["env"]
-    env.mock["config"].return_value.gemini_api_key = None
+    env.clear_gemini_api_key()
 
 
 # ═══════════════════════════════════════════════════════════════════════
@@ -4766,9 +4766,9 @@ def given_message_asset_no_gemini_key(ctx: dict) -> None:
     last_creative.setdefault("assets", {}).update(
         build_assets(text_spec("message", content="Generate a banner ad for summer sale"))
     )
-    # Remove GEMINI_API_KEY from config mock
+    # Remove GEMINI_API_KEY from config mock (impl-only on e2e)
     env = ctx["env"]
-    env.mock["config"].return_value.gemini_api_key = None
+    env.clear_gemini_api_key()
 
 
 # ═══════════════════════════════════════════════════════════════════════
@@ -4846,8 +4846,8 @@ def given_creative_generative_no_gemini(ctx: dict) -> None:
     _ensure_tenant_principal(ctx, env)
     # Set up generative format but WITHOUT gemini key
     fmt = env.setup_generative_build(format_id="display_gen", gemini_api_key="test-gemini-key")
-    # Now remove the key — setup_generative_build sets it, we override
-    env.mock["config"].return_value.gemini_api_key = None
+    # Now remove the key — setup_generative_build sets it, we clear via env
+    env.clear_gemini_api_key()
     creative_payload = {
         "creative_id": "creative-gen-no-key-001",
         "name": "Generative No Key",

--- a/tests/bdd/steps/generic/then_error.py
+++ b/tests/bdd/steps/generic/then_error.py
@@ -33,7 +33,7 @@ def _nested_creative_advisory_error(ctx: dict) -> dict | None:
     fallback — they never stash success-path wire.
 
     When ``wire_response`` is a dict, ``ctx["transport"]`` MUST be set — defaulting
-    to ``Transport.IMPL`` would disarm the loud guards.
+    to an in-process / no-wire transport would disarm the loud guards.
 
     CreativeSyncEnv A2A stashes a ``model_dump`` proxy (``wire_response_is_proxy``),
     not Task/Artifact DataPart framing (#1919). BDD still grades that proxy's
@@ -49,14 +49,14 @@ def _nested_creative_advisory_error(ctx: dict) -> dict | None:
 
     wire = ctx.get("wire_response")
     transport = ctx.get("transport")
-    response = ctx.get("response")
+    response = payload_or_none(ctx)
     result = ctx.get("result")
     wire_is_proxy = bool(getattr(result, "envelope", None) and result.envelope.get("wire_response_is_proxy"))
     if isinstance(wire, dict):
         if transport is None:
             raise AssertionError(
                 "wire_response present but ctx['transport'] unset — "
-                "refusing Transport.IMPL default that would disarm loud guards"
+                "refusing an implicit no-wire default that would disarm loud guards"
             )
         return first_failed_creative_advisory(
             wire,
@@ -66,7 +66,7 @@ def _nested_creative_advisory_error(ctx: dict) -> dict | None:
             # Payload content OK until #1919; framing-sensitive callers use True.
             require_real_wire=False,
         )
-    # IMPL / unset: no success-path wire to require.
+    # No-wire / unset: no success-path wire to require.
     if transport is None or _transport_has_no_wire(transport):
         return None
     if _response_has_failed_creative(response):
@@ -506,7 +506,7 @@ def then_error_recovery(ctx: dict, recovery: str) -> None:
             code,
             recovery=recovery,
             transport=transport,
-            response=ctx.get("response"),
+            response=payload_or_none(ctx),
             wire_is_proxy=wire_is_proxy,
             require_real_wire=False,
         )

--- a/tests/bdd/steps/generic/then_error.py
+++ b/tests/bdd/steps/generic/then_error.py
@@ -16,6 +16,29 @@ from tests.bdd.steps._outcome_helpers import payload_or_none, wire_error_envelop
 # ── Helpers ─────────────────────────────────────────────────────────
 
 
+def _nested_creative_advisory_error(ctx: dict) -> dict | None:
+    """First failed ``creatives[].errors[0]`` from a success-path ``wire_response``.
+
+    Per-creative advisories live inside a successful sync artifact (no
+    ``wire_error_envelope``). Grade buyer-visible nested wire fields when present.
+    """
+    wire = ctx.get("wire_response")
+    if not isinstance(wire, dict):
+        return None
+    creatives = wire.get("creatives") or wire.get("results") or []
+    for creative in creatives:
+        if not isinstance(creative, dict):
+            continue
+        action = creative.get("action")
+        action_str = action.get("value") if isinstance(action, dict) else action
+        if action_str != "failed":
+            continue
+        errs = creative.get("errors") or []
+        if errs and isinstance(errs[0], dict):
+            return errs[0]
+    return None
+
+
 def _wire_code(ctx: dict) -> str | None:
     """Return the authoritative wire error code when a wire envelope was captured.
 
@@ -420,14 +443,21 @@ def then_error_recovery(ctx: dict, recovery: str) -> None:
     """Assert the error recovery hint matches — wire-first, reconstructed fallback.
 
     On a wire transport the recovery is read from the real envelope via
-    ``assert_wire_error`` (the buyer-facing contract); IMPL/no-wire scenarios
-    fall back to the reconstructed ``ctx['error']``.
+    ``assert_wire_error`` (the buyer-facing contract). Success+advisory sync
+    grades nested ``creatives[].errors[0].recovery`` on ``wire_response``.
+    IMPL/no-wire scenarios fall back to the reconstructed ``ctx['error']``.
     """
     envelope = wire_error_envelope_or_none(ctx)
     if envelope is not None:
         wire_code = _wire_code(ctx)
         assert wire_code, f"Expected wire error code when asserting recovery={recovery!r}: {envelope}"
         ctx["result"].assert_wire_error(wire_code, recovery=recovery)
+        return
+    nested = _nested_creative_advisory_error(ctx)
+    if nested is not None:
+        actual = nested.get("recovery")
+        actual_str = actual.value if hasattr(actual, "value") else str(actual) if actual is not None else None
+        assert actual_str == recovery, f"Expected recovery '{recovery}', got '{actual_str}' from wire_response"
         return
     error = ctx.get("error")
     assert error is not None, "No error recorded in ctx"
@@ -436,11 +466,11 @@ def then_error_recovery(ctx: dict, recovery: str) -> None:
     if isinstance(error, AdCPError):
         assert error.recovery == recovery, f"Expected recovery '{recovery}', got '{error.recovery}'"
         return
-    # Per-creative / per-package advisory Error models carry recovery directly.
-    actual = getattr(error, "recovery", None)
+    # Per-creative / per-package advisory Error models — reuse _get_error_dict.
+    err_dict = _get_error_dict(error)
+    actual = err_dict.get("recovery")
     if actual is not None:
-        actual_str = actual.value if hasattr(actual, "value") else str(actual)
-        assert actual_str == recovery, f"Expected recovery '{recovery}', got '{actual_str}'"
+        assert actual == recovery, f"Expected recovery '{recovery}', got '{actual}'"
         return
     raise AssertionError(f"Cannot check recovery on {type(error).__name__}: {error!r}")
 

--- a/tests/bdd/steps/generic/then_error.py
+++ b/tests/bdd/steps/generic/then_error.py
@@ -20,23 +20,17 @@ def _nested_creative_advisory_error(ctx: dict) -> dict | None:
     """First failed ``creatives[].errors[0]`` from a success-path ``wire_response``.
 
     Per-creative advisories live inside a successful sync artifact (no
-    ``wire_error_envelope``). Grade buyer-visible nested wire fields when present.
+    ``wire_error_envelope``). Delegates to the harness accessor so BDD steps and
+    integration tests share one guarded traversal (loud when a wire-stashing
+    transport omitted ``wire_response``).
     """
+    from tests.harness.transport import first_failed_creative_advisory
+
     wire = ctx.get("wire_response")
-    if not isinstance(wire, dict):
-        return None
-    creatives = wire.get("creatives") or wire.get("results") or []
-    for creative in creatives:
-        if not isinstance(creative, dict):
-            continue
-        action = creative.get("action")
-        action_str = action.get("value") if isinstance(action, dict) else action
-        if action_str != "failed":
-            continue
-        errs = creative.get("errors") or []
-        if errs and isinstance(errs[0], dict):
-            return errs[0]
-    return None
+    return first_failed_creative_advisory(
+        wire if isinstance(wire, dict) else None,
+        transport=ctx.get("transport"),
+    )
 
 
 def _wire_code(ctx: dict) -> str | None:

--- a/tests/bdd/steps/generic/then_error.py
+++ b/tests/bdd/steps/generic/then_error.py
@@ -34,6 +34,11 @@ def _nested_creative_advisory_error(ctx: dict) -> dict | None:
 
     When ``wire_response`` is a dict, ``ctx["transport"]`` MUST be set — defaulting
     to ``Transport.IMPL`` would disarm the loud guards.
+
+    CreativeSyncEnv A2A stashes a ``model_dump`` proxy (``wire_response_is_proxy``),
+    not Task/Artifact DataPart framing (#1919). A proxy must not count as a third
+    independent wire grade — return ``None`` so callers fall back to the
+    reconstructed model (honest) rather than pretending the proxy is A2A wire.
     """
     from tests.harness.transport import (
         _response_has_failed_creative,
@@ -52,14 +57,15 @@ def _nested_creative_advisory_error(ctx: dict) -> dict | None:
                 "wire_response present but ctx['transport'] unset — "
                 "refusing Transport.IMPL default that would disarm loud guards"
             )
+        if wire_is_proxy:
+            # Not genuine A2A framing — do not claim wire-grade evidence (#1919).
+            return None
         return first_failed_creative_advisory(
             wire,
             transport=transport,
             response=response,
-            wire_is_proxy=wire_is_proxy,
-            # BDD grades proxy payload content (same serializer as REST) until #1919;
-            # integration callers that need real framing pass require_real_wire=True.
-            require_real_wire=False,
+            wire_is_proxy=False,
+            require_real_wire=True,
         )
     # IMPL / unset: no success-path wire to require.
     if transport is None or _transport_has_no_wire(transport):

--- a/tests/bdd/steps/generic/then_error.py
+++ b/tests/bdd/steps/generic/then_error.py
@@ -498,7 +498,7 @@ def then_error_recovery(ctx: dict, recovery: str) -> None:
         result = ctx.get("result")
         wire_is_proxy = bool(getattr(result, "envelope", None) and result.envelope.get("wire_response_is_proxy"))
         # Payload grading on CreativeSyncEnv A2A model_dump proxy stays allowed
-        # until #1919 (Chris R3-04); require_real_wire=True would refuse that arm.
+        # until #1919 (Chris GH #1802); require_real_wire=True would refuse that arm.
         from tests.harness.transport import assert_wire_advisory
 
         assert_wire_advisory(

--- a/tests/bdd/steps/generic/then_error.py
+++ b/tests/bdd/steps/generic/then_error.py
@@ -16,21 +16,55 @@ from tests.bdd.steps._outcome_helpers import payload_or_none, wire_error_envelop
 # ── Helpers ─────────────────────────────────────────────────────────
 
 
+def _response_has_failed_creative(ctx: dict) -> bool:
+    """True when ``ctx['response']`` carries a per-creative ``action == "failed"``.
+
+    Used to decide whether a missing ``wire_response`` on a wire-stashing
+    transport is a nested-advisory grading bug (loud) vs an envelope-less
+    error path that should soft-fall back to the reconstructed exception
+    (UC003 / UC019 validation failures).
+    """
+    resp = ctx.get("response")
+    if resp is None:
+        return False
+    creatives = getattr(resp, "creatives", None) or getattr(resp, "results", None) or []
+    for creative in creatives:
+        if isinstance(creative, dict):
+            action = creative.get("action")
+            action_str = action.get("value") if isinstance(action, dict) else action
+        else:
+            action = getattr(creative, "action", None)
+            action_str = action.value if hasattr(action, "value") else action
+        if action_str == "failed":
+            return True
+    return False
+
+
 def _nested_creative_advisory_error(ctx: dict) -> dict | None:
     """First failed ``creatives[].errors[0]`` from a success-path ``wire_response``.
 
     Per-creative advisories live inside a successful sync artifact (no
     ``wire_error_envelope``). Delegates to the harness accessor so BDD steps and
-    integration tests share one guarded traversal (loud when a wire-stashing
-    transport omitted ``wire_response``).
+    integration tests share one guarded traversal.
+
+    Loud when a wire-stashing transport omitted ``wire_response`` **and** the
+    typed response already shows a failed creative (success+advisory path).
+    Soft ``None`` otherwise so envelope-less error Then steps (UC003/UC019)
+    keep reconstructed fallback — they never stash success-path wire.
     """
-    from tests.harness.transport import first_failed_creative_advisory
+    from tests.harness.transport import Transport, first_failed_creative_advisory
 
     wire = ctx.get("wire_response")
-    return first_failed_creative_advisory(
-        wire if isinstance(wire, dict) else None,
-        transport=ctx.get("transport"),
-    )
+    transport = ctx.get("transport")
+    if isinstance(wire, dict):
+        return first_failed_creative_advisory(wire, transport=transport)
+    # IMPL / unset: no success-path wire to require.
+    if transport is None or transport is Transport.IMPL or getattr(transport, "value", transport) == "impl":
+        return None
+    if _response_has_failed_creative(ctx):
+        # Success+advisory on a wire transport without a stashed body — loud.
+        return first_failed_creative_advisory(None, transport=transport)
+    return None
 
 
 def _wire_code(ctx: dict) -> str | None:

--- a/tests/bdd/steps/generic/then_error.py
+++ b/tests/bdd/steps/generic/then_error.py
@@ -16,52 +16,38 @@ from tests.bdd.steps._outcome_helpers import payload_or_none, wire_error_envelop
 # ── Helpers ─────────────────────────────────────────────────────────
 
 
-def _response_has_failed_creative(ctx: dict) -> bool:
-    """True when ``ctx['response']`` carries a per-creative ``action == "failed"``.
-
-    Used to decide whether a missing ``wire_response`` on a wire-stashing
-    transport is a nested-advisory grading bug (loud) vs an envelope-less
-    error path that should soft-fall back to the reconstructed exception
-    (UC003 / UC019 validation failures).
-    """
-    resp = ctx.get("response")
-    if resp is None:
-        return False
-    creatives = getattr(resp, "creatives", None) or getattr(resp, "results", None) or []
-    for creative in creatives:
-        if isinstance(creative, dict):
-            action = creative.get("action")
-            action_str = action.get("value") if isinstance(action, dict) else action
-        else:
-            action = getattr(creative, "action", None)
-            action_str = action.value if hasattr(action, "value") else action
-        if action_str == "failed":
-            return True
-    return False
-
-
 def _nested_creative_advisory_error(ctx: dict) -> dict | None:
     """First failed ``creatives[].errors[0]`` from a success-path ``wire_response``.
 
     Per-creative advisories live inside a successful sync artifact (no
-    ``wire_error_envelope``). Delegates to the harness accessor so BDD steps and
-    integration tests share one guarded traversal.
+    ``wire_error_envelope``). Delegates entirely to the single guarded harness
+    oracle (``tests.harness.transport.first_failed_creative_advisory``) so BDD
+    steps and integration tests share one traversal — including the "wire
+    present but the failed creative dropped errors[]" regression check.
 
     Loud when a wire-stashing transport omitted ``wire_response`` **and** the
-    typed response already shows a failed creative (success+advisory path).
-    Soft ``None`` otherwise so envelope-less error Then steps (UC003/UC019)
-    keep reconstructed fallback — they never stash success-path wire.
+    typed response already shows a failed creative (success+advisory path) —
+    the ``_response_has_failed_creative`` discriminator, shared from the
+    harness rather than reimplemented here. Soft ``None`` otherwise so
+    envelope-less error Then steps (UC003/UC019) keep the reconstructed
+    fallback — they never stash success-path wire.
     """
-    from tests.harness.transport import Transport, first_failed_creative_advisory
+    from tests.harness.transport import (
+        Transport,
+        _response_has_failed_creative,
+        _transport_has_no_wire,
+        first_failed_creative_advisory,
+    )
 
     wire = ctx.get("wire_response")
     transport = ctx.get("transport")
+    response = ctx.get("response")
     if isinstance(wire, dict):
-        return first_failed_creative_advisory(wire, transport=transport)
+        return first_failed_creative_advisory(wire, transport=transport or Transport.IMPL, response=response)
     # IMPL / unset: no success-path wire to require.
-    if transport is None or transport is Transport.IMPL or getattr(transport, "value", transport) == "impl":
+    if transport is None or _transport_has_no_wire(transport):
         return None
-    if _response_has_failed_creative(ctx):
+    if _response_has_failed_creative(response):
         # Success+advisory on a wire transport without a stashed body — loud.
         return first_failed_creative_advisory(None, transport=transport)
     return None

--- a/tests/bdd/steps/generic/then_error.py
+++ b/tests/bdd/steps/generic/then_error.py
@@ -491,9 +491,25 @@ def then_error_recovery(ctx: dict, recovery: str) -> None:
         return
     nested = _nested_creative_advisory_error(ctx)
     if nested is not None:
-        actual = nested.get("recovery")
-        actual_str = actual.value if hasattr(actual, "value") else str(actual) if actual is not None else None
-        assert actual_str == recovery, f"Expected recovery '{recovery}', got '{actual_str}' from wire_response"
+        wire = ctx.get("wire_response")
+        transport = ctx["transport"]
+        code = nested.get("code")
+        assert code, f"Expected nested advisory code when asserting recovery={recovery!r}: {nested}"
+        result = ctx.get("result")
+        wire_is_proxy = bool(getattr(result, "envelope", None) and result.envelope.get("wire_response_is_proxy"))
+        # Payload grading on CreativeSyncEnv A2A model_dump proxy stays allowed
+        # until #1919 (Chris R3-04); require_real_wire=True would refuse that arm.
+        from tests.harness.transport import assert_wire_advisory
+
+        assert_wire_advisory(
+            wire,
+            code,
+            recovery=recovery,
+            transport=transport,
+            response=ctx.get("response"),
+            wire_is_proxy=wire_is_proxy,
+            require_real_wire=False,
+        )
         return
     error = ctx.get("error")
     assert error is not None, "No error recorded in ctx"

--- a/tests/bdd/steps/generic/then_error.py
+++ b/tests/bdd/steps/generic/then_error.py
@@ -31,9 +31,11 @@ def _nested_creative_advisory_error(ctx: dict) -> dict | None:
     harness rather than reimplemented here. Soft ``None`` otherwise so
     envelope-less error Then steps (UC003/UC019) keep the reconstructed
     fallback — they never stash success-path wire.
+
+    When ``wire_response`` is a dict, ``ctx["transport"]`` MUST be set — defaulting
+    to ``Transport.IMPL`` would disarm the loud guards.
     """
     from tests.harness.transport import (
-        Transport,
         _response_has_failed_creative,
         _transport_has_no_wire,
         first_failed_creative_advisory,
@@ -42,8 +44,23 @@ def _nested_creative_advisory_error(ctx: dict) -> dict | None:
     wire = ctx.get("wire_response")
     transport = ctx.get("transport")
     response = ctx.get("response")
+    result = ctx.get("result")
+    wire_is_proxy = bool(getattr(result, "envelope", None) and result.envelope.get("wire_response_is_proxy"))
     if isinstance(wire, dict):
-        return first_failed_creative_advisory(wire, transport=transport or Transport.IMPL, response=response)
+        if transport is None:
+            raise AssertionError(
+                "wire_response present but ctx['transport'] unset — "
+                "refusing Transport.IMPL default that would disarm loud guards"
+            )
+        return first_failed_creative_advisory(
+            wire,
+            transport=transport,
+            response=response,
+            wire_is_proxy=wire_is_proxy,
+            # BDD grades proxy payload content (same serializer as REST) until #1919;
+            # integration callers that need real framing pass require_real_wire=True.
+            require_real_wire=False,
+        )
     # IMPL / unset: no success-path wire to require.
     if transport is None or _transport_has_no_wire(transport):
         return None

--- a/tests/bdd/steps/generic/then_error.py
+++ b/tests/bdd/steps/generic/then_error.py
@@ -36,9 +36,10 @@ def _nested_creative_advisory_error(ctx: dict) -> dict | None:
     to ``Transport.IMPL`` would disarm the loud guards.
 
     CreativeSyncEnv A2A stashes a ``model_dump`` proxy (``wire_response_is_proxy``),
-    not Task/Artifact DataPart framing (#1919). A proxy must not count as a third
-    independent wire grade — return ``None`` so callers fall back to the
-    reconstructed model (honest) rather than pretending the proxy is A2A wire.
+    not Task/Artifact DataPart framing (#1919). BDD still grades that proxy's
+    *payload* (byte-identical to REST's ``model_dump``) so nested-advisory Then
+    steps stay live; callers that need genuine A2A framing pass
+    ``require_real_wire=True`` (integration) and refuse the proxy.
     """
     from tests.harness.transport import (
         _response_has_failed_creative,
@@ -57,15 +58,13 @@ def _nested_creative_advisory_error(ctx: dict) -> dict | None:
                 "wire_response present but ctx['transport'] unset — "
                 "refusing Transport.IMPL default that would disarm loud guards"
             )
-        if wire_is_proxy:
-            # Not genuine A2A framing — do not claim wire-grade evidence (#1919).
-            return None
         return first_failed_creative_advisory(
             wire,
             transport=transport,
             response=response,
-            wire_is_proxy=False,
-            require_real_wire=True,
+            wire_is_proxy=wire_is_proxy,
+            # Payload content OK until #1919; framing-sensitive callers use True.
+            require_real_wire=False,
         )
     # IMPL / unset: no success-path wire to require.
     if transport is None or _transport_has_no_wire(transport):

--- a/tests/bdd/steps/generic/then_error.py
+++ b/tests/bdd/steps/generic/then_error.py
@@ -435,8 +435,14 @@ def then_error_recovery(ctx: dict, recovery: str) -> None:
 
     if isinstance(error, AdCPError):
         assert error.recovery == recovery, f"Expected recovery '{recovery}', got '{error.recovery}'"
-    else:
-        raise AssertionError(f"Cannot check recovery on non-AdCPError: {type(error).__name__}")
+        return
+    # Per-creative / per-package advisory Error models carry recovery directly.
+    actual = getattr(error, "recovery", None)
+    if actual is not None:
+        actual_str = actual.value if hasattr(actual, "value") else str(actual)
+        assert actual_str == recovery, f"Expected recovery '{recovery}', got '{actual_str}'"
+        return
+    raise AssertionError(f"Cannot check recovery on {type(error).__name__}: {error!r}")
 
 
 @then('the error should include a "suggestion" field')

--- a/tests/harness/creative_sync.py
+++ b/tests/harness/creative_sync.py
@@ -174,7 +174,7 @@ class CreativeSyncEnv(EgressHatchMixin, IntegrationEnv):
 
         Live e2e_rest cannot unset the server process env mid-suite — declare
         E2EUnsupportedSetup so the BDD hook non-strict-xfails e2e only while
-        a2a/mcp/rest still grade CREATIVE_GEMINI_KEY_MISSING.
+        a2a/mcp/rest still grade X_PREBID_CREATIVE_GEMINI_KEY_MISSING.
         """
         self.mock["config"].return_value.gemini_api_key = None
 

--- a/tests/harness/creative_sync.py
+++ b/tests/harness/creative_sync.py
@@ -158,8 +158,12 @@ class CreativeSyncEnv(EgressHatchMixin, IntegrationEnv):
         # Also configure get_format to return this format for validation
         registry.get_format = AsyncMock(return_value=mock_format)
 
-        # Set gemini API key
+        # Set gemini API key on both lookup surfaces production consults
+        # (tenant dict first, then process-global config).
         self.mock["config"].return_value.gemini_api_key = gemini_api_key
+        tenant = getattr(self.identity, "tenant", None)
+        if isinstance(tenant, dict):
+            tenant["gemini_api_key"] = gemini_api_key
 
         return {"agent_url": agent, "id": format_id}
 
@@ -170,13 +174,16 @@ class CreativeSyncEnv(EgressHatchMixin, IntegrationEnv):
         )
     )
     def clear_gemini_api_key(self) -> None:
-        """Clear GEMINI_API_KEY on the in-process config mock (impl-only).
+        """Clear GEMINI_API_KEY on config mock and tenant dict (impl-only).
 
         Live e2e_rest cannot unset the server process env mid-suite — declare
         E2EUnsupportedSetup so the BDD hook non-strict-xfails e2e only while
         a2a/mcp/rest still grade X_PREBID_CREATIVE_GEMINI_KEY_MISSING.
         """
         self.mock["config"].return_value.gemini_api_key = None
+        tenant = getattr(self.identity, "tenant", None)
+        if isinstance(tenant, dict):
+            tenant["gemini_api_key"] = None
 
     def set_run_async_result(self, formats: list[Any]) -> None:
         """Configure run_async_in_sync_context to return *formats*.

--- a/tests/harness/creative_sync.py
+++ b/tests/harness/creative_sync.py
@@ -163,6 +163,21 @@ class CreativeSyncEnv(EgressHatchMixin, IntegrationEnv):
 
         return {"agent_url": agent, "id": format_id}
 
+    @realize_e2e(
+        e2e_unsupported(
+            "CI / e2e stack always injects GEMINI_API_KEY into the live server process; "
+            "clearing the in-process get_config mock cannot realize a missing-key seller"
+        )
+    )
+    def clear_gemini_api_key(self) -> None:
+        """Clear GEMINI_API_KEY on the in-process config mock (impl-only).
+
+        Live e2e_rest cannot unset the server process env mid-suite — declare
+        E2EUnsupportedSetup so the BDD hook non-strict-xfails e2e only while
+        a2a/mcp/rest still grade CREATIVE_GEMINI_KEY_MISSING.
+        """
+        self.mock["config"].return_value.gemini_api_key = None
+
     def set_run_async_result(self, formats: list[Any]) -> None:
         """Configure run_async_in_sync_context to return *formats*.
 

--- a/tests/harness/creative_sync.py
+++ b/tests/harness/creative_sync.py
@@ -53,6 +53,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 from src.core.schemas import SyncCreativesResponse
 from tests.harness._base import IntegrationEnv
+from tests.harness._realize import e2e_unsupported, realize_e2e
 from tests.harness.egress import EgressHatchMixin
 from tests.harness.transport import DeliverResult
 
@@ -60,6 +61,26 @@ from tests.harness.transport import DeliverResult
 # push config, request model) rather than forwarding as skill parameters — see
 # tests/harness/_base.py. They must reach it untouched.
 _A2A_RESERVED_KWARGS = frozenset({"identity", "a2a_push_notification_config", "req"})
+
+
+def _clear_gemini_api_key_e2e(env: IntegrationEnv) -> None:
+    """Null the shared-DB tenant ``gemini_api_key`` so live e2e sees a keyless seller.
+
+    Production creative-sync advisories are account-scoped (tenant dict / DB
+    column only), so clearing the process env is unnecessary — the live server
+    re-reads the tenant row on each request.
+    """
+    from sqlalchemy import select
+
+    from src.core.database.models import Tenant
+
+    tenant = env.get_session().scalars(select(Tenant).filter_by(tenant_id=env._tenant_id)).first()
+    if tenant is not None:
+        tenant.gemini_api_key = None
+        env._commit_factory_data()
+    tenant_dict = getattr(env.identity, "tenant", None)
+    if isinstance(tenant_dict, dict):
+        tenant_dict["gemini_api_key"] = None
 
 
 class CreativeSyncEnv(EgressHatchMixin, IntegrationEnv):

--- a/tests/harness/creative_sync.py
+++ b/tests/harness/creative_sync.py
@@ -188,14 +188,33 @@ class CreativeSyncEnv(EgressHatchMixin, IntegrationEnv):
         """Set tenant and process-global GEMINI keys independently.
 
         Production creative-sync advisories read only
-        ``tenant["gemini_api_key"]`` (account-scoped). The config mock remains
-        writable so unrelated surfaces and regression arms can still set a
-        process-global key that must *not* rescue a keyless tenant.
+        ``tenant["gemini_api_key"]`` (account-scoped). ``call_via`` builds a
+        per-protocol identity via ``identity_for`` *after* setup, and MCP/REST
+        with a real auth token re-load the tenant from the DB — so this setter
+        MUST (1) stash the key in ``_tenant_overrides`` and clear the identity
+        cache, (2) update any already-cached tenant dicts, and (3) persist the
+        DB column when a session is bound. The config mock remains writable so
+        regression arms can still set a process-global key that must *not*
+        rescue a keyless tenant.
         """
         self.mock["config"].return_value.gemini_api_key = global_key
-        tenant_dict = getattr(self.identity, "tenant", None)
-        if isinstance(tenant_dict, dict):
-            tenant_dict["gemini_api_key"] = tenant
+        # Future identity_for builds (all protocols) pick this up via make_tenant.
+        self._tenant_overrides["gemini_api_key"] = tenant
+        for ident in self._identity_cache.values():
+            tenant_dict = getattr(ident, "tenant", None)
+            if isinstance(tenant_dict, dict):
+                tenant_dict["gemini_api_key"] = tenant
+        # Drop cached identities so the next call_via rebuilds with overrides.
+        self._identity_cache.clear()
+        if self.use_real_db and self._session is not None:
+            from sqlalchemy import select
+
+            from src.core.database.models import Tenant
+
+            row = self._session.scalars(select(Tenant).filter_by(tenant_id=self._tenant_id)).first()
+            if row is not None:
+                row.gemini_api_key = tenant
+                self._commit_factory_data()
 
     @realize_e2e(_clear_gemini_api_key_e2e)
     def clear_gemini_api_key(self) -> None:

--- a/tests/harness/creative_sync.py
+++ b/tests/harness/creative_sync.py
@@ -114,7 +114,7 @@ class CreativeSyncEnv(EgressHatchMixin, IntegrationEnv):
         e2e_unsupported(
             "generative build grading injects an in-process format mock and "
             "registry.build_creative AsyncMock; the live e2e creative-agent "
-            "catalog cannot be stubbed mid-suite, and Then steps assert the mock (#1887)"
+            "catalog cannot be stubbed mid-suite, and Then steps assert the mock (#1964)"
         )
     )
     def setup_generative_build(
@@ -129,13 +129,14 @@ class CreativeSyncEnv(EgressHatchMixin, IntegrationEnv):
         Sets up:
         - A format mock with output_format_ids (makes it generative)
         - build_creative AsyncMock with the given return value
-        - gemini_api_key on the config mock
+        - gemini_api_key on the account-scoped tenant dict (and config mock
+          for unrelated surfaces)
         - run_async to return the generative format list
 
         In-process only (a2a/mcp/rest). Live e2e_rest cannot stub the
         creative-agent catalog or observe ``registry.build_creative`` —
         declare E2EUnsupportedSetup so the BDD hook non-strict-xfails e2e
-        (#1887; partial adoption — ``set_run_async_result`` and direct
+        (#1964; partial adoption — ``set_run_async_result`` and direct
         registry pokes remain unwrapped).
 
         Returns a format_id dict for use in creative payloads::
@@ -171,9 +172,9 @@ class CreativeSyncEnv(EgressHatchMixin, IntegrationEnv):
         # Also configure get_format to return this format for validation
         registry.get_format = AsyncMock(return_value=mock_format)
 
-        # Set gemini API key on both lookup surfaces production consults
-        # (tenant dict first, then process-global config). Prefer
-        # ``set_gemini_keys`` when the surfaces must diverge.
+        # Account-scoped key is the sole advisory source; keep config mock
+        # aligned for unrelated surfaces. Prefer ``set_gemini_keys`` when the
+        # surfaces must diverge.
         self.set_gemini_keys(tenant=gemini_api_key, global_key=gemini_api_key)
 
         return {"agent_url": agent, "id": format_id}
@@ -186,28 +187,22 @@ class CreativeSyncEnv(EgressHatchMixin, IntegrationEnv):
     ) -> None:
         """Set tenant and process-global GEMINI keys independently.
 
-        Production prefers ``tenant["gemini_api_key"]`` then
-        ``get_config().gemini_api_key``. Tests that need tenant-present /
-        global-absent (or the reverse) must use this setter — writing both
-        surfaces to the same value makes the tenant preference unfalsifiable.
+        Production creative-sync advisories read only
+        ``tenant["gemini_api_key"]`` (account-scoped). The config mock remains
+        writable so unrelated surfaces and regression arms can still set a
+        process-global key that must *not* rescue a keyless tenant.
         """
         self.mock["config"].return_value.gemini_api_key = global_key
         tenant_dict = getattr(self.identity, "tenant", None)
         if isinstance(tenant_dict, dict):
             tenant_dict["gemini_api_key"] = tenant
 
-    @realize_e2e(
-        e2e_unsupported(
-            "CI / e2e stack always injects GEMINI_API_KEY into the live server process; "
-            "clearing the in-process get_config mock cannot realize a missing-key seller (#1887)"
-        )
-    )
+    @realize_e2e(_clear_gemini_api_key_e2e)
     def clear_gemini_api_key(self) -> None:
-        """Clear GEMINI_API_KEY on config mock and tenant dict (impl-only).
+        """Clear account-scoped GEMINI key (tenant dict + config mock).
 
-        Live e2e_rest cannot unset the server process env mid-suite — declare
-        E2EUnsupportedSetup so the BDD hook non-strict-xfails e2e only while
-        a2a/mcp/rest still grade X_PREBID_CREATIVE_GEMINI_KEY_MISSING.
+        E2E: null the shared-DB tenant column so the live server sees a keyless
+        seller even when the process still has ``GEMINI_API_KEY`` injected.
         """
         self.set_gemini_keys(tenant=None, global_key=None)
 

--- a/tests/harness/creative_sync.py
+++ b/tests/harness/creative_sync.py
@@ -110,6 +110,13 @@ class CreativeSyncEnv(EgressHatchMixin, IntegrationEnv):
         mock_config.gemini_api_key = None
         self.mock["config"].return_value = mock_config
 
+    @realize_e2e(
+        e2e_unsupported(
+            "generative build grading injects an in-process format mock and "
+            "registry.build_creative AsyncMock; the live e2e creative-agent "
+            "catalog cannot be stubbed mid-suite, and Then steps assert the mock"
+        )
+    )
     def setup_generative_build(
         self,
         format_id: str = "display_gen",
@@ -124,6 +131,10 @@ class CreativeSyncEnv(EgressHatchMixin, IntegrationEnv):
         - build_creative AsyncMock with the given return value
         - gemini_api_key on the config mock
         - run_async to return the generative format list
+
+        In-process only (a2a/mcp/rest). Live e2e_rest cannot stub the
+        creative-agent catalog or observe ``registry.build_creative`` —
+        declare E2EUnsupportedSetup so the BDD hook non-strict-xfails e2e.
 
         Returns a format_id dict for use in creative payloads::
 

--- a/tests/harness/creative_sync.py
+++ b/tests/harness/creative_sync.py
@@ -114,7 +114,7 @@ class CreativeSyncEnv(EgressHatchMixin, IntegrationEnv):
         e2e_unsupported(
             "generative build grading injects an in-process format mock and "
             "registry.build_creative AsyncMock; the live e2e creative-agent "
-            "catalog cannot be stubbed mid-suite, and Then steps assert the mock"
+            "catalog cannot be stubbed mid-suite, and Then steps assert the mock (#1887)"
         )
     )
     def setup_generative_build(
@@ -134,7 +134,9 @@ class CreativeSyncEnv(EgressHatchMixin, IntegrationEnv):
 
         In-process only (a2a/mcp/rest). Live e2e_rest cannot stub the
         creative-agent catalog or observe ``registry.build_creative`` —
-        declare E2EUnsupportedSetup so the BDD hook non-strict-xfails e2e.
+        declare E2EUnsupportedSetup so the BDD hook non-strict-xfails e2e
+        (#1887; partial adoption — ``set_run_async_result`` and direct
+        registry pokes remain unwrapped).
 
         Returns a format_id dict for use in creative payloads::
 
@@ -170,18 +172,34 @@ class CreativeSyncEnv(EgressHatchMixin, IntegrationEnv):
         registry.get_format = AsyncMock(return_value=mock_format)
 
         # Set gemini API key on both lookup surfaces production consults
-        # (tenant dict first, then process-global config).
-        self.mock["config"].return_value.gemini_api_key = gemini_api_key
-        tenant = getattr(self.identity, "tenant", None)
-        if isinstance(tenant, dict):
-            tenant["gemini_api_key"] = gemini_api_key
+        # (tenant dict first, then process-global config). Prefer
+        # ``set_gemini_keys`` when the surfaces must diverge.
+        self.set_gemini_keys(tenant=gemini_api_key, global_key=gemini_api_key)
 
         return {"agent_url": agent, "id": format_id}
+
+    def set_gemini_keys(
+        self,
+        *,
+        tenant: str | None = None,
+        global_key: str | None = None,
+    ) -> None:
+        """Set tenant and process-global GEMINI keys independently.
+
+        Production prefers ``tenant["gemini_api_key"]`` then
+        ``get_config().gemini_api_key``. Tests that need tenant-present /
+        global-absent (or the reverse) must use this setter — writing both
+        surfaces to the same value makes the tenant preference unfalsifiable.
+        """
+        self.mock["config"].return_value.gemini_api_key = global_key
+        tenant_dict = getattr(self.identity, "tenant", None)
+        if isinstance(tenant_dict, dict):
+            tenant_dict["gemini_api_key"] = tenant
 
     @realize_e2e(
         e2e_unsupported(
             "CI / e2e stack always injects GEMINI_API_KEY into the live server process; "
-            "clearing the in-process get_config mock cannot realize a missing-key seller"
+            "clearing the in-process get_config mock cannot realize a missing-key seller (#1887)"
         )
     )
     def clear_gemini_api_key(self) -> None:
@@ -191,10 +209,7 @@ class CreativeSyncEnv(EgressHatchMixin, IntegrationEnv):
         E2EUnsupportedSetup so the BDD hook non-strict-xfails e2e only while
         a2a/mcp/rest still grade X_PREBID_CREATIVE_GEMINI_KEY_MISSING.
         """
-        self.mock["config"].return_value.gemini_api_key = None
-        tenant = getattr(self.identity, "tenant", None)
-        if isinstance(tenant, dict):
-            tenant["gemini_api_key"] = None
+        self.set_gemini_keys(tenant=None, global_key=None)
 
     def set_run_async_result(self, formats: list[Any]) -> None:
         """Configure run_async_in_sync_context to return *formats*.

--- a/tests/harness/dispatchers.py
+++ b/tests/harness/dispatchers.py
@@ -83,9 +83,10 @@ class ImplDispatcher:
 class A2ADispatcher:
     """Dispatch via ``handler.on_message_send`` — exercises the full A2A pipeline.
 
-    ``env.call_a2a`` drives ``AdCPRequestHandler.on_message_send`` end-to-end
-    (message parsing → skill routing → handler dispatch → ``_serialize_for_a2a``
-    → Task/Artifact framing). On a failed Task, the harness reconstructs the
+    ``env.call_a2a`` for envs that drive ``AdCPRequestHandler.on_message_send``
+    end-to-end (message parsing → skill routing → handler dispatch →
+    ``_serialize_for_a2a`` → Task/Artifact framing) stashes the real
+    Task/Artifact DataPart. On a failed Task, the harness reconstructs the
     ``AdCPError`` from the artifact DataPart and stashes the real wire
     envelope on the exception via ``_wire_error_envelope`` — read off it by
     ``client.py``'s ``unwrap_a2a_error``, the one A2A error unwrap.

--- a/tests/harness/test_harness_creative.py
+++ b/tests/harness/test_harness_creative.py
@@ -106,6 +106,39 @@ class TestCreativeSyncEnvContract:
         # Should be a distinct method (not inherited NotImplementedError stub)
         assert callable(env.call_mcp)
 
+    def test_clear_gemini_api_key_clears_in_process_mock(self):
+        """In-process clear_gemini_api_key nulls the config mock key."""
+        from tests.harness.creative_sync import CreativeSyncEnv
+
+        class _UnitMode(CreativeSyncEnv):
+            use_real_db = False
+
+        with _UnitMode() as env:
+            env.mock["config"].return_value.gemini_api_key = "present"
+            env.clear_gemini_api_key()
+            assert env.mock["config"].return_value.gemini_api_key is None
+
+    def test_clear_gemini_api_key_e2e_unsupported(self):
+        """e2e cannot clear live-server GEMINI_API_KEY — declare unsupported."""
+        import pytest
+
+        from tests.harness._realize import E2EUnsupportedSetup
+        from tests.harness.creative_sync import CreativeSyncEnv
+        from tests.harness.transport import E2EConfig
+
+        class _UnitMode(CreativeSyncEnv):
+            use_real_db = False
+
+        e2e = E2EConfig(
+            base_url="http://proxy:8000",
+            postgres_url="postgresql://unused",
+        )
+        with _UnitMode(e2e_config=e2e) as env:
+            with pytest.raises(E2EUnsupportedSetup) as exc_info:
+                env.clear_gemini_api_key()
+        assert "GEMINI_API_KEY" in str(exc_info.value)
+        assert exc_info.value.method_name == "clear_gemini_api_key"
+
 
 class TestCreativeListEnvContract:
     """CreativeListEnv must mock only audit logger."""

--- a/tests/harness/test_harness_creative.py
+++ b/tests/harness/test_harness_creative.py
@@ -358,6 +358,35 @@ class TestNestedCreativeAdvisoryAccessor:
         with pytest.raises(AssertionError, match="wire_response missing"):
             _nested_creative_advisory_error({"transport": Transport.A2A, "wire_response": None, "response": resp})
 
+    def test_nested_bdd_helper_skips_a2a_model_dump_proxy(self):
+        """Proxy wire must not count as nested-advisory wire evidence (#1919 / Chris R3-04)."""
+        from types import SimpleNamespace
+
+        from tests.bdd.steps.generic.then_error import _nested_creative_advisory_error
+        from tests.harness.transport import Transport
+
+        result = SimpleNamespace(envelope={"wire_response_is_proxy": True})
+        wire = {
+            "creatives": [
+                {
+                    "creative_id": "c1",
+                    "action": "failed",
+                    "errors": [{"code": "X_PREBID_CREATIVE_GEMINI_KEY_MISSING", "recovery": "terminal"}],
+                }
+            ]
+        }
+        assert (
+            _nested_creative_advisory_error(
+                {
+                    "transport": Transport.A2A,
+                    "wire_response": wire,
+                    "response": None,
+                    "result": result,
+                }
+            )
+            is None
+        )
+
     def test_nested_bdd_helper_loud_when_wire_without_transport(self):
         """Present wire + unset transport must not default to IMPL."""
         import pytest

--- a/tests/harness/test_harness_creative.py
+++ b/tests/harness/test_harness_creative.py
@@ -111,34 +111,38 @@ class TestCreativeSyncEnvContract:
         assert callable(env.call_mcp)
 
     def test_clear_gemini_api_key_clears_in_process_mock(self):
-        """In-process clear_gemini_api_key nulls the config mock key."""
+        """In-process clear_gemini_api_key nulls the account-scoped tenant key."""
         from tests.harness.creative_sync import CreativeSyncEnv
 
         with _unit_mode(CreativeSyncEnv)() as env:
-            env.mock["config"].return_value.gemini_api_key = "present"
+            env.set_gemini_keys(tenant="present", global_key="present")
             env.clear_gemini_api_key()
+            assert env.identity.tenant["gemini_api_key"] is None
             assert env.mock["config"].return_value.gemini_api_key is None
 
-    def test_clear_gemini_api_key_e2e_unsupported(self):
-        """e2e cannot clear live-server GEMINI_API_KEY — declare unsupported."""
-        import pytest
+    def test_clear_gemini_api_key_e2e_nulls_tenant_row(self):
+        """e2e realization nulls the shared-DB tenant column (account-scoped)."""
+        from unittest.mock import MagicMock
 
-        from tests.harness._realize import E2EUnsupportedSetup
-        from tests.harness.creative_sync import CreativeSyncEnv
-        from tests.harness.transport import E2EConfig
+        from tests.harness.creative_sync import _clear_gemini_api_key_e2e
 
-        e2e = E2EConfig(
-            base_url="http://proxy:8000",
-            postgres_url="postgresql://unused",
-        )
-        with _unit_mode(CreativeSyncEnv)(e2e_config=e2e) as env:
-            with pytest.raises(E2EUnsupportedSetup) as exc_info:
-                env.clear_gemini_api_key()
-        assert "GEMINI_API_KEY" in str(exc_info.value)
-        assert exc_info.value.method_name == "clear_gemini_api_key"
+        tenant_row = MagicMock()
+        tenant_row.gemini_api_key = "present"
+        session = MagicMock()
+        session.scalars.return_value.first.return_value = tenant_row
+        env = MagicMock()
+        env.get_session.return_value = session
+        env._tenant_id = "t1"
+        env.identity.tenant = {"gemini_api_key": "present"}
+
+        _clear_gemini_api_key_e2e(env)
+
+        assert tenant_row.gemini_api_key is None
+        env._commit_factory_data.assert_called_once()
+        assert env.identity.tenant["gemini_api_key"] is None
 
     def test_setup_generative_build_e2e_unsupported(self):
-        """e2e cannot stub creative-agent catalog — declare unsupported (#1887)."""
+        """e2e cannot stub creative-agent catalog — declare unsupported (#1964)."""
         import pytest
 
         from tests.harness._realize import E2EUnsupportedSetup
@@ -153,7 +157,7 @@ class TestCreativeSyncEnvContract:
             with pytest.raises(E2EUnsupportedSetup) as exc_info:
                 env.setup_generative_build()
         assert exc_info.value.method_name == "setup_generative_build"
-        assert "#1887" in str(exc_info.value)
+        assert "#1964" in str(exc_info.value)
 
     def test_set_gemini_keys_independent_surfaces(self):
         """Tenant and global GEMINI keys must be independently controllable."""

--- a/tests/harness/test_harness_creative.py
+++ b/tests/harness/test_harness_creative.py
@@ -137,6 +137,36 @@ class TestCreativeSyncEnvContract:
         assert "GEMINI_API_KEY" in str(exc_info.value)
         assert exc_info.value.method_name == "clear_gemini_api_key"
 
+    def test_setup_generative_build_e2e_unsupported(self):
+        """e2e cannot stub creative-agent catalog — declare unsupported (#1887)."""
+        import pytest
+
+        from tests.harness._realize import E2EUnsupportedSetup
+        from tests.harness.creative_sync import CreativeSyncEnv
+        from tests.harness.transport import E2EConfig
+
+        e2e = E2EConfig(
+            base_url="http://proxy:8000",
+            postgres_url="postgresql://unused",
+        )
+        with _unit_mode(CreativeSyncEnv)(e2e_config=e2e) as env:
+            with pytest.raises(E2EUnsupportedSetup) as exc_info:
+                env.setup_generative_build()
+        assert exc_info.value.method_name == "setup_generative_build"
+        assert "#1887" in str(exc_info.value)
+
+    def test_set_gemini_keys_independent_surfaces(self):
+        """Tenant and global GEMINI keys must be independently controllable."""
+        from tests.harness.creative_sync import CreativeSyncEnv
+
+        with _unit_mode(CreativeSyncEnv)() as env:
+            env.set_gemini_keys(tenant="tenant-only-key", global_key=None)
+            assert env.identity.tenant["gemini_api_key"] == "tenant-only-key"
+            assert env.mock["config"].return_value.gemini_api_key is None
+            env.set_gemini_keys(tenant=None, global_key="global-only-key")
+            assert env.identity.tenant["gemini_api_key"] is None
+            assert env.mock["config"].return_value.gemini_api_key == "global-only-key"
+
     def test_call_a2a_stashes_wire_response(self, monkeypatch):
         """_raw() A2A path must stash model_dump wire for nested-advisory grading."""
         from unittest.mock import MagicMock
@@ -207,10 +237,16 @@ class TestNestedCreativeAdvisoryAccessor:
         wire = {"creatives": [{"creative_id": "bad", "action": "failed"}]}  # errors[] dropped
         resp = SimpleNamespace(
             creatives=[SimpleNamespace(action="failed", errors=[{"code": "X"}])],
-            results=None,
         )
         with pytest.raises(AssertionError, match="dropped errors"):
             first_failed_creative_advisory(wire, transport=Transport.REST, response=resp)
+
+    def test_soft_none_when_wire_has_no_failed_creative(self):
+        """Present wire + no failed creative → soft None (envelope-only paths)."""
+        from tests.harness.transport import Transport, first_failed_creative_advisory
+
+        wire = {"creatives": [{"creative_id": "ok", "action": "created", "errors": []}]}
+        assert first_failed_creative_advisory(wire, transport=Transport.REST) is None
 
     def test_assert_wire_advisory_grades_code_and_recovery(self):
         from tests.harness.transport import Transport, assert_wire_advisory
@@ -231,7 +267,71 @@ class TestNestedCreativeAdvisoryAccessor:
             transport=Transport.REST,
         )
         assert advisory is not None
-        assert advisory["code"] == "X_PREBID_CREATIVE_GEMINI_KEY_MISSING"
+
+    def test_assert_wire_advisory_reddens_on_wrong_code(self):
+        """Mutation oracle: gutting the code assert must fail this meta-test."""
+        import pytest
+
+        from tests.harness.transport import Transport, assert_wire_advisory
+
+        wire = {
+            "creatives": [
+                {
+                    "creative_id": "bad",
+                    "action": "failed",
+                    "errors": [{"code": "X_PREBID_CREATIVE_GEMINI_KEY_MISSING", "recovery": "terminal"}],
+                }
+            ]
+        }
+        with pytest.raises(AssertionError, match="unexpected wire advisory code"):
+            assert_wire_advisory(wire, "WRONG_CODE", recovery="terminal", transport=Transport.REST)
+
+    def test_assert_wire_advisory_reddens_on_wrong_recovery(self):
+        """Mutation oracle: gutting the recovery assert must fail this meta-test."""
+        import pytest
+
+        from tests.harness.transport import Transport, assert_wire_advisory
+
+        wire = {
+            "creatives": [
+                {
+                    "creative_id": "bad",
+                    "action": "failed",
+                    "errors": [{"code": "X_PREBID_CREATIVE_GEMINI_KEY_MISSING", "recovery": "terminal"}],
+                }
+            ]
+        }
+        with pytest.raises(AssertionError, match="unexpected wire advisory recovery"):
+            assert_wire_advisory(
+                wire,
+                "X_PREBID_CREATIVE_GEMINI_KEY_MISSING",
+                recovery="transient",
+                transport=Transport.REST,
+            )
+
+    def test_assert_wire_advisory_refuses_proxy_when_require_real_wire(self):
+        import pytest
+
+        from tests.harness.transport import Transport, assert_wire_advisory
+
+        wire = {
+            "creatives": [
+                {
+                    "creative_id": "bad",
+                    "action": "failed",
+                    "errors": [{"code": "X_PREBID_CREATIVE_GEMINI_KEY_MISSING", "recovery": "terminal"}],
+                }
+            ]
+        }
+        with pytest.raises(AssertionError, match="model_dump proxy"):
+            assert_wire_advisory(
+                wire,
+                "X_PREBID_CREATIVE_GEMINI_KEY_MISSING",
+                recovery="terminal",
+                transport=Transport.A2A,
+                wire_is_proxy=True,
+                require_real_wire=True,
+            )
 
     def test_nested_bdd_helper_soft_on_envelope_less_error_path(self):
         """UC003/UC019-style: wire transport, no wire_response, no failed creative → soft None."""
@@ -254,11 +354,33 @@ class TestNestedCreativeAdvisoryAccessor:
 
         resp = SimpleNamespace(
             creatives=[SimpleNamespace(action="failed", errors=[{"code": "X"}])],
-            results=None,
         )
         with pytest.raises(AssertionError, match="wire_response missing"):
             _nested_creative_advisory_error({"transport": Transport.A2A, "wire_response": None, "response": resp})
 
+    def test_nested_bdd_helper_loud_when_wire_without_transport(self):
+        """Present wire + unset transport must not default to IMPL."""
+        import pytest
+
+        from tests.bdd.steps.generic.then_error import _nested_creative_advisory_error
+
+        with pytest.raises(AssertionError, match="transport"):
+            _nested_creative_advisory_error(
+                {
+                    "wire_response": {
+                        "creatives": [
+                            {
+                                "creative_id": "bad",
+                                "action": "failed",
+                                "errors": [{"code": "X_PREBID_CREATIVE_GEMINI_KEY_MISSING"}],
+                            }
+                        ]
+                    }
+                }
+            )
+
+
+class TestCreativeListEnvContract:
     """CreativeListEnv must mock only audit logger."""
 
     def test_import_succeeds(self):

--- a/tests/harness/test_harness_creative.py
+++ b/tests/harness/test_harness_creative.py
@@ -358,8 +358,12 @@ class TestNestedCreativeAdvisoryAccessor:
         with pytest.raises(AssertionError, match="wire_response missing"):
             _nested_creative_advisory_error({"transport": Transport.A2A, "wire_response": None, "response": resp})
 
-    def test_nested_bdd_helper_skips_a2a_model_dump_proxy(self):
-        """Proxy wire must not count as nested-advisory wire evidence (#1919 / Chris R3-04)."""
+    def test_nested_bdd_helper_grades_a2a_model_dump_proxy_payload(self):
+        """BDD grades proxy *payload* until real A2A framing lands (#1919 / Chris R3-04).
+
+        Framing refusal is ``require_real_wire=True`` (integration +
+        ``test_assert_wire_advisory_refuses_proxy_when_require_real_wire``).
+        """
         from types import SimpleNamespace
 
         from tests.bdd.steps.generic.then_error import _nested_creative_advisory_error
@@ -375,17 +379,16 @@ class TestNestedCreativeAdvisoryAccessor:
                 }
             ]
         }
-        assert (
-            _nested_creative_advisory_error(
-                {
-                    "transport": Transport.A2A,
-                    "wire_response": wire,
-                    "response": None,
-                    "result": result,
-                }
-            )
-            is None
+        advisory = _nested_creative_advisory_error(
+            {
+                "transport": Transport.A2A,
+                "wire_response": wire,
+                "response": None,
+                "result": result,
+            }
         )
+        assert advisory is not None
+        assert advisory["code"] == "X_PREBID_CREATIVE_GEMINI_KEY_MISSING"
 
     def test_nested_bdd_helper_loud_when_wire_without_transport(self):
         """Present wire + unset transport must not default to IMPL."""

--- a/tests/harness/test_harness_creative.py
+++ b/tests/harness/test_harness_creative.py
@@ -171,6 +171,18 @@ class TestCreativeSyncEnvContract:
             assert env.identity.tenant["gemini_api_key"] is None
             assert env.mock["config"].return_value.gemini_api_key == "global-only-key"
 
+    def test_set_gemini_keys_applies_to_later_transport_identities(self):
+        """call_via builds per-protocol identities after setup — key must survive."""
+        from tests.harness.creative_sync import CreativeSyncEnv
+        from tests.harness.transport import Transport
+
+        with _unit_mode(CreativeSyncEnv)() as env:
+            env.set_gemini_keys(tenant="shared-key", global_key=None)
+            a2a = env.identity_for(Transport.A2A)
+            rest = env.identity_for(Transport.REST)
+            assert a2a.tenant["gemini_api_key"] == "shared-key"
+            assert rest.tenant["gemini_api_key"] == "shared-key"
+
     def test_call_a2a_stashes_wire_response(self, monkeypatch):
         """_raw() A2A path must stash model_dump wire for nested-advisory grading."""
         from unittest.mock import MagicMock

--- a/tests/harness/test_harness_creative.py
+++ b/tests/harness/test_harness_creative.py
@@ -138,7 +138,7 @@ class TestCreativeSyncEnvContract:
         _clear_gemini_api_key_e2e(env)
 
         assert tenant_row.gemini_api_key is None
-        env._commit_factory_data.assert_called_once()
+        env._commit_factory_data.assert_called_once_with()
         assert env.identity.tenant["gemini_api_key"] is None
 
     def test_setup_generative_build_e2e_unsupported(self):

--- a/tests/harness/test_harness_creative.py
+++ b/tests/harness/test_harness_creative.py
@@ -196,6 +196,22 @@ class TestNestedCreativeAdvisoryAccessor:
         advisory = first_failed_creative_advisory(wire, transport=Transport.MCP)
         assert advisory == {"code": "X_PREBID_CREATIVE_GEMINI_KEY_MISSING", "recovery": "terminal"}
 
+    def test_loud_when_failed_creative_drops_errors_with_response(self):
+        """Present wire + failed creative + dropped errors[] must raise (KM Aug-05)."""
+        from types import SimpleNamespace
+
+        import pytest
+
+        from tests.harness.transport import Transport, first_failed_creative_advisory
+
+        wire = {"creatives": [{"creative_id": "bad", "action": "failed"}]}  # errors[] dropped
+        resp = SimpleNamespace(
+            creatives=[SimpleNamespace(action="failed", errors=[{"code": "X"}])],
+            results=None,
+        )
+        with pytest.raises(AssertionError, match="dropped errors"):
+            first_failed_creative_advisory(wire, transport=Transport.REST, response=resp)
+
     def test_assert_wire_advisory_grades_code_and_recovery(self):
         from tests.harness.transport import Transport, assert_wire_advisory
 

--- a/tests/harness/test_harness_creative.py
+++ b/tests/harness/test_harness_creative.py
@@ -183,31 +183,40 @@ class TestCreativeSyncEnvContract:
             assert a2a.tenant["gemini_api_key"] == "shared-key"
             assert rest.tenant["gemini_api_key"] == "shared-key"
 
-    def test_call_a2a_stashes_wire_response(self, monkeypatch):
-        """_raw() A2A path must stash model_dump wire for nested-advisory grading."""
-        from unittest.mock import MagicMock
+    def test_deliver_a2a_carries_wire_on_result(self, monkeypatch):
+        """A2A wire rides DeliverResult — not a deleted per-env ``_last_wire_response`` stash.
 
+        After the single-dispatch migration, ``call_a2a`` is ``deliver_a2a(...).payload`` and
+        dispatchers read ``DeliverResult.wire_response``. The old unit contract mocked
+        ``sync_creatives_raw`` and asserted ``env._last_wire_response``; that bypass and
+        attribute are gone. Pin the return-value contract instead.
+        """
         from tests.harness.creative_sync import CreativeSyncEnv
+        from tests.harness.transport import DeliverResult
 
-        fake = MagicMock()
-        fake.model_dump.return_value = {
+        wire = {
             "creatives": [
-                {"creative_id": "c1", "action": "failed", "errors": [{"code": "X_PREBID_CREATIVE_GEMINI_KEY_MISSING"}]}
+                {
+                    "creative_id": "c1",
+                    "action": "failed",
+                    "errors": [{"code": "X_PREBID_CREATIVE_GEMINI_KEY_MISSING"}],
+                }
             ],
         }
-        monkeypatch.setattr(
-            "src.core.tools.creatives.sync_wrappers.sync_creatives_raw",
-            lambda **_kwargs: fake,
-        )
+        payload = object()
+
+        def _fake_handler(self, skill_name, response_cls, **kwargs):
+            return DeliverResult(payload=payload, wire_response=wire)
+
+        monkeypatch.setattr(CreativeSyncEnv, "_run_a2a_handler", _fake_handler)
         with _unit_mode(CreativeSyncEnv)() as env:
             env._commit_factory_data = lambda: None  # noqa: E731 — unit stub
+            delivered = env.deliver_a2a(creatives=[])
             out = env.call_a2a(creatives=[])
-        assert out is fake
-        assert env._last_wire_response == fake.model_dump.return_value
-        assert env._wire_response_is_proxy is True, (
-            "stashed wire must be flagged as a model_dump proxy, not real A2A framing"
-        )
-        fake.model_dump.assert_called_once_with(mode="json")
+        assert delivered.wire_response == wire
+        assert delivered.payload is payload
+        assert out is payload
+        assert not hasattr(env, "_last_wire_response")
 
 
 class TestNestedCreativeAdvisoryAccessor:
@@ -405,7 +414,7 @@ class TestNestedCreativeAdvisoryAccessor:
             _nested_creative_advisory_error({"transport": Transport.A2A, "wire_response": None, "response": resp})
 
     def test_nested_bdd_helper_grades_a2a_model_dump_proxy_payload(self):
-        """BDD grades proxy *payload* until real A2A framing lands (#1919 / Chris R3-04).
+        """BDD grades proxy *payload* until real A2A framing lands (#1919).
 
         Framing refusal is ``require_real_wire=True`` (integration +
         ``test_assert_wire_advisory_refuses_proxy_when_require_real_wire``).

--- a/tests/harness/test_harness_creative.py
+++ b/tests/harness/test_harness_creative.py
@@ -139,8 +139,112 @@ class TestCreativeSyncEnvContract:
         assert "GEMINI_API_KEY" in str(exc_info.value)
         assert exc_info.value.method_name == "clear_gemini_api_key"
 
+    def test_call_a2a_stashes_wire_response(self, monkeypatch):
+        """_raw() A2A path must stash model_dump wire for nested-advisory grading."""
+        from unittest.mock import MagicMock
 
-class TestCreativeListEnvContract:
+        from tests.harness.creative_sync import CreativeSyncEnv
+
+        class _UnitMode(CreativeSyncEnv):
+            use_real_db = False
+
+        fake = MagicMock()
+        fake.model_dump.return_value = {
+            "creatives": [
+                {"creative_id": "c1", "action": "failed", "errors": [{"code": "CREATIVE_GEMINI_KEY_MISSING"}]}
+            ],
+        }
+        monkeypatch.setattr(
+            "src.core.tools.creatives.sync_wrappers.sync_creatives_raw",
+            lambda **_kwargs: fake,
+        )
+        with _UnitMode() as env:
+            env._commit_factory_data = lambda: None  # noqa: E731 — unit stub
+            out = env.call_a2a(creatives=[])
+        assert out is fake
+        assert env._last_wire_response == fake.model_dump.return_value
+        fake.model_dump.assert_called_once_with(mode="json")
+
+
+class TestNestedCreativeAdvisoryAccessor:
+    """first_failed_creative_advisory / assert_wire_advisory contracts."""
+
+    def test_loud_when_wire_missing_on_wire_transport(self):
+        import pytest
+
+        from tests.harness.transport import Transport, first_failed_creative_advisory
+
+        with pytest.raises(AssertionError, match="wire_response missing"):
+            first_failed_creative_advisory(None, transport=Transport.A2A)
+
+    def test_soft_none_on_impl(self):
+        from tests.harness.transport import Transport, first_failed_creative_advisory
+
+        assert first_failed_creative_advisory(None, transport=Transport.IMPL) is None
+
+    def test_returns_first_failed_advisory(self):
+        from tests.harness.transport import Transport, first_failed_creative_advisory
+
+        wire = {
+            "creatives": [
+                {"creative_id": "ok", "action": "created", "errors": []},
+                {
+                    "creative_id": "bad",
+                    "action": "failed",
+                    "errors": [{"code": "CREATIVE_GEMINI_KEY_MISSING", "recovery": "terminal"}],
+                },
+            ]
+        }
+        advisory = first_failed_creative_advisory(wire, transport=Transport.MCP)
+        assert advisory == {"code": "CREATIVE_GEMINI_KEY_MISSING", "recovery": "terminal"}
+
+    def test_assert_wire_advisory_grades_code_and_recovery(self):
+        from tests.harness.transport import Transport, assert_wire_advisory
+
+        wire = {
+            "creatives": [
+                {
+                    "creative_id": "bad",
+                    "action": "failed",
+                    "errors": [{"code": "CREATIVE_GEMINI_KEY_MISSING", "recovery": "terminal"}],
+                }
+            ]
+        }
+        advisory = assert_wire_advisory(
+            wire,
+            "CREATIVE_GEMINI_KEY_MISSING",
+            recovery="terminal",
+            transport=Transport.REST,
+        )
+        assert advisory is not None
+        assert advisory["code"] == "CREATIVE_GEMINI_KEY_MISSING"
+
+    def test_nested_bdd_helper_soft_on_envelope_less_error_path(self):
+        """UC003/UC019-style: wire transport, no wire_response, no failed creative → soft None."""
+        from tests.bdd.steps.generic.then_error import _nested_creative_advisory_error
+        from tests.harness.transport import Transport
+
+        assert (
+            _nested_creative_advisory_error({"transport": Transport.MCP, "wire_response": None, "response": None})
+            is None
+        )
+
+    def test_nested_bdd_helper_loud_when_failed_creative_without_wire(self):
+        """Success+advisory without stashed wire must not soft-fallback."""
+        from types import SimpleNamespace
+
+        import pytest
+
+        from tests.bdd.steps.generic.then_error import _nested_creative_advisory_error
+        from tests.harness.transport import Transport
+
+        resp = SimpleNamespace(
+            creatives=[SimpleNamespace(action="failed", errors=[{"code": "X"}])],
+            results=None,
+        )
+        with pytest.raises(AssertionError, match="wire_response missing"):
+            _nested_creative_advisory_error({"transport": Transport.A2A, "wire_response": None, "response": resp})
+
     """CreativeListEnv must mock only audit logger."""
 
     def test_import_succeeds(self):

--- a/tests/harness/test_harness_creative.py
+++ b/tests/harness/test_harness_creative.py
@@ -325,6 +325,36 @@ class TestNestedCreativeAdvisoryAccessor:
                 transport=Transport.REST,
             )
 
+    def test_assert_wire_advisory_reddens_on_wrong_suggestion(self):
+        """Mutation oracle: gutting the suggestion assert must fail this meta-test."""
+        import pytest
+
+        from tests.harness.transport import Transport, assert_wire_advisory
+
+        wire = {
+            "creatives": [
+                {
+                    "creative_id": "bad",
+                    "action": "failed",
+                    "errors": [
+                        {
+                            "code": "X_PREBID_CREATIVE_GEMINI_KEY_MISSING",
+                            "recovery": "terminal",
+                            "suggestion": "wrong suggestion",
+                        }
+                    ],
+                }
+            ]
+        }
+        with pytest.raises(AssertionError, match="unexpected wire advisory suggestion"):
+            assert_wire_advisory(
+                wire,
+                "X_PREBID_CREATIVE_GEMINI_KEY_MISSING",
+                recovery="terminal",
+                suggestion="Ask the seller to configure a Gemini API key for this account",
+                transport=Transport.REST,
+            )
+
     def test_assert_wire_advisory_refuses_proxy_when_require_real_wire(self):
         import pytest
 

--- a/tests/harness/test_harness_creative.py
+++ b/tests/harness/test_harness_creative.py
@@ -8,6 +8,16 @@ mock dict populated, identity lazy, _configure_mocks called.
 from __future__ import annotations
 
 
+def _unit_mode(env_cls: type) -> type:
+    """Return a ``use_real_db = False`` subclass of *env_cls* for unit-mode smoke tests.
+
+    Single home for the unit-mode stamp — avoids ``class _UnitMode(<Env>):
+    use_real_db = False`` copy-pasted at every call site that wants to exercise
+    an IntegrationEnv's patches without needing the ``integration_db`` fixture.
+    """
+    return type("_UnitMode", (env_cls,), {"use_real_db": False})
+
+
 class TestCreativeSyncEnvContract:
     """CreativeSyncEnv must mock only external services, not DB."""
 
@@ -35,10 +45,7 @@ class TestCreativeSyncEnvContract:
         from tests.harness.creative_sync import CreativeSyncEnv
 
         # Override use_real_db to avoid needing integration_db fixture
-        class _UnitMode(CreativeSyncEnv):
-            use_real_db = False
-
-        with _UnitMode() as env:
+        with _unit_mode(CreativeSyncEnv)() as env:
             assert "registry" in env.mock
             assert "run_async" in env.mock
             assert "send_notifications" in env.mock
@@ -58,10 +65,7 @@ class TestCreativeSyncEnvContract:
         """_configure_mocks sets up happy-path registry return values."""
         from tests.harness.creative_sync import CreativeSyncEnv
 
-        class _UnitMode(CreativeSyncEnv):
-            use_real_db = False
-
-        with _UnitMode() as env:
+        with _unit_mode(CreativeSyncEnv)() as env:
             # Registry mock should have a return value configured
             assert env.mock["registry"].return_value is not None
 
@@ -110,10 +114,7 @@ class TestCreativeSyncEnvContract:
         """In-process clear_gemini_api_key nulls the config mock key."""
         from tests.harness.creative_sync import CreativeSyncEnv
 
-        class _UnitMode(CreativeSyncEnv):
-            use_real_db = False
-
-        with _UnitMode() as env:
+        with _unit_mode(CreativeSyncEnv)() as env:
             env.mock["config"].return_value.gemini_api_key = "present"
             env.clear_gemini_api_key()
             assert env.mock["config"].return_value.gemini_api_key is None
@@ -126,14 +127,11 @@ class TestCreativeSyncEnvContract:
         from tests.harness.creative_sync import CreativeSyncEnv
         from tests.harness.transport import E2EConfig
 
-        class _UnitMode(CreativeSyncEnv):
-            use_real_db = False
-
         e2e = E2EConfig(
             base_url="http://proxy:8000",
             postgres_url="postgresql://unused",
         )
-        with _UnitMode(e2e_config=e2e) as env:
+        with _unit_mode(CreativeSyncEnv)(e2e_config=e2e) as env:
             with pytest.raises(E2EUnsupportedSetup) as exc_info:
                 env.clear_gemini_api_key()
         assert "GEMINI_API_KEY" in str(exc_info.value)
@@ -145,24 +143,24 @@ class TestCreativeSyncEnvContract:
 
         from tests.harness.creative_sync import CreativeSyncEnv
 
-        class _UnitMode(CreativeSyncEnv):
-            use_real_db = False
-
         fake = MagicMock()
         fake.model_dump.return_value = {
             "creatives": [
-                {"creative_id": "c1", "action": "failed", "errors": [{"code": "CREATIVE_GEMINI_KEY_MISSING"}]}
+                {"creative_id": "c1", "action": "failed", "errors": [{"code": "X_PREBID_CREATIVE_GEMINI_KEY_MISSING"}]}
             ],
         }
         monkeypatch.setattr(
             "src.core.tools.creatives.sync_wrappers.sync_creatives_raw",
             lambda **_kwargs: fake,
         )
-        with _UnitMode() as env:
+        with _unit_mode(CreativeSyncEnv)() as env:
             env._commit_factory_data = lambda: None  # noqa: E731 — unit stub
             out = env.call_a2a(creatives=[])
         assert out is fake
         assert env._last_wire_response == fake.model_dump.return_value
+        assert env._wire_response_is_proxy is True, (
+            "stashed wire must be flagged as a model_dump proxy, not real A2A framing"
+        )
         fake.model_dump.assert_called_once_with(mode="json")
 
 
@@ -191,12 +189,12 @@ class TestNestedCreativeAdvisoryAccessor:
                 {
                     "creative_id": "bad",
                     "action": "failed",
-                    "errors": [{"code": "CREATIVE_GEMINI_KEY_MISSING", "recovery": "terminal"}],
+                    "errors": [{"code": "X_PREBID_CREATIVE_GEMINI_KEY_MISSING", "recovery": "terminal"}],
                 },
             ]
         }
         advisory = first_failed_creative_advisory(wire, transport=Transport.MCP)
-        assert advisory == {"code": "CREATIVE_GEMINI_KEY_MISSING", "recovery": "terminal"}
+        assert advisory == {"code": "X_PREBID_CREATIVE_GEMINI_KEY_MISSING", "recovery": "terminal"}
 
     def test_assert_wire_advisory_grades_code_and_recovery(self):
         from tests.harness.transport import Transport, assert_wire_advisory
@@ -206,18 +204,18 @@ class TestNestedCreativeAdvisoryAccessor:
                 {
                     "creative_id": "bad",
                     "action": "failed",
-                    "errors": [{"code": "CREATIVE_GEMINI_KEY_MISSING", "recovery": "terminal"}],
+                    "errors": [{"code": "X_PREBID_CREATIVE_GEMINI_KEY_MISSING", "recovery": "terminal"}],
                 }
             ]
         }
         advisory = assert_wire_advisory(
             wire,
-            "CREATIVE_GEMINI_KEY_MISSING",
+            "X_PREBID_CREATIVE_GEMINI_KEY_MISSING",
             recovery="terminal",
             transport=Transport.REST,
         )
         assert advisory is not None
-        assert advisory["code"] == "CREATIVE_GEMINI_KEY_MISSING"
+        assert advisory["code"] == "X_PREBID_CREATIVE_GEMINI_KEY_MISSING"
 
     def test_nested_bdd_helper_soft_on_envelope_less_error_path(self):
         """UC003/UC019-style: wire transport, no wire_response, no failed creative → soft None."""
@@ -270,10 +268,7 @@ class TestNestedCreativeAdvisoryAccessor:
         """Verify patches activate correctly."""
         from tests.harness.creative_list import CreativeListEnv
 
-        class _UnitMode(CreativeListEnv):
-            use_real_db = False
-
-        with _UnitMode() as env:
+        with _unit_mode(CreativeListEnv)() as env:
             assert "audit_logger" in env.mock
             assert len(env.mock) == 1
 
@@ -304,10 +299,7 @@ class TestCreativeFormatsEnvContract:
         """Verify patches activate correctly."""
         from tests.harness.creative_formats import CreativeFormatsEnv
 
-        class _UnitMode(CreativeFormatsEnv):
-            use_real_db = False
-
-        with _UnitMode() as env:
+        with _unit_mode(CreativeFormatsEnv)() as env:
             assert "registry" in env.mock
             assert "audit_logger" in env.mock
             assert len(env.mock) == 2

--- a/tests/harness/transport.py
+++ b/tests/harness/transport.py
@@ -140,6 +140,150 @@ def _envelope_from_mcp_error(exc: Exception) -> dict[str, Any] | None:
     return None
 
 
+def _enum_value(x: Any) -> Any:
+    """Unwrap enum-or-str discriminators to a comparable value."""
+    return x.value if hasattr(x, "value") else x
+
+
+def _transport_has_no_wire(transport: Transport) -> bool:
+    """True when *transport* is IMPL (no success-path wire to stash)."""
+    return _enum_value(transport) == Transport.IMPL.value
+
+
+def _action_value(obj: Any) -> Any:
+    """Unwrap dict/enum/str action discriminators to a comparable value."""
+    if isinstance(obj, dict):
+        action = obj.get("action")
+        if isinstance(action, dict):
+            return action.get("value")
+        return _enum_value(action)
+    return _enum_value(getattr(obj, "action", None))
+
+
+def _iter_creative_entries(container: Any) -> list[Any]:
+    """Return the creatives list from a typed response or wire dict (no ``results`` key)."""
+    if container is None:
+        return []
+    if isinstance(container, dict):
+        return list(container.get("creatives") or [])
+    return list(getattr(container, "creatives", None) or [])
+
+
+def _response_has_failed_creative(response: Any) -> bool:
+    """True when a typed sync response carries a per-creative ``action == "failed"``.
+
+    Single home for the discriminator shared by ``first_failed_creative_advisory``
+    (wire-present-but-dropped-advisory case) and the BDD ``then_error`` reader
+    (wire-absent case) — decides whether a missing/advisory-free wire on a
+    wire-stashing transport is a buyer-facing regression (loud) vs a genuinely
+    envelope-only error path that never carries a success+advisory response
+    (soft ``None``, e.g. UC003/UC019 validation failures).
+    """
+    for creative in _iter_creative_entries(response):
+        if _action_value(creative) == "failed":
+            return True
+    return False
+
+
+def first_failed_creative_advisory(
+    wire: dict[str, Any] | None,
+    *,
+    transport: Transport,
+    response: Any = None,
+    wire_is_proxy: bool = False,
+    require_real_wire: bool = False,
+) -> dict[str, Any] | None:
+    """First failed ``creatives[].errors[0]`` from a success-path wire body.
+
+    Grades the buyer-facing nested advisory inside a successful ``sync_creatives``
+    artifact (no ``wire_error_envelope``). Filters to ``action == "failed"``.
+
+    Loud guards (same contract as BDD ``wire_dict`` / ``wire_field``):
+    - A wire-stashing transport (REST/A2A/MCP/…) that did not stash ``wire`` at
+      all raises unconditionally instead of silently returning ``None``.
+    - A wire-stashing transport that stashed a *present* wire whose failed
+      creative dropped ``errors[]`` — the buyer-facing regression this
+      accessor exists to catch — raises when the caller passes the typed
+      ``response`` and it shows a failed creative (``_response_has_failed_creative``).
+      Without ``response`` this case cannot be distinguished from "no failed
+      creative on the wire" and returns ``None``.
+    - When ``require_real_wire=True`` and ``wire_is_proxy=True`` (CreativeSyncEnv
+      A2A ``model_dump`` proxy — not Task/Artifact DataPart; see #1919), raises
+      instead of treating the proxy as real A2A framing evidence.
+
+    IMPL transport legitimately has no wire and returns ``None``.
+    """
+    if require_real_wire and wire_is_proxy:
+        raise AssertionError(
+            f"{transport}: wire_response is a model_dump proxy — not real A2A Task/Artifact "
+            "framing (see #1919); refuse require_real_wire grading"
+        )
+    no_wire = _transport_has_no_wire(transport)
+    if wire is None:
+        if no_wire:
+            return None
+        raise AssertionError(f"{transport}: wire_response missing — env does not stash success-path wire")
+    if not isinstance(wire, dict):
+        return None
+    for creative in _iter_creative_entries(wire):
+        if not isinstance(creative, dict):
+            continue
+        if _action_value(creative) != "failed":
+            continue
+        errs = creative.get("errors") or []
+        if errs and isinstance(errs[0], dict):
+            return errs[0]
+    if not no_wire and _response_has_failed_creative(response):
+        raise AssertionError(f"{transport}: advisory missing from wire body — failed creative dropped errors[]")
+    return None
+
+
+def assert_wire_advisory(
+    wire: dict[str, Any] | None,
+    code: str,
+    *,
+    recovery: str | None = None,
+    suggestion: str | None = None,
+    transport: Transport,
+    response: Any = None,
+    wire_is_proxy: bool = False,
+    require_real_wire: bool = False,
+) -> dict[str, Any] | None:
+    """Assert the first failed creative's nested advisory on the success-path wire.
+
+    On wire transports the advisory **must** be present (dropped ``errors[]`` is
+    a buyer-facing regression) — this call is unconditionally loud regardless of
+    ``response`` (see ``first_failed_creative_advisory``'s unconditional
+    missing-wire raise; callers here already know they expect an advisory). On
+    IMPL, returns ``None`` without asserting. When an advisory is present,
+    grades ``code`` and optional ``recovery`` and ``suggestion`` — the single
+    wire oracle for BDD Then-steps and integration tests alike.
+
+    Pass ``require_real_wire=True`` to refuse CreativeSyncEnv's A2A
+    ``model_dump`` proxy (``wire_is_proxy=True`` / envelope flag) — that path
+    is not Task/Artifact framing (#1919).
+    """
+    advisory = first_failed_creative_advisory(
+        wire,
+        transport=transport,
+        response=response,
+        wire_is_proxy=wire_is_proxy,
+        require_real_wire=require_real_wire,
+    )
+    if _transport_has_no_wire(transport):
+        return advisory
+    assert advisory, "advisory missing from wire body"
+    assert advisory.get("code") == code, f"unexpected wire advisory code: {advisory.get('code')!r}"
+    if recovery is not None:
+        actual = advisory.get("recovery")
+        actual_str = _enum_value(actual)
+        assert actual_str == recovery, f"unexpected wire advisory recovery: {actual_str!r}"
+    if suggestion is not None:
+        actual_suggestion = advisory.get("suggestion")
+        assert actual_suggestion == suggestion, f"unexpected wire advisory suggestion: {actual_suggestion!r}"
+    return advisory
+
+
 class Transport(StrEnum):
     """Dispatch transports for behavioral tests."""
 

--- a/tests/harness/transport.py
+++ b/tests/harness/transport.py
@@ -298,9 +298,14 @@ class TransportResult:
         raw_response: Unprocessed transport response (httpx.Response, ToolResult, etc.).
         wire_response: Serialized success-path response body as a dict, captured
             from the real wire (REST HTTP JSON body, MCP structured_content, A2A
-            artifact DataPart). ``None`` on error and on IMPL (no wire — serialize
-            the typed ``payload`` instead). Lets success-path tests assert the
-            actual serialized shape (e.g. the v3.1 format_id federation contract).
+            artifact DataPart) for most envs. Some envs blocked on a documented
+            real-dispatch bug (e.g. ``CreativeSyncEnv``'s A2A path) instead stash
+            a re-serialized ``model_dump()`` proxy and flag
+            ``envelope["wire_response_is_proxy"] = True`` — that field is NOT the
+            real Task/Artifact framing for those envs. ``None`` on error and on
+            IMPL (no wire — serialize the typed ``payload`` instead). Lets
+            success-path tests assert the actual serialized shape (e.g. the v3.1
+            format_id federation contract).
         wire_error_envelope: Raw two-layer error envelope dict captured from
             the actual wire bytes (REST HTTP body, MCP ToolError content text,
             A2A failed-Task artifact DataPart). ``None`` on success or on the

--- a/tests/helpers/creative_test_helpers.py
+++ b/tests/helpers/creative_test_helpers.py
@@ -30,6 +30,20 @@ def make_creative_dict(creative_id: str = "c1", name: str = "Test Banner") -> di
 
 _DEFAULT_AGENT_URL = "https://creative.test.example.com"
 
+# Independent oracle for the GEMINI misconfig advisory suggestion (must match
+# production ``_GEMINI_KEY_MISSING_SUGGESTION``; kept as a test literal so a
+# silent production-string drift still fails these pins).
+_EXPECTED_GEMINI_KEY_MISSING_SUGGESTION = "Ask the seller to configure GEMINI_API_KEY in their agent settings"
+
+
+def assert_gemini_key_missing_advisory(errs: list) -> None:
+    """Pin platform ``CREATIVE_GEMINI_KEY_MISSING`` + ``terminal`` + suggestion."""
+    assert errs, "expected non-empty errors[] for GEMINI key missing advisory"
+    err = errs[0]
+    assert err.code == "CREATIVE_GEMINI_KEY_MISSING", f"unexpected code: {err.code!r}"
+    assert err.recovery == "terminal", f"unexpected recovery: {err.recovery!r}"
+    assert err.suggestion == _EXPECTED_GEMINI_KEY_MISSING_SUGGESTION, f"unexpected suggestion: {err.suggestion!r}"
+
 
 def creative_payload(**overrides: object) -> dict:
     """Build a minimal creative request dict (``creative_id``/``name``/``format_id``/``assets``).

--- a/tests/helpers/creative_test_helpers.py
+++ b/tests/helpers/creative_test_helpers.py
@@ -37,10 +37,10 @@ _EXPECTED_GEMINI_KEY_MISSING_SUGGESTION = "Ask the seller to configure GEMINI_AP
 
 
 def assert_gemini_key_missing_advisory(errs: list) -> None:
-    """Pin platform ``CREATIVE_GEMINI_KEY_MISSING`` + ``terminal`` + suggestion."""
+    """Pin platform ``X_PREBID_CREATIVE_GEMINI_KEY_MISSING`` + ``terminal`` + suggestion."""
     assert errs, "expected non-empty errors[] for GEMINI key missing advisory"
     err = errs[0]
-    assert err.code == "CREATIVE_GEMINI_KEY_MISSING", f"unexpected code: {err.code!r}"
+    assert err.code == "X_PREBID_CREATIVE_GEMINI_KEY_MISSING", f"unexpected code: {err.code!r}"
     assert err.recovery == "terminal", f"unexpected recovery: {err.recovery!r}"
     assert err.suggestion == _EXPECTED_GEMINI_KEY_MISSING_SUGGESTION, f"unexpected suggestion: {err.suggestion!r}"
 

--- a/tests/helpers/creative_test_helpers.py
+++ b/tests/helpers/creative_test_helpers.py
@@ -33,7 +33,7 @@ _DEFAULT_AGENT_URL = "https://creative.test.example.com"
 # Independent oracle for the GEMINI misconfig advisory suggestion (must match
 # production ``_GEMINI_KEY_MISSING_SUGGESTION``; kept as a test literal so a
 # silent production-string drift still fails these pins).
-_EXPECTED_GEMINI_KEY_MISSING_SUGGESTION = "Ask the seller to configure GEMINI_API_KEY in their agent settings"
+_EXPECTED_GEMINI_KEY_MISSING_SUGGESTION = "Ask the seller to configure a Gemini API key for this account"
 
 
 def assert_gemini_key_missing_advisory(errs: list) -> None:

--- a/tests/integration/test_creative_advisory_recovery_pair.py
+++ b/tests/integration/test_creative_advisory_recovery_pair.py
@@ -213,15 +213,15 @@ class TestConfigurationErrorAdvisoryCarriesThePinnedPair:
 
     @pytest.mark.parametrize("transport", _ALL_TRANSPORTS, ids=lambda t: t.value)
     def test_update_path_missing_generative_key(self, integration_db, transport):
-        """Production's OWN AdCPConfigurationError raise, on the update-path arm.
+        """Missing account GEMINI key on the update-path generative arm.
 
         No injection: a generative format with no GEMINI_API_KEY configured is
-        the exact condition ``_update_existing_creative`` raises
-        ``AdCPConfigurationError`` for (``_processing.py`` :223-228), and it is
-        the deployment misconfiguration the ``except`` arm's comment names. It
-        must classify identically to the create-path arm (:434-442) — the same
-        fault on the same tool cannot carry two different pairs depending on
-        whether the creative already existed.
+        the exact condition ``_check_gemini_key_or_advisory`` grades. Per #1831
+        this seller-specific misconfiguration uses
+        ``X_PREBID_CREATIVE_GEMINI_KEY_MISSING`` / ``terminal`` (AdCP 3.1.1
+        seller-specific code shape), not ``CONFIGURATION_ERROR`` (which the
+        enum pairs with flipped transport failure markers unsuitable for a
+        success-path per-creative advisory).
         """
         from tests.factories import CreativeFactory
 
@@ -257,7 +257,7 @@ class TestConfigurationErrorAdvisoryCarriesThePinnedPair:
 
             _assert_pair(
                 _advisory(result, creative_id),
-                code="CONFIGURATION_ERROR",
+                code="X_PREBID_CREATIVE_GEMINI_KEY_MISSING",
                 recovery="terminal",
                 message_substr="GEMINI_API_KEY not configured",
             )

--- a/tests/integration/test_creative_sync_data_preservation.py
+++ b/tests/integration/test_creative_sync_data_preservation.py
@@ -121,8 +121,23 @@ def _setup_generative_registry(env: _DataPreservationEnv, format_id: str, output
     mock_registry.get_format = AsyncMock(return_value=mock_format)
     env.mock["registry"].return_value = mock_registry
 
-    # Enable Gemini API key for generative tests
+    # Account-scoped sole source for creative-sync GEMINI advisories — config
+    # mock alone no longer rescues a keyless tenant dict.
     env.mock["config"].return_value = MagicMock(gemini_api_key="test-gemini-key")
+    env._tenant_overrides["gemini_api_key"] = "test-gemini-key"
+    env._identity_cache.clear()
+    tenant_dict = getattr(env.identity, "tenant", None)
+    if isinstance(tenant_dict, dict):
+        tenant_dict["gemini_api_key"] = "test-gemini-key"
+    if env.use_real_db and env._session is not None:
+        from sqlalchemy import select
+
+        from src.core.database.models import Tenant
+
+        row = env._session.scalars(select(Tenant).filter_by(tenant_id=env._tenant_id)).first()
+        if row is not None:
+            row.gemini_api_key = "test-gemini-key"
+            env._commit_factory_data()
 
     return mock_registry
 

--- a/tests/integration/test_creative_sync_processing.py
+++ b/tests/integration/test_creative_sync_processing.py
@@ -354,7 +354,7 @@ class TestGenerativeUpdateGeminiKeyMissing:
             )
 
             # Remove gemini key for update
-            env.mock["config"].return_value.gemini_api_key = None
+            env.clear_gemini_api_key()
 
             result = env.call_impl(
                 creatives=[

--- a/tests/integration/test_creative_sync_processing.py
+++ b/tests/integration/test_creative_sync_processing.py
@@ -364,7 +364,12 @@ class TestGenerativeUpdateGeminiKeyMissing:
 
             creative_result = result.creatives[0]
             assert creative_result.action == "failed"
-            assert any("GEMINI_API_KEY" in e for e in _error_messages(creative_result.errors))
+            errs = creative_result.errors or []
+            assert any("GEMINI_API_KEY" in e for e in _error_messages(errs))
+            assert errs[0].code == "CREATIVE_GEMINI_KEY_MISSING"
+            assert errs[0].recovery == "terminal"
+            assert errs[0].suggestion is not None
+            assert "seller" in errs[0].suggestion.lower()
 
 
 # ── Approval Mode UPDATE Tests (covers lines 97-139) ──────────────────────

--- a/tests/integration/test_creative_sync_processing.py
+++ b/tests/integration/test_creative_sync_processing.py
@@ -22,7 +22,11 @@ from tests.factories.creative_asset import (
     text_spec,
 )
 from tests.harness import CreativeSyncEnv
-from tests.helpers.creative_test_helpers import assert_stored_creative_assets, creative_payload
+from tests.helpers.creative_test_helpers import (
+    assert_gemini_key_missing_advisory,
+    assert_stored_creative_assets,
+    creative_payload,
+)
 
 DEFAULT_AGENT_URL = "https://creative.test.example.com"
 
@@ -366,10 +370,7 @@ class TestGenerativeUpdateGeminiKeyMissing:
             assert creative_result.action == "failed"
             errs = creative_result.errors or []
             assert any("GEMINI_API_KEY" in e for e in _error_messages(errs))
-            assert errs[0].code == "CREATIVE_GEMINI_KEY_MISSING"
-            assert errs[0].recovery == "terminal"
-            assert errs[0].suggestion is not None
-            assert "seller" in errs[0].suggestion.lower()
+            assert_gemini_key_missing_advisory(errs)
 
 
 # ── Approval Mode UPDATE Tests (covers lines 97-139) ──────────────────────

--- a/tests/integration/test_creative_sync_transport.py
+++ b/tests/integration/test_creative_sync_transport.py
@@ -26,7 +26,11 @@ from src.core.database.models import Creative as DBCreative
 from src.core.exceptions import AdCPAuthenticationError, AdCPNotFoundError
 from tests.factories.creative_asset import build_assets, image_spec, text_spec
 from tests.harness import CreativeSyncEnv, Transport, assert_envelope, make_identity
-from tests.helpers.creative_test_helpers import assert_stored_creative_assets, creative_payload
+from tests.helpers.creative_test_helpers import (
+    assert_gemini_key_missing_advisory,
+    assert_stored_creative_assets,
+    creative_payload,
+)
 
 
 def _error_messages(errors: list | None) -> list[str]:
@@ -1166,10 +1170,15 @@ class TestGeminiKeyMissing:
         assert creative_result.action == "failed"
         errs = creative_result.errors or []
         assert any("gemini" in e.lower() for e in _error_messages(errs))
-        assert errs[0].code == "CREATIVE_GEMINI_KEY_MISSING"
-        assert errs[0].recovery == "terminal"
-        assert errs[0].suggestion is not None
-        assert "seller" in errs[0].suggestion.lower()
+        assert_gemini_key_missing_advisory(errs)
+        # When the transport stashes success-path wire, grade nested advisory fields.
+        wire = result.wire_response
+        if isinstance(wire, dict):
+            wire_creatives = wire.get("creatives") or []
+            wire_errs = (wire_creatives[0].get("errors") or []) if wire_creatives else []
+            if wire_errs:
+                assert wire_errs[0].get("code") == "CREATIVE_GEMINI_KEY_MISSING"
+                assert wire_errs[0].get("recovery") == "terminal"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_creative_sync_transport.py
+++ b/tests/integration/test_creative_sync_transport.py
@@ -1174,14 +1174,31 @@ class TestGeminiKeyMissing:
         assert any("gemini" in e.lower() for e in _error_messages(errs))
         assert_gemini_key_missing_advisory(errs)
         # Wire transports must expose the nested advisory on the success-path body.
-        assert_wire_advisory(
-            result.wire_response,
-            "X_PREBID_CREATIVE_GEMINI_KEY_MISSING",
-            recovery="terminal",
-            suggestion=_EXPECTED_GEMINI_KEY_MISSING_SUGGESTION,
-            transport=transport,
-            response=result.payload,
-        )
+        # CreativeSyncEnv A2A stashes a model_dump proxy (#1919) — refuse that as
+        # real-wire evidence; typed advisory above already graded the payload.
+        wire_is_proxy = bool(result.envelope.get("wire_response_is_proxy"))
+        if transport is not Transport.IMPL and not wire_is_proxy:
+            assert_wire_advisory(
+                result.wire_response,
+                "X_PREBID_CREATIVE_GEMINI_KEY_MISSING",
+                recovery="terminal",
+                suggestion=_EXPECTED_GEMINI_KEY_MISSING_SUGGESTION,
+                transport=transport,
+                response=result.payload,
+                require_real_wire=True,
+            )
+        elif wire_is_proxy:
+            assert transport is Transport.A2A
+            with pytest.raises(AssertionError, match="model_dump proxy"):
+                assert_wire_advisory(
+                    result.wire_response,
+                    "X_PREBID_CREATIVE_GEMINI_KEY_MISSING",
+                    recovery="terminal",
+                    transport=transport,
+                    response=result.payload,
+                    wire_is_proxy=True,
+                    require_real_wire=True,
+                )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_creative_sync_transport.py
+++ b/tests/integration/test_creative_sync_transport.py
@@ -1164,7 +1164,12 @@ class TestGeminiKeyMissing:
         assert_envelope(result, transport)
         creative_result = result.payload.creatives[0]
         assert creative_result.action == "failed"
-        assert any("gemini" in e.lower() for e in _error_messages(creative_result.errors))
+        errs = creative_result.errors or []
+        assert any("gemini" in e.lower() for e in _error_messages(errs))
+        assert errs[0].code == "CREATIVE_GEMINI_KEY_MISSING"
+        assert errs[0].recovery == "terminal"
+        assert errs[0].suggestion is not None
+        assert "seller" in errs[0].suggestion.lower()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_creative_sync_transport.py
+++ b/tests/integration/test_creative_sync_transport.py
@@ -28,6 +28,7 @@ from tests.factories.creative_asset import build_assets, image_spec, text_spec
 from tests.harness import CreativeSyncEnv, Transport, assert_envelope, make_identity
 from tests.harness.transport import assert_wire_advisory
 from tests.helpers.creative_test_helpers import (
+    _EXPECTED_GEMINI_KEY_MISSING_SUGGESTION,
     assert_gemini_key_missing_advisory,
     assert_stored_creative_assets,
     creative_payload,
@@ -1175,9 +1176,11 @@ class TestGeminiKeyMissing:
         # Wire transports must expose the nested advisory on the success-path body.
         assert_wire_advisory(
             result.wire_response,
-            "CREATIVE_GEMINI_KEY_MISSING",
+            "X_PREBID_CREATIVE_GEMINI_KEY_MISSING",
             recovery="terminal",
+            suggestion=_EXPECTED_GEMINI_KEY_MISSING_SUGGESTION,
             transport=transport,
+            response=result.payload,
         )
 
 

--- a/tests/integration/test_creative_sync_transport.py
+++ b/tests/integration/test_creative_sync_transport.py
@@ -26,6 +26,7 @@ from src.core.database.models import Creative as DBCreative
 from src.core.exceptions import AdCPAuthenticationError, AdCPNotFoundError
 from tests.factories.creative_asset import build_assets, image_spec, text_spec
 from tests.harness import CreativeSyncEnv, Transport, assert_envelope, make_identity
+from tests.harness.transport import assert_wire_advisory
 from tests.helpers.creative_test_helpers import (
     assert_gemini_key_missing_advisory,
     assert_stored_creative_assets,
@@ -1149,7 +1150,7 @@ class TestGeminiKeyMissing:
             fmt = env.setup_generative_build(gemini_api_key="")
 
             # Override: remove the gemini key after setup
-            env.mock["config"].return_value.gemini_api_key = None
+            env.clear_gemini_api_key()
 
             result = env.call_via(
                 transport,
@@ -1171,14 +1172,13 @@ class TestGeminiKeyMissing:
         errs = creative_result.errors or []
         assert any("gemini" in e.lower() for e in _error_messages(errs))
         assert_gemini_key_missing_advisory(errs)
-        # When the transport stashes success-path wire, grade nested advisory fields.
-        wire = result.wire_response
-        if isinstance(wire, dict):
-            wire_creatives = wire.get("creatives") or []
-            wire_errs = (wire_creatives[0].get("errors") or []) if wire_creatives else []
-            if wire_errs:
-                assert wire_errs[0].get("code") == "CREATIVE_GEMINI_KEY_MISSING"
-                assert wire_errs[0].get("recovery") == "terminal"
+        # Wire transports must expose the nested advisory on the success-path body.
+        assert_wire_advisory(
+            result.wire_response,
+            "CREATIVE_GEMINI_KEY_MISSING",
+            recovery="terminal",
+            transport=transport,
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_generative_creatives.py
+++ b/tests/integration/test_generative_creatives.py
@@ -158,8 +158,13 @@ class TestGenerativeCreatives:
         assert isinstance(result, SyncCreativesResponse)
         assert len(result.creatives) == 1
         assert result.creatives[0].action == "failed"
-        assert result.creatives[0].errors
-        assert any("GEMINI_API_KEY" in str(err) for err in result.creatives[0].errors)
+        errs = result.creatives[0].errors
+        assert errs
+        assert any("GEMINI_API_KEY" in str(err) for err in errs)
+        assert errs[0].code == "CREATIVE_GEMINI_KEY_MISSING"
+        assert errs[0].recovery == "terminal"
+        assert errs[0].suggestion is not None
+        assert "seller" in errs[0].suggestion.lower()
 
     def test_message_extraction_from_assets(self, integration_db):
         """Test that message is correctly extracted from various asset roles."""

--- a/tests/integration/test_generative_creatives.py
+++ b/tests/integration/test_generative_creatives.py
@@ -18,7 +18,7 @@ from src.core.database.models import Creative as DBCreative
 from src.core.schemas import SyncCreativesResponse
 from tests.factories.creative_asset import build_assets, image_spec, text_spec
 from tests.harness import CreativeSyncEnv
-from tests.helpers.creative_test_helpers import creative_payload
+from tests.helpers.creative_test_helpers import assert_gemini_key_missing_advisory, creative_payload
 
 DEFAULT_AGENT_URL = "https://creative.test.example.com"
 
@@ -161,10 +161,7 @@ class TestGenerativeCreatives:
         errs = result.creatives[0].errors
         assert errs
         assert any("GEMINI_API_KEY" in str(err) for err in errs)
-        assert errs[0].code == "CREATIVE_GEMINI_KEY_MISSING"
-        assert errs[0].recovery == "terminal"
-        assert errs[0].suggestion is not None
-        assert "seller" in errs[0].suggestion.lower()
+        assert_gemini_key_missing_advisory(errs)
 
     def test_message_extraction_from_assets(self, integration_db):
         """Test that message is correctly extracted from various asset roles."""

--- a/tests/integration/test_generative_creatives.py
+++ b/tests/integration/test_generative_creatives.py
@@ -143,7 +143,7 @@ class TestGenerativeCreatives:
                 gemini_api_key=None,  # No API key
             )
             # Override to remove gemini key (setup_generative_build sets it)
-            env.mock["config"].return_value.gemini_api_key = None
+            env.clear_gemini_api_key()
 
             result = env.call_impl(
                 creatives=[

--- a/tests/unit/test_architecture_bdd_no_inline_xfail.py
+++ b/tests/unit/test_architecture_bdd_no_inline_xfail.py
@@ -145,7 +145,6 @@ _ALLOWLIST: set[XfailSite] = {
     ("domain/uc004_delivery.py", "then_geo_system", 1),
     ("domain/uc004_delivery.py", "then_packages_include_breakdown", 1),
     ("domain/uc006_sync_creatives.py", "_assert_generative_build", 1),
-    ("domain/uc006_sync_creatives.py", "_assert_per_creative_failure", 3),
     ("domain/uc006_sync_creatives.py", "_assert_standard_processing", 1),
     ("domain/uc006_sync_creatives.py", "_xfail_if_e2e", 1),
     ("domain/uc006_sync_creatives.py", "given_principal_no_associated_tenant", 1),

--- a/tests/unit/test_architecture_e2e_rest_escape_hatches.py
+++ b/tests/unit/test_architecture_e2e_rest_escape_hatches.py
@@ -446,6 +446,13 @@ EXPECTED_UNSUPPORTED_DECLARATIONS: frozenset[tuple[str, str, str]] = frozenset(
             "CI / e2e stack always injects GEMINI_API_KEY into the live server process; "
             "clearing the in-process get_config mock cannot realize a missing-key seller",
         ),
+        (
+            "tests/harness/creative_sync.py",
+            "setup_generative_build",
+            "generative build grading injects an in-process format mock and "
+            "registry.build_creative AsyncMock; the live e2e creative-agent "
+            "catalog cannot be stubbed mid-suite, and Then steps assert the mock",
+        ),
     }
 )
 

--- a/tests/unit/test_architecture_e2e_rest_escape_hatches.py
+++ b/tests/unit/test_architecture_e2e_rest_escape_hatches.py
@@ -442,16 +442,10 @@ EXPECTED_UNSUPPORTED_DECLARATIONS: frozenset[tuple[str, str, str]] = frozenset(
         ("tests/harness/creative_formats.py", "_validate_registry_formats", "<dynamic>"),
         (
             "tests/harness/creative_sync.py",
-            "clear_gemini_api_key",
-            "CI / e2e stack always injects GEMINI_API_KEY into the live server process; "
-            "clearing the in-process get_config mock cannot realize a missing-key seller (#1887)",
-        ),
-        (
-            "tests/harness/creative_sync.py",
             "setup_generative_build",
             "generative build grading injects an in-process format mock and "
             "registry.build_creative AsyncMock; the live e2e creative-agent "
-            "catalog cannot be stubbed mid-suite, and Then steps assert the mock (#1887)",
+            "catalog cannot be stubbed mid-suite, and Then steps assert the mock (#1964)",
         ),
     }
 )

--- a/tests/unit/test_architecture_e2e_rest_escape_hatches.py
+++ b/tests/unit/test_architecture_e2e_rest_escape_hatches.py
@@ -444,14 +444,14 @@ EXPECTED_UNSUPPORTED_DECLARATIONS: frozenset[tuple[str, str, str]] = frozenset(
             "tests/harness/creative_sync.py",
             "clear_gemini_api_key",
             "CI / e2e stack always injects GEMINI_API_KEY into the live server process; "
-            "clearing the in-process get_config mock cannot realize a missing-key seller",
+            "clearing the in-process get_config mock cannot realize a missing-key seller (#1887)",
         ),
         (
             "tests/harness/creative_sync.py",
             "setup_generative_build",
             "generative build grading injects an in-process format mock and "
             "registry.build_creative AsyncMock; the live e2e creative-agent "
-            "catalog cannot be stubbed mid-suite, and Then steps assert the mock",
+            "catalog cannot be stubbed mid-suite, and Then steps assert the mock (#1887)",
         ),
     }
 )

--- a/tests/unit/test_architecture_e2e_rest_escape_hatches.py
+++ b/tests/unit/test_architecture_e2e_rest_escape_hatches.py
@@ -440,6 +440,12 @@ EXPECTED_UNSUPPORTED_DECLARATIONS: frozenset[tuple[str, str, str]] = frozenset(
             "live stack always serves the agent catalog; an empty catalog cannot be realized over e2e",
         ),
         ("tests/harness/creative_formats.py", "_validate_registry_formats", "<dynamic>"),
+        (
+            "tests/harness/creative_sync.py",
+            "clear_gemini_api_key",
+            "CI / e2e stack always injects GEMINI_API_KEY into the live server process; "
+            "clearing the in-process get_config mock cannot realize a missing-key seller",
+        ),
     }
 )
 

--- a/tests/unit/test_architecture_error_code_compliance.py
+++ b/tests/unit/test_architecture_error_code_compliance.py
@@ -27,9 +27,16 @@ _SPEC_CODES = {
     "BILLING_NOT_SUPPORTED",  # BR-UC-011 BR-RULE-059: unsupported billing model
 }
 
+# Platform-specific codes permitted by pinned core/error.json ("Sellers MAY use
+# codes not in the standard vocabulary … agents MUST handle unknown codes
+# gracefully by falling back to the recovery classification").
+_PLATFORM_SPECIFIC_CODES = {
+    "CREATIVE_GEMINI_KEY_MISSING",  # sync_creatives GEMINI misconfig advisory (#1831)
+}
+
 # All acceptable codes: wire-standard (SDK + spec supplement) + justified
-# internal + spec-required literals
-_ALLOWED_CODES = set(WIRE_STANDARD_CODES) | INTERNAL_CODES | _SPEC_CODES
+# internal + spec-required literals + platform-specific advisories
+_ALLOWED_CODES = set(WIRE_STANDARD_CODES) | INTERNAL_CODES | _SPEC_CODES | _PLATFORM_SPECIFIC_CODES
 
 # Anchor scan paths on the test file's location so they resolve correctly
 # regardless of pytest's working directory (CI runs from the repo root;

--- a/tests/unit/test_architecture_error_code_compliance.py
+++ b/tests/unit/test_architecture_error_code_compliance.py
@@ -1,9 +1,9 @@
-"""Guard: all wire error codes must be in WIRE_STANDARD_CODES.
+"""Guard: all wire error codes must be in ``_ALLOWED_CODES``.
 
 AST-scans Error(code=...) construction sites in src/core/tools/ and
-src/adapters/ to verify every string-literal error code is either in
-WIRE_STANDARD_CODES (SDK STANDARD_ERROR_CODES + the pinned-spec supplement)
-or in the justified INTERNAL_CODES set.
+src/adapters/ to verify every string-literal error code is in the union of
+WIRE_STANDARD_CODES (SDK STANDARD_ERROR_CODES + pinned-spec supplement),
+INTERNAL_CODES, ``_SPEC_CODES``, and ``_PLATFORM_SPECIFIC_CODES``.
 
 Also verifies that AdCPError subclass error_code class attributes are
 standard or internal (complementing test_error_code_mapping.py).
@@ -31,7 +31,7 @@ _SPEC_CODES = {
 # codes not in the standard vocabulary … agents MUST handle unknown codes
 # gracefully by falling back to the recovery classification").
 _PLATFORM_SPECIFIC_CODES = {
-    "CREATIVE_GEMINI_KEY_MISSING",  # sync_creatives GEMINI misconfig advisory (#1831)
+    "CREATIVE_GEMINI_KEY_MISSING",  # sync_creatives GEMINI misconfig advisory (platform MAY)
 }
 
 # All acceptable codes: wire-standard (SDK + spec supplement) + justified
@@ -105,18 +105,19 @@ def _collect_error_code_literals() -> list[tuple[str, int, str]]:
 
 
 class TestErrorCodeCompliance:
-    """Every Error(code=...) literal must be in STANDARD_ERROR_CODES or INTERNAL_CODES."""
+    """Every Error(code=...) literal must be in ``_ALLOWED_CODES``."""
 
     @pytest.mark.arch_guard
     def test_no_nonstandard_error_codes_in_tools_and_adapters(self):
-        """AST-scan Error(code=...) sites for non-standard codes."""
+        """AST-scan Error(code=...) sites for codes outside ``_ALLOWED_CODES``."""
         violations = _collect_error_code_literals()
         if violations:
             msg_lines = [f"  {f}:{line}: code={code!r}" for f, line, code in violations]
             raise AssertionError(
                 f"{len(violations)} Error(code=...) sites use non-standard codes:\n"
                 + "\n".join(msg_lines)
-                + "\n\nEach code must be in STANDARD_ERROR_CODES or INTERNAL_CODES."
+                + "\n\nEach code must be in _ALLOWED_CODES "
+                "(WIRE_STANDARD_CODES ∪ INTERNAL_CODES ∪ _SPEC_CODES ∪ _PLATFORM_SPECIFIC_CODES)."
             )
 
     @pytest.mark.arch_guard

--- a/tests/unit/test_architecture_error_code_compliance.py
+++ b/tests/unit/test_architecture_error_code_compliance.py
@@ -37,7 +37,8 @@ _SPEC_CODES = {
 # CREATIVE_* namespace (the exact bug this guard exists to catch, GH #1835).
 # A predicate rejects that by construction: only a string matching the pinned
 # shape can ever pass, regardless of what gets added at a call site.
-_SELLER_SPECIFIC_CODE_PATTERN = re.compile(r"^X_[A-Z][A-Z0-9]{1,19}_[A-Z][A-Z0-9_]{1,39}$")
+# fullmatch (not search+$) so a trailing newline cannot sneak past the shape.
+_SELLER_SPECIFIC_CODE_PATTERN = re.compile(r"X_[A-Z][A-Z0-9]{1,19}_[A-Z][A-Z0-9_]{1,39}")
 
 
 def _is_seller_specific_code(code: str) -> bool:
@@ -50,7 +51,7 @@ def _is_seller_specific_code(code: str) -> bool:
     construction or fails this guard — it cannot silently fork the vocabulary
     by landing a bare string in a membership set.
     """
-    return bool(_SELLER_SPECIFIC_CODE_PATTERN.match(code))
+    return bool(_SELLER_SPECIFIC_CODE_PATTERN.fullmatch(code))
 
 
 # All acceptable codes: wire-standard (SDK + spec supplement) + justified
@@ -75,9 +76,68 @@ _SCAN_DIRS = [
     _REPO_ROOT / "src/adapters",
 ]
 
+# Per-creative advisory factories that take ``code=`` literals (not Error(...)).
+# Without these, ``_failed_sync_result(code="CREATIVE_GEMINI_KEY_MISSING")`` is
+# invisible to the guard even though that is the production call site (#1835).
+_ADVISORY_FACTORIES = frozenset({"_failed_sync_result"})
+
 
 from tests.unit._architecture_helpers import collect_error_aliases as _collect_error_aliases  # noqa: E402
 from tests.unit._architecture_helpers import iter_call_expressions  # noqa: E402
+
+
+def _error_aliases_for_tree(tree: ast.AST) -> set[str]:
+    """Error aliases including ``from adcp.types import Error as …``.
+
+    Shared ``collect_error_aliases`` requires ``"error"`` in the import module
+    path; ``adcp.types`` re-exports ``Error`` without that token, so the alias
+    ``AdCPErrorDetail`` would otherwise never register.
+    """
+    aliases = set(_collect_error_aliases(tree))
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ImportFrom):
+            continue
+        module = node.module or ""
+        if module != "adcp.types" and not module.startswith("adcp.types."):
+            continue
+        for alias in node.names:
+            if alias.name == "Error":
+                aliases.add(alias.asname or alias.name)
+    return aliases
+
+
+def _collect_error_code_literals_from_tree(tree: ast.AST, *, filename: str) -> list[tuple[str, int, str]]:
+    """Return (file, line, code) triples for non-compliant ``code=`` literals."""
+    violations: list[tuple[str, int, str]] = []
+    error_aliases = _error_aliases_for_tree(tree)
+
+    for node in iter_call_expressions(tree):
+        func = node.func
+        matched = False
+        if isinstance(func, ast.Name) and (func.id in error_aliases or func.id in _ADVISORY_FACTORIES):
+            matched = True
+        elif isinstance(func, ast.Attribute) and func.attr == "Error":
+            matched = True
+        if not matched:
+            continue
+
+        code_value = None
+        for kw in node.keywords:
+            if kw.arg == "code":
+                if isinstance(kw.value, ast.Constant) and isinstance(kw.value.value, str):
+                    code_value = kw.value.value
+                else:
+                    logger.warning(
+                        "%s:%d: Error(code=<non-literal>) — cannot validate statically",
+                        filename,
+                        node.lineno,
+                    )
+                break
+
+        if code_value is not None and not _code_is_compliant(code_value):
+            violations.append((filename, node.lineno, code_value))
+
+    return violations
 
 
 def _collect_error_code_literals() -> list[tuple[str, int, str]]:
@@ -85,6 +145,7 @@ def _collect_error_code_literals() -> list[tuple[str, int, str]]:
 
     Tracks `from ... import Error as <alias>` so call sites that use the
     aliased name (e.g. ``AdCPErrorDetail(code=...)``) are also validated.
+    Also matches ``_failed_sync_result(code=...)`` advisory factory sites.
     """
     violations: list[tuple[str, int, str]] = []
 
@@ -97,36 +158,7 @@ def _collect_error_code_literals() -> list[tuple[str, int, str]]:
                 tree = ast.parse(source, filename=str(py_file))
             except SyntaxError:
                 continue
-
-            error_aliases = _collect_error_aliases(tree)
-
-            for node in iter_call_expressions(tree):  # Match calls to Error(...) / <alias>(...) / adcp.types.Error(...)
-                func = node.func
-                matched = False
-                if isinstance(func, ast.Name) and func.id in error_aliases:
-                    matched = True
-                elif isinstance(func, ast.Attribute) and func.attr == "Error":
-                    matched = True
-                if not matched:
-                    continue
-
-                # Extract the code= keyword argument
-                code_value = None
-                for kw in node.keywords:
-                    if kw.arg == "code":
-                        if isinstance(kw.value, ast.Constant) and isinstance(kw.value.value, str):
-                            code_value = kw.value.value
-                        else:
-                            # Non-literal code — skip with warning
-                            logger.warning(
-                                "%s:%d: Error(code=<non-literal>) — cannot validate statically",
-                                py_file,
-                                node.lineno,
-                            )
-                        break
-
-                if code_value is not None and not _code_is_compliant(code_value):
-                    violations.append((str(py_file), node.lineno, code_value))
+            violations.extend(_collect_error_code_literals_from_tree(tree, filename=str(py_file)))
 
     return violations
 
@@ -199,3 +231,65 @@ class TestSellerSpecificCodeShape:
 
     def test_rejects_lowercase(self):
         assert not _is_seller_specific_code("x_prebid_creative_gemini_key_missing")
+
+    def test_vendor_length_boundaries(self):
+        """VENDOR is ``[A-Z][A-Z0-9]{1,19}`` → 2..20 chars after ``X_`` before code."""
+        assert _is_seller_specific_code("X_" + "A" * 2 + "_CODE")
+        assert _is_seller_specific_code("X_" + "A" * 20 + "_CODE")
+        assert not _is_seller_specific_code("X_" + "A" * 1 + "_CODE")  # vendor too short
+        assert not _is_seller_specific_code("X_" + "A" * 21 + "_CODE")  # vendor too long
+
+    def test_code_length_boundaries(self):
+        """CODE is ``[A-Z][A-Z0-9_]{1,39}`` → 2..40 chars after the vendor underscore."""
+        assert _is_seller_specific_code("X_PREBID_" + "C" * 2)
+        assert _is_seller_specific_code("X_PREBID_" + "C" * 40)
+        assert not _is_seller_specific_code("X_PREBID_" + "C" * 1)  # code too short
+        assert not _is_seller_specific_code("X_PREBID_" + "C" * 41)  # code too long
+
+    def test_rejects_trailing_newline(self):
+        """``fullmatch`` must reject a trailing newline (``$`` would accept it)."""
+        assert not _is_seller_specific_code("X_PREBID_CREATIVE_GEMINI_KEY_MISSING\n")
+
+    def test_advisory_factory_literal_is_scanned(self):
+        """``_failed_sync_result(code=…)`` literals must be visible to the guard.
+
+        Without ``_ADVISORY_FACTORIES``, reverting
+        ``_gemini_key_missing_result`` to ``CREATIVE_GEMINI_KEY_MISSING`` stays
+        green — the exact blindness Chris measured on #1835.
+        """
+        source = (
+            "def _failed_sync_result(creative_id, msg, *, recovery, code):\n"
+            "    pass\n"
+            '_failed_sync_result("c1", "boom", recovery="terminal", '
+            'code="CREATIVE_GEMINI_KEY_MISSING")\n'
+        )
+        tree = ast.parse(source)
+        violations = _collect_error_code_literals_from_tree(tree, filename="<advisory>")
+        assert any(code == "CREATIVE_GEMINI_KEY_MISSING" for _, _, code in violations), violations
+
+    def test_adcp_types_error_alias_literal_is_scanned(self):
+        """``from adcp.types import Error as AdCPErrorDetail`` sites must register."""
+        source = (
+            "from adcp.types import Error as AdCPErrorDetail\n"
+            'AdCPErrorDetail(code="TOTALLY_BOGUS_CODE", message="x", recovery="terminal")\n'
+        )
+        tree = ast.parse(source)
+        violations = _collect_error_code_literals_from_tree(tree, filename="<alias>")
+        assert any(code == "TOTALLY_BOGUS_CODE" for _, _, code in violations), violations
+
+    def test_production_gemini_advisory_site_is_visible(self):
+        """Live ``_gemini_key_missing_result`` literal must appear in the scan."""
+        processing = _REPO_ROOT / "src/core/tools/creatives/_processing.py"
+        tree = ast.parse(processing.read_text(), filename=str(processing))
+        # Collect ALL code literals at advisory/Error sites (compliant + not)
+        error_aliases = _error_aliases_for_tree(tree)
+        seen: list[str] = []
+        for node in iter_call_expressions(tree):
+            func = node.func
+            matched = isinstance(func, ast.Name) and (func.id in error_aliases or func.id in _ADVISORY_FACTORIES)
+            if not matched:
+                continue
+            for kw in node.keywords:
+                if kw.arg == "code" and isinstance(kw.value, ast.Constant) and isinstance(kw.value.value, str):
+                    seen.append(kw.value.value)
+        assert "X_PREBID_CREATIVE_GEMINI_KEY_MISSING" in seen, seen

--- a/tests/unit/test_architecture_error_code_compliance.py
+++ b/tests/unit/test_architecture_error_code_compliance.py
@@ -1,9 +1,10 @@
-"""Guard: all wire error codes must be in ``_ALLOWED_CODES``.
+"""Guard: all wire error codes must be in ``_ALLOWED_CODES`` or seller-specific shape.
 
 AST-scans Error(code=...) construction sites in src/core/tools/ and
 src/adapters/ to verify every string-literal error code is in the union of
 WIRE_STANDARD_CODES (SDK STANDARD_ERROR_CODES + pinned-spec supplement),
-INTERNAL_CODES, ``_SPEC_CODES``, and ``_PLATFORM_SPECIFIC_CODES``.
+INTERNAL_CODES, ``_SPEC_CODES``, or matches the seller-specific error code
+shape (``_is_seller_specific_code``).
 
 Also verifies that AdCPError subclass error_code class attributes are
 standard or internal (complementing test_error_code_mapping.py).
@@ -13,6 +14,7 @@ Ref: GH #1248
 
 import ast
 import logging
+import re
 from pathlib import Path
 
 import pytest
@@ -27,16 +29,41 @@ _SPEC_CODES = {
     "BILLING_NOT_SUPPORTED",  # BR-UC-011 BR-RULE-059: unsupported billing model
 }
 
-# Platform-specific codes permitted by pinned core/error.json ("Sellers MAY use
-# codes not in the standard vocabulary … agents MUST handle unknown codes
-# gracefully by falling back to the recovery classification").
-_PLATFORM_SPECIFIC_CODES = {
-    "CREATIVE_GEMINI_KEY_MISSING",  # sync_creatives GEMINI misconfig advisory (platform MAY)
-}
+# AdCP 3.1.1 transport-errors.mdx § Seller-Specific Error Codes (MUST):
+# non-standard codes MUST match X_{VENDOR}_{CODE}, VENDOR ~ [A-Z][A-Z0-9]{1,19},
+# CODE ~ [A-Z][A-Z0-9_]{1,39}. A bare membership set (the prior design) merely
+# allowlists a value instead of enforcing this shape, so it stays green for any
+# string added to it — including one that collides with the standard
+# CREATIVE_* namespace (the exact bug this guard exists to catch, GH #1835).
+# A predicate rejects that by construction: only a string matching the pinned
+# shape can ever pass, regardless of what gets added at a call site.
+_SELLER_SPECIFIC_CODE_PATTERN = re.compile(r"^X_[A-Z][A-Z0-9]{1,19}_[A-Z][A-Z0-9_]{1,39}$")
+
+
+def _is_seller_specific_code(code: str) -> bool:
+    """True when *code* matches the AdCP seller-specific error code shape.
+
+    transport-errors.mdx § Seller-Specific Error Codes (AdCP 3.1.1): sellers
+    MAY emit codes outside the standard vocabulary, but any such code MUST
+    match ``X_{VENDOR}_{CODE}``. Enforcing the shape (rather than allowlisting
+    specific values) means a future platform code either conforms by
+    construction or fails this guard — it cannot silently fork the vocabulary
+    by landing a bare string in a membership set.
+    """
+    return bool(_SELLER_SPECIFIC_CODE_PATTERN.match(code))
+
 
 # All acceptable codes: wire-standard (SDK + spec supplement) + justified
-# internal + spec-required literals + platform-specific advisories
-_ALLOWED_CODES = set(WIRE_STANDARD_CODES) | INTERNAL_CODES | _SPEC_CODES | _PLATFORM_SPECIFIC_CODES
+# internal + spec-required literals. Seller-specific (X_{VENDOR}_{CODE})
+# codes are validated separately via _is_seller_specific_code, not by
+# membership, so _ALLOWED_CODES stays a closed, auditable set.
+_ALLOWED_CODES = set(WIRE_STANDARD_CODES) | INTERNAL_CODES | _SPEC_CODES
+
+
+def _code_is_compliant(code: str) -> bool:
+    """True when *code* is wire-standard/internal/spec, or seller-specific-shaped."""
+    return code in _ALLOWED_CODES or _is_seller_specific_code(code)
+
 
 # Anchor scan paths on the test file's location so they resolve correctly
 # regardless of pytest's working directory (CI runs from the repo root;
@@ -98,7 +125,7 @@ def _collect_error_code_literals() -> list[tuple[str, int, str]]:
                             )
                         break
 
-                if code_value is not None and code_value not in _ALLOWED_CODES:
+                if code_value is not None and not _code_is_compliant(code_value):
                     violations.append((str(py_file), node.lineno, code_value))
 
     return violations
@@ -117,7 +144,9 @@ class TestErrorCodeCompliance:
                 f"{len(violations)} Error(code=...) sites use non-standard codes:\n"
                 + "\n".join(msg_lines)
                 + "\n\nEach code must be in _ALLOWED_CODES "
-                "(WIRE_STANDARD_CODES ∪ INTERNAL_CODES ∪ _SPEC_CODES ∪ _PLATFORM_SPECIFIC_CODES)."
+                "(WIRE_STANDARD_CODES ∪ INTERNAL_CODES ∪ _SPEC_CODES) or match the "
+                "seller-specific shape X_{VENDOR}_{CODE} (transport-errors.mdx § "
+                "Seller-Specific Error Codes, AdCP 3.1.1)."
             )
 
     @pytest.mark.arch_guard
@@ -136,10 +165,37 @@ class TestErrorCodeCompliance:
             cls = queue.pop()
             for sub in cls.__subclasses__():
                 code = sub._default_error_code
-                if code not in _ALLOWED_CODES:
+                if not _code_is_compliant(code):
                     violations.append(f"{sub.__name__}._default_error_code = {code!r}")
                 queue.append(sub)
 
         assert not violations, "AdCPError subclasses with non-compliant codes:\n" + "\n".join(
             f"  {v}" for v in violations
         )
+
+
+class TestSellerSpecificCodeShape:
+    """The seller-specific predicate enforces a SHAPE, not a membership list.
+
+    Proves the exact bug the prior ``_PLATFORM_SPECIFIC_CODES`` bare-set design
+    could not catch: an arbitrary made-up string, or a value inside the
+    standard ``CREATIVE_*`` namespace, must be rejected — only the pinned
+    ``X_{VENDOR}_{CODE}`` shape passes.
+    """
+
+    def test_rejects_arbitrary_made_up_code(self):
+        """A membership set would pass this if simply added to it; the shape predicate cannot."""
+        assert not _is_seller_specific_code("TOTALLY_MADE_UP_CODE")
+
+    def test_rejects_standard_namespace_collision(self):
+        """The original bug: a platform code shaped like the standard CREATIVE_* vocabulary."""
+        assert not _is_seller_specific_code("CREATIVE_GEMINI_KEY_MISSING")
+
+    def test_rejects_missing_vendor_prefix(self):
+        assert not _is_seller_specific_code("PREBID_CREATIVE_GEMINI_KEY_MISSING")
+
+    def test_accepts_the_renamed_production_code(self):
+        assert _is_seller_specific_code("X_PREBID_CREATIVE_GEMINI_KEY_MISSING")
+
+    def test_rejects_lowercase(self):
+        assert not _is_seller_specific_code("x_prebid_creative_gemini_key_missing")

--- a/tests/unit/test_creative.py
+++ b/tests/unit/test_creative.py
@@ -2319,7 +2319,13 @@ class TestGenerativeCreativeBuild:
             if hasattr(action_val, "value"):
                 action_val = action_val.value
             assert action_val == "failed"
-            assert any("GEMINI_API_KEY" in e.message for e in (result.errors or []))
+            errs = result.errors or []
+            assert any("GEMINI_API_KEY" in e.message for e in errs)
+            assert errs[0].code == "CREATIVE_GEMINI_KEY_MISSING"
+            assert errs[0].recovery == "terminal"
+            assert errs[0].suggestion is not None
+            assert "seller" in errs[0].suggestion.lower()
+            assert "GEMINI" in errs[0].suggestion
 
 
 # ============================================================================

--- a/tests/unit/test_creative.py
+++ b/tests/unit/test_creative.py
@@ -2325,6 +2325,49 @@ class TestGenerativeCreativeBuild:
             assert any("GEMINI_API_KEY" in e.message for e in errs)
             assert_gemini_key_missing_advisory(errs)
 
+    @pytest.mark.parametrize(
+        ("tenant_key", "global_key", "expect_advisory"),
+        [
+            ("tenant-key", None, False),
+            (None, "global-key", False),
+            (None, None, True),
+        ],
+        ids=["tenant_only", "global_only", "neither"],
+    )
+    def test_gemini_key_prefers_tenant_then_global(self, tenant_key, global_key, expect_advisory):
+        """Tenant key wins over global; neither → X_PREBID advisory.
+
+        Deleting ``tenant.get("gemini_api_key") or`` must redden the tenant_only
+        arm — grades advisory **code**, not action (key-present arms may still
+        fail downstream with SERVICE_UNAVAILABLE under mocks).
+        """
+        from types import SimpleNamespace
+        from unittest.mock import patch
+
+        from src.core.tools.creatives._processing import _check_gemini_key_or_advisory
+
+        tenant: dict = {"tenant_id": "t1"}
+        if tenant_key is not None:
+            tenant["gemini_api_key"] = tenant_key
+        mock_config = MagicMock()
+        mock_config.gemini_api_key = global_key
+        fmt = SimpleNamespace(id="display_gen")
+
+        with patch("src.core.config.get_config", return_value=mock_config):
+            out = _check_gemini_key_or_advisory(
+                "c1",
+                action_verb="create",
+                creative_format=fmt,
+                tenant=tenant,
+            )
+
+        if expect_advisory:
+            assert not isinstance(out, str)
+            errs = out.errors or []
+            assert errs and errs[0].code == "X_PREBID_CREATIVE_GEMINI_KEY_MISSING"
+        else:
+            assert out in {tenant_key, global_key}
+
 
 # ============================================================================
 # 10. CREATIVE WORKFLOW STEPS

--- a/tests/unit/test_creative.py
+++ b/tests/unit/test_creative.py
@@ -2326,20 +2326,21 @@ class TestGenerativeCreativeBuild:
             assert_gemini_key_missing_advisory(errs)
 
     @pytest.mark.parametrize(
-        ("tenant_key", "global_key", "expect_advisory"),
+        ("tenant_key", "global_key", "expect_advisory", "expected_key"),
         [
-            ("tenant-key", None, False),
-            (None, "global-key", False),
-            (None, None, True),
+            ("tenant-key", None, False, "tenant-key"),
+            (None, "global-key", True, None),
+            (None, None, True, None),
+            ("tenant-key", "global-key", False, "tenant-key"),
         ],
-        ids=["tenant_only", "global_only", "neither"],
+        ids=["tenant_only", "global_only_ignored", "neither", "both_tenant_wins"],
     )
-    def test_gemini_key_prefers_tenant_then_global(self, tenant_key, global_key, expect_advisory):
-        """Tenant key wins over global; neither → X_PREBID advisory.
+    def test_gemini_key_is_account_scoped(self, tenant_key, global_key, expect_advisory, expected_key):
+        """Account-scoped key is sole source; process-global alone → advisory.
 
-        Deleting ``tenant.get("gemini_api_key") or`` must redden the tenant_only
-        arm — grades advisory **code**, not action (key-present arms may still
-        fail downstream with SERVICE_UNAVAILABLE under mocks).
+        Deleting ``tenant.get("gemini_api_key")`` must redden the tenant_only /
+        both_tenant_wins arms. A non-None process-global key must not rescue a
+        keyless tenant (``global_only_ignored``).
         """
         from types import SimpleNamespace
         from unittest.mock import patch
@@ -2366,7 +2367,7 @@ class TestGenerativeCreativeBuild:
             errs = out.errors or []
             assert errs and errs[0].code == "X_PREBID_CREATIVE_GEMINI_KEY_MISSING"
         else:
-            assert out in {tenant_key, global_key}
+            assert out == expected_key
 
 
 # ============================================================================

--- a/tests/unit/test_creative.py
+++ b/tests/unit/test_creative.py
@@ -1816,6 +1816,11 @@ class TestGenerativeCreativeBuild:
         Note: mock_format_obj.format_id uses _adcp_format_id() (the library type)
         to match the CreativeAsset.format_id type from _make_creative_asset().
         FormatId equality requires same type instances.
+
+        ``gemini_key`` is returned for the caller to put on the **tenant**
+        dict — production creative-sync advisories are account-scoped and do
+        not read ``get_config().gemini_api_key``. The config mock is still
+        populated so unrelated surfaces stay consistent in the patch stack.
         """
         mock_format_obj = MagicMock()
         mock_format_obj.format_id = _adcp_format_id()
@@ -1826,6 +1831,16 @@ class TestGenerativeCreativeBuild:
         mock_config.gemini_api_key = gemini_key
 
         return mock_format_obj, mock_config
+
+    @staticmethod
+    def _tenant(*, gemini_key: str | None = "test-gemini-key") -> dict:
+        """Tenant dict for generative unit tests (account-scoped GEMINI key)."""
+        return {
+            "tenant_id": "t1",
+            "approval_mode": "auto-approve",
+            "slack_webhook_url": None,
+            "gemini_api_key": gemini_key,
+        }
 
     def test_format_with_output_format_ids_classified_as_generative(self):
         """Format with output_format_ids is classified as a generative creative.
@@ -1839,7 +1854,7 @@ class TestGenerativeCreativeBuild:
         from src.core.tools.creatives._processing import _create_new_creative
 
         mock_session = _make_mock_creative_repo()
-        tenant = {"tenant_id": "t1", "approval_mode": "auto-approve", "slack_webhook_url": None}
+        tenant = self._tenant()
         mock_format_obj, mock_config = self._setup_generative_mocks(mock_session)
 
         with (
@@ -1890,7 +1905,7 @@ class TestGenerativeCreativeBuild:
         from src.core.tools.creatives._processing import _create_new_creative
 
         mock_session = _make_mock_creative_repo()
-        tenant = {"tenant_id": "t1", "approval_mode": "auto-approve", "slack_webhook_url": None}
+        tenant = self._tenant()
         mock_format_obj, mock_config = self._setup_generative_mocks(mock_session)
 
         with (
@@ -1949,7 +1964,7 @@ class TestGenerativeCreativeBuild:
         from src.core.tools.creatives._processing import _create_new_creative
 
         mock_session = _make_mock_creative_repo()
-        tenant = {"tenant_id": "t1", "approval_mode": "auto-approve", "slack_webhook_url": None}
+        tenant = self._tenant()
         mock_format_obj, mock_config = self._setup_generative_mocks(mock_session)
 
         with (
@@ -1999,7 +2014,7 @@ class TestGenerativeCreativeBuild:
         from src.core.tools.creatives._processing import _create_new_creative
 
         mock_session = _make_mock_creative_repo()
-        tenant = {"tenant_id": "t1", "approval_mode": "auto-approve", "slack_webhook_url": None}
+        tenant = self._tenant()
         mock_format_obj, mock_config = self._setup_generative_mocks(mock_session)
 
         with (
@@ -2051,7 +2066,7 @@ class TestGenerativeCreativeBuild:
         from src.core.tools.creatives._processing import _create_new_creative
 
         mock_session = _make_mock_creative_repo()
-        tenant = {"tenant_id": "t1", "approval_mode": "auto-approve", "slack_webhook_url": None}
+        tenant = self._tenant()
         mock_format_obj, mock_config = self._setup_generative_mocks(mock_session)
 
         with (
@@ -2106,7 +2121,7 @@ class TestGenerativeCreativeBuild:
         from src.core.tools.creatives._processing import _create_new_creative
 
         mock_session = _make_mock_creative_repo()
-        tenant = {"tenant_id": "t1", "approval_mode": "auto-approve", "slack_webhook_url": None}
+        tenant = self._tenant()
         mock_format_obj, mock_config = self._setup_generative_mocks(mock_session)
 
         with (
@@ -2162,7 +2177,7 @@ class TestGenerativeCreativeBuild:
         from src.core.tools.creatives._processing import _update_existing_creative
 
         mock_session = MagicMock()
-        tenant = {"tenant_id": "t1", "approval_mode": "auto-approve", "slack_webhook_url": None}
+        tenant = self._tenant()
         mock_format_obj, mock_config = self._setup_generative_mocks(mock_session)
 
         mock_existing = MagicMock()
@@ -2223,7 +2238,7 @@ class TestGenerativeCreativeBuild:
         from src.core.tools.creatives._processing import _create_new_creative
 
         mock_session = _make_mock_creative_repo()
-        tenant = {"tenant_id": "t1", "approval_mode": "auto-approve", "slack_webhook_url": None}
+        tenant = self._tenant()
         mock_format_obj, mock_config = self._setup_generative_mocks(mock_session)
 
         with (
@@ -2287,7 +2302,7 @@ class TestGenerativeCreativeBuild:
         from tests.helpers.creative_test_helpers import assert_gemini_key_missing_advisory
 
         mock_session = _make_mock_creative_repo()
-        tenant = {"tenant_id": "t1", "approval_mode": "auto-approve", "slack_webhook_url": None}
+        tenant = self._tenant(gemini_key=None)
         mock_format_obj, mock_config = self._setup_generative_mocks(mock_session, gemini_key=None)
 
         with (

--- a/tests/unit/test_creative.py
+++ b/tests/unit/test_creative.py
@@ -2341,21 +2341,32 @@ class TestGenerativeCreativeBuild:
             assert_gemini_key_missing_advisory(errs)
 
     @pytest.mark.parametrize(
-        ("tenant_key", "global_key", "expect_advisory", "expected_key"),
+        ("tenant_key", "ai_config_key", "global_key", "expect_advisory", "expected_key"),
         [
-            ("tenant-key", None, False, "tenant-key"),
-            (None, "global-key", True, None),
-            (None, None, True, None),
-            ("tenant-key", "global-key", False, "tenant-key"),
+            ("tenant-key", None, None, False, "tenant-key"),
+            (None, "ai-config-key", None, False, "ai-config-key"),
+            (None, "ai-config-key", "global-key", False, "ai-config-key"),
+            ("tenant-key", "ai-config-key", None, False, "ai-config-key"),
+            (None, None, "global-key", True, None),
+            (None, None, None, True, None),
+            ("tenant-key", None, "global-key", False, "tenant-key"),
         ],
-        ids=["tenant_only", "global_only_ignored", "neither", "both_tenant_wins"],
+        ids=[
+            "legacy_column_only",
+            "ai_config_only",
+            "ai_config_ignores_global",
+            "ai_config_prefers_over_legacy",
+            "global_only_ignored",
+            "neither",
+            "legacy_with_global",
+        ],
     )
-    def test_gemini_key_is_account_scoped(self, tenant_key, global_key, expect_advisory, expected_key):
-        """Account-scoped key is sole source; process-global alone → advisory.
+    def test_gemini_key_is_account_scoped(self, tenant_key, ai_config_key, global_key, expect_advisory, expected_key):
+        """Account-scoped key: ai_config.api_key first, then legacy column; never process-global.
 
-        Deleting ``tenant.get("gemini_api_key")`` must redden the tenant_only /
-        both_tenant_wins arms. A non-None process-global key must not rescue a
-        keyless tenant (``global_only_ignored``).
+        An account that configured Gemini only via admin AI settings (``ai_config``)
+        must not receive a terminal missing-key advisory. Process-global alone must
+        not rescue a keyless tenant.
         """
         from types import SimpleNamespace
         from unittest.mock import patch
@@ -2365,6 +2376,8 @@ class TestGenerativeCreativeBuild:
         tenant: dict = {"tenant_id": "t1"}
         if tenant_key is not None:
             tenant["gemini_api_key"] = tenant_key
+        if ai_config_key is not None:
+            tenant["ai_config"] = {"provider": "gemini", "api_key": ai_config_key}
         mock_config = MagicMock()
         mock_config.gemini_api_key = global_key
         fmt = SimpleNamespace(id="display_gen")

--- a/tests/unit/test_creative.py
+++ b/tests/unit/test_creative.py
@@ -2279,10 +2279,12 @@ class TestGenerativeCreativeBuild:
         """Generative creative without GEMINI_API_KEY configured fails with clear error.
 
         GAP: BR-UC-006-ext-i -- Gemini key missing for generative.
-        Production code at _processing.py lines 520-525.
+        Production early-returns ``_gemini_key_missing_result`` in
+        ``_create_new_creative`` when ``gemini_api_key`` is unset.
         Covers: UC-006-EXT-I-01
         """
         from src.core.tools.creatives._processing import _create_new_creative
+        from tests.helpers.creative_test_helpers import assert_gemini_key_missing_advisory
 
         mock_session = _make_mock_creative_repo()
         tenant = {"tenant_id": "t1", "approval_mode": "auto-approve", "slack_webhook_url": None}
@@ -2321,11 +2323,7 @@ class TestGenerativeCreativeBuild:
             assert action_val == "failed"
             errs = result.errors or []
             assert any("GEMINI_API_KEY" in e.message for e in errs)
-            assert errs[0].code == "CREATIVE_GEMINI_KEY_MISSING"
-            assert errs[0].recovery == "terminal"
-            assert errs[0].suggestion is not None
-            assert "seller" in errs[0].suggestion.lower()
-            assert "GEMINI" in errs[0].suggestion
+            assert_gemini_key_missing_advisory(errs)
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary
- Wire creative-sync GEMINI misconfiguration as seller-specific `X_PREBID_CREATIVE_GEMINI_KEY_MISSING` + `recovery=terminal` per-creative advisories (reject `CONFIGURATION_ERROR` on 200+advisory).
- Account-scoped Gemini key as the sole source: prefer `tenant.ai_config.api_key` (admin AI settings), then legacy `gemini_api_key` column; no process-global fallback (so a keyless seller is realizable via the DB row alone).
- Harden wire grading: advisory-factory AST scan, nested-advisory field presence (no model soft-fallback), `assert_wire_advisory` mutation oracles (including suggestion), refuse A2A `model_dump` proxy when `require_real_wire=True` (#1919), normalize AdCPError advisories via `to_wire_error_code` + `field`.
- `clear_gemini_api_key` realized on e2e via the tenant column; one remaining `setup_generative_build` `E2EUnsupportedSetup` declaration cites #1964 (catalog/build path — descoped from this leaf). Partial #1887 adoption — `set_run_async_result` and direct registry pokes remain unwrapped.

Closes #1831

## Spec grounding
- AdCP **3.1.1** / pinned `adcp` SDK: `transport-errors.mdx` § Seller-Specific Error Codes — non-standard codes MUST match `X_{VENDOR}_{CODE}` (VENDOR `[A-Z][A-Z0-9]{1,19}`, CODE `[A-Z][A-Z0-9_]{1,39}`).
- `enums/error-code.json` — `CONFIGURATION_ERROR` requires flipped transport failure markers + “cannot produce a success artifact”; recovery `terminal`. Not valid inside a successful `sync_creatives` artifact.
- Same enum: `SERVICE_UNAVAILABLE` ↔ recovery `transient` (not a durable pin for admin-fixable misconfig).
- `core/error.json`: sellers MAY use seller-specific codes; agents fall back to `recovery`.
- Storyboard: the position `creatives[].errors[0].code` is graded in pinned compliance scenarios; this condition’s specific code/recovery pair is ungraded there. BDD UC-006 ext-i grades `X_PREBID_CREATIVE_GEMINI_KEY_MISSING`.
- Precedent: seller-specific `X_{VENDOR}_{CODE}` shape (not the older bare `CREATIVE_*` / membership allowlist).

## Test plan
- [x] Unit: missing GEMINI → `X_PREBID_CREATIVE_GEMINI_KEY_MISSING` / `terminal` / suggestion mentions seller account lever
- [x] Unit: `ai_config`-only / legacy-column / neither / global-ignored key preference (`_check_gemini_key_or_advisory`)
- [x] Architecture: seller-specific shape predicate (`fullmatch`); `_failed_sync_result` + `adcp.types.Error` alias sites scanned; negative self-tests
- [x] Harness: `assert_wire_advisory` wrong-code/wrong-recovery/wrong-suggestion oracles; proxy+`require_real_wire` refuse
- [x] E2E: `clear_gemini_api_key` realized; `setup_generative_build` remains unsupported citing #1964
- [x] BDD `@T-UC-006-ext-i` grades production code + recovery (nested wire, no model soft-skip) with AdCP `@source` citations
- [x] CI tip-wide green

## Scope note
See Conversation comment on tip `59d423cb6` for what landed in this PR vs what is descoped to follow-ups (#1919, #1964, harness/BDD epics).