### PR TITLE
fix: emit brief relevance from product ranking

### DIFF
--- a/src/core/tools/products.py
+++ b/src/core/tools/products.py
@@ -687,6 +687,11 @@ async def _get_products_impl(
                 # Filter out products with very low relevance (score < 0.1)
                 eligible_products = [p for p in eligible_products if ranking_map.get(p.product_id, (0.0, ""))[0] >= 0.1]
 
+                # AdCP 3.1.1 core/product.json: explain why each curated
+                # product matches the supplied brief.
+                for product in eligible_products:
+                    product.brief_relevance = ranking_map[product.product_id][1]
+
                 # Log the ranking results
                 for r in ranking_result.rankings:
                     logger.info(f"[AI_RANKING] {r.product_id}: score={r.relevance_score:.2f}, reason={r.reason}")

--- a/tests/bdd/conftest.py
+++ b/tests/bdd/conftest.py
@@ -55,6 +55,7 @@ pytest_plugins = [
     "tests.bdd.steps.generic.then_success",
     "tests.bdd.steps.generic.then_error",
     "tests.bdd.steps.generic.then_payload",
+    "tests.bdd.steps.domain.uc001_discover_inventory",
     "tests.bdd.steps.domain.uc004_delivery",
     "tests.bdd.steps.domain.uc002_create_media_buy",
     "tests.bdd.steps.domain.uc002_nfr",
@@ -3075,6 +3076,8 @@ def _setup_existing_media_buy(ctx: dict, env: object, tenant: object, principal:
 def _detect_uc(request: pytest.FixtureRequest) -> str | None:
     """Detect which use case a BDD scenario belongs to via its tags."""
     marker_names = {m.name for m in request.node.iter_markers()}
+    if any(t.startswith("T-UC-001-") for t in marker_names):
+        return "UC-001"
     if any(t.startswith("T-UC-002") for t in marker_names):
         return "UC-002"
     if any(t.startswith("T-UC-003") for t in marker_names):
@@ -3517,6 +3520,66 @@ def _harness_env(request: pytest.FixtureRequest, ctx: dict) -> Generator[None, N
                 yield
         else:
             pytest.xfail(f"UC-004 harness not yet wired for type: {harness_type}")
+    elif uc == "UC-001":
+        marker_names = {m.name for m in request.node.iter_markers()}
+        if "T-UC-001-main" not in marker_names:
+            pytest.xfail("UC-001 harness is wired only for T-UC-001-main (#1595)")
+
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from src.services.ai.agents.ranking_agent import ProductRanking, ProductRankingResult
+        from tests.factories import PricingOptionFactory, ProductFactory
+        from tests.harness.product import ProductEnv
+
+        ranking_prompt = "Rank products against the buyer brief"
+        with (
+            _db_scope_for(request, e2e_config),
+            ProductEnv(
+                e2e_config=e2e_config,
+                product_ranking_prompt=ranking_prompt,
+            ) as env,
+            patch("src.services.ai.agents.ranking_agent.create_ranking_agent"),
+        ):
+            tenant, principal = env.setup_default_data()
+            low = ProductFactory(tenant=tenant, product_id="uc001-low")
+            PricingOptionFactory(product=low)
+            high = ProductFactory(tenant=tenant, product_id="uc001-high")
+            PricingOptionFactory(product=high)
+
+            tenant.product_ranking_prompt = ranking_prompt
+            env._commit_factory_data()
+
+            ranking_reasons = {
+                high.product_id: "Strongest match for the requested tech audience",
+                low.product_id: "Relevant display inventory with broader reach",
+            }
+            ranking_result = ProductRankingResult(
+                rankings=[
+                    ProductRanking(
+                        product_id=low.product_id, relevance_score=0.4, reason=ranking_reasons[low.product_id]
+                    ),
+                    ProductRanking(
+                        product_id=high.product_id,
+                        relevance_score=0.9,
+                        reason=ranking_reasons[high.product_id],
+                    ),
+                ]
+            )
+            with patch(
+                "src.services.ai.agents.ranking_agent.rank_products_async",
+                new=AsyncMock(return_value=ranking_result),
+            ):
+                mock_factory = MagicMock()
+                mock_factory.is_ai_enabled.return_value = True
+                mock_factory.create_model.return_value = MagicMock()
+                env.mock["ranking_factory"].return_value = mock_factory
+
+                ctx["env"] = env
+                ctx["tenant"] = tenant
+                ctx["principal"] = principal
+                ctx["ranked_product_ids"] = [high.product_id, low.product_id]
+                ctx["ranking_reasons"] = ranking_reasons
+                yield
     elif uc == "UC-GET-PRODUCTS":
         from tests.harness.product import ProductEnv
 

--- a/tests/bdd/steps/domain/uc001_discover_inventory.py
+++ b/tests/bdd/steps/domain/uc001_discover_inventory.py
@@ -1,0 +1,114 @@
+"""Steps for the wired UC-001 main get_products scenario."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from pytest_bdd import given, parsers, then, when
+
+from tests.bdd.steps._outcome_helpers import _require_response, wire_field
+from tests.bdd.steps.generic._dispatch import dispatch_request
+
+
+def _datatable_to_kwargs(datatable: list) -> dict[str, Any]:
+    """Convert a two-column field/value datatable to request kwargs."""
+    headers = [str(header).strip() for header in datatable[0]]
+    field_index, value_index = headers.index("field"), headers.index("value")
+    kwargs: dict[str, Any] = {}
+    for row in datatable[1:]:
+        field = str(row[field_index]).strip()
+        raw = str(row[value_index]).strip()
+        if field == "buying_mode":
+            continue
+        kwargs[field] = json.loads(raw) if raw.startswith(("{", "[")) else raw
+    return kwargs
+
+
+def _wire_products(ctx: dict) -> list[dict[str, Any]]:
+    """Return products exactly as serialized for the buyer."""
+    return wire_field(ctx, "products")
+
+
+@given("a tenant exists with at least one product in the catalog")
+def given_tenant_with_catalog(ctx: dict) -> None:
+    """Assert that the UC-001 harness seeded the catalog."""
+    assert ctx["ranked_product_ids"], "UC-001 harness did not seed ranked products"
+
+
+@given(parsers.parse('the tenant brand_manifest_policy is "{policy}"'))
+def given_brand_manifest_policy(ctx: dict, policy: str) -> None:
+    """Configure the tenant's product-discovery authentication policy."""
+    ctx["tenant"].brand_manifest_policy = policy
+    ctx["env"]._commit_factory_data()
+
+
+@given("the tenant has an advertising_policy configured")
+def given_advertising_policy(ctx: dict) -> None:
+    """Configure a valid, disabled-by-default advertising policy."""
+    ctx["tenant"].advertising_policy = {"prohibited_categories": ["weapons"]}
+    ctx["env"]._commit_factory_data()
+
+
+@given(
+    "the product catalog contains products with valid schema "
+    "(format_ids, publisher_properties, pricing_options, reporting_capabilities)"
+)
+def given_valid_catalog(ctx: dict) -> None:
+    """Assert that the scenario has a non-vacuous product catalog."""
+    assert len(ctx["ranked_product_ids"]) == 2
+
+
+@when("the Buyer Agent sends a get_products request with:")
+def when_send_get_products(ctx: dict, datatable: list) -> None:
+    """Dispatch get_products through the parametrized wire transport."""
+    dispatch_request(ctx, **_datatable_to_kwargs(datatable))
+
+
+@then(parsers.parse('the response status should be "completed"'))
+def then_status_completed(ctx: dict) -> None:
+    """Assert synchronous product discovery completed successfully."""
+    assert ctx.get("error") is None, f"Request failed: {ctx.get('error')!r}"
+    assert _require_response(ctx).products is not None
+
+
+@then('the response should contain "products" array')
+def then_contains_products_array(ctx: dict) -> None:
+    """Assert products are present on the serialized response."""
+    products = _wire_products(ctx)
+    assert isinstance(products, list)
+    assert products, "products array is empty — ranking assertions would be vacuous"
+
+
+@then(
+    "each product should have product_id, name, format_ids, publisher_properties, "
+    "pricing_options, and reporting_capabilities"
+)
+def then_products_have_required_fields(ctx: dict) -> None:
+    """Assert the core product fields are present on the wire."""
+    required = (
+        "product_id",
+        "name",
+        "format_ids",
+        "publisher_properties",
+        "pricing_options",
+        "reporting_capabilities",
+    )
+    for product in _wire_products(ctx):
+        for field in required:
+            assert product.get(field) is not None, f"{product.get('product_id')!r} missing {field!r}"
+
+
+@then("the products should be ordered by relevance_score descending")
+def then_products_ordered_by_relevance(ctx: dict) -> None:
+    """Assert wire order follows the ranker's descending internal scores."""
+    actual = [product["product_id"] for product in _wire_products(ctx)]
+    assert actual == ctx["ranked_product_ids"], f"unexpected relevance order: {actual}"
+
+
+@then("each product should include brief_relevance explanation")
+def then_products_have_brief_relevance(ctx: dict) -> None:
+    """Assert each ranked product exposes its ranker's explanation."""
+    for product in _wire_products(ctx):
+        expected = ctx["ranking_reasons"][product["product_id"]]
+        assert product.get("brief_relevance") == expected

--- a/tests/bdd/test_uc001_discover_available_inventory.py
+++ b/tests/bdd/test_uc001_discover_available_inventory.py
@@ -1,0 +1,5 @@
+"""BDD binding for UC-001 discover available inventory."""
+
+from pytest_bdd import scenarios
+
+scenarios("features/BR-UC-001-discover-available-inventory.feature")

--- a/tests/unit/test_product_schema_obligations.py
+++ b/tests/unit/test_product_schema_obligations.py
@@ -1706,6 +1706,46 @@ class TestProductUniquenessSchema:
 class TestRelevanceThresholdSchema:
     """AI ranking threshold filter behavior at schema level."""
 
+    async def test_ranked_products_emit_brief_relevance(self):
+        """AI ranking reasons are serialized as AdCP brief_relevance.
+
+        Covers: T-UC-001-main, issue #1595
+        """
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        with ProductEnv() as env:
+            env.add_product(product_id="prod_low")
+            env.add_product(product_id="prod_high")
+            env.identity.tenant["product_ranking_prompt"] = "rank by relevance"
+
+            mock_factory = MagicMock()
+            mock_factory.is_ai_enabled.return_value = True
+            mock_factory.create_model.return_value = MagicMock()
+            env.mock["ranking_factory"].return_value = mock_factory
+
+            mock_result = MagicMock()
+            mock_result.rankings = [
+                MagicMock(product_id="prod_low", relevance_score=0.4, reason="Useful secondary fit"),
+                MagicMock(product_id="prod_high", relevance_score=0.9, reason="Best match for the brief"),
+            ]
+
+            with (
+                patch(
+                    "src.services.ai.agents.ranking_agent.rank_products_async",
+                    new_callable=AsyncMock,
+                    return_value=mock_result,
+                ),
+                patch("src.services.ai.agents.ranking_agent.create_ranking_agent"),
+            ):
+                response = await env.call_impl(brief="Display ads for a tech audience")
+
+            products = response.model_dump(mode="json")["products"]
+            assert [product["product_id"] for product in products] == ["prod_high", "prod_low"]
+            assert [product["brief_relevance"] for product in products] == [
+                "Best match for the brief",
+                "Useful secondary fit",
+            ]
+
     async def test_threshold_boundary_included(self):
         """Score exactly at threshold (0.1) is included.
 


### PR DESCRIPTION
## Summary

- emit the existing AI ranking explanation as the AdCP 3.1.1 `brief_relevance` product field
- keep relevance scores internal while preserving the existing sort and threshold behavior
- wire `T-UC-001-main` across A2A, MCP, and REST

## Why

The product ranker already returned a relevance score and a human-readable reason for each product. `get_products` used the score for ordering and filtering, but discarded the reason before constructing the response. As a result, curated products never carried the spec-defined `brief_relevance` explanation on the wire.

This change copies the ranker's reason onto each surviving ranked product. Products returned without AI ranking remain unchanged and do not gain a synthetic explanation.

## Spec grounding

- AdCP 3.1.1 `core/product.json` defines `brief_relevance` as the explanation of why a product matches the supplied brief.
- AdCP 3.1.1 Brief Expectations directs publishers to explain relevance in curated responses.
- `T-UC-001-main` grades relevance ordering and the presence of product explanations.

## Validation

- `T-UC-001-main`: 3 passed across A2A, MCP, and REST
- product and `get_products` suites: 138 passed
- AdCP contract and BDD architecture checks: 151 passed
- Ruff formatting and lint checks passed
- code-duplication guard passed with no baseline growth

## Coordination note

PR #1837 is adding shared UC-001 BDD wiring that overlaps with the test scaffolding currently included in this draft. I plan to rebase after #1837 lands and remove the duplicate harness changes, while retaining the focused `brief_relevance` implementation and coverage for issue #1595.

I also identified a stale integration expectation and an overly broad BDD step in this draft. I will address both as part of that cleanup before marking the PR ready for review. Thank you.

Fixes #1595
