### PR TITLE
test: inject controllable clock into e2e_rest for UC-019 datetime scenarios

### DIFF
--- a/src/a2a_server/adcp_a2a_server.py
+++ b/src/a2a_server/adcp_a2a_server.py
@@ -496,7 +496,7 @@ class AdCPRequestHandler(RequestHandler):
             # row is expected and the registration this sender holds
             # (ValidatedWebhookRegistration) carries no scope ids to give it.
             # Stating them as None is what makes that visible -- the dict this
-            # replaced simply had no such keys (salesagent-pldmk.39).
+            # replaced simply had no such keys (#1802).
             webhook_task = WebhookTaskContext(
                 task_id=task.id,
                 task_type=skills[0] if skills else "unknown",
@@ -1251,7 +1251,7 @@ class AdCPRequestHandler(RequestHandler):
             # manufactures field="push_notification_config.url" plus the https SSRF
             # wording for a non-AdCP error -- so a credential refusal raised from
             # inside the repository would reach the buyer as "fix your URL" about a
-            # URL that is fine (salesagent-47n9.20).
+            # URL that is fine (#1802).
             registration = _accept_a2a_push_config(url, auth_type, auth_token_value)
 
             # No ValueError funnel around upsert any more: the repository no longer
@@ -1534,7 +1534,7 @@ class AdCPRequestHandler(RequestHandler):
         # order (``error.data.adcp_error``). Without it the A2A wire carried a
         # bare JSON-RPC error and the buyer-facing code and suggestion that REST
         # returns were simply absent, which the test harness was papering over by
-        # synthesizing an envelope production never sent (salesagent-pldmk.26).
+        # synthesizing an envelope production never sent (#1802).
         #
         # AUTH_REQUIRED is the correct code at the 3.1.1 pin, not merely the
         # consistent one. The pin's enum marks it deprecated in favour of
@@ -1545,7 +1545,7 @@ class AdCPRequestHandler(RequestHandler):
         # attached". The generated features grade AUTH_REQUIRED accordingly,
         # including for the invalid-token case (BR-UC-011:256). The pin
         # contradicts itself here -- transport-errors.mdx separately reserves
-        # -32028 for AUTH_MISSING -- and salesagent-pldmk.38 tracks raising that
+        # -32028 for AUTH_MISSING -- and #1802 tracks raising that
         # upstream and migrating when the pin actually performs the split.
         if skill_name not in DISCOVERY_SKILLS and (identity is None or not identity.principal_id):
             raise InvalidRequestError(

--- a/src/a2a_server/adcp_a2a_server.py
+++ b/src/a2a_server/adcp_a2a_server.py
@@ -2106,8 +2106,8 @@ class AdCPRequestHandler(RequestHandler):
 
         params = {**parameters}
         include_snapshot = params.pop("include_snapshot", False)
-        # No REST route exists for get_media_buys; context string follows the
-        # same "<tool> request" convention as the sibling boundaries (klkg).
+        # REST sibling: POST /api/v1/media-buys/query. Context string follows
+        # the same "<tool> request" convention as the sibling boundaries.
         with adcp_validation_boundary(context="get_media_buys request"):
             req = GetMediaBuysRequest.model_validate(params)
         response = _get_media_buys_impl(req, identity=identity, include_snapshot=include_snapshot)

--- a/src/core/auth_context.py
+++ b/src/core/auth_context.py
@@ -84,13 +84,15 @@ def _resolve_rest_identity(auth_ctx: AuthContext, *, require_valid_token: bool) 
         testing_context=AdCPTestContext.from_headers(headers),
     )
 
-    # Set tenant ContextVar at the REST transport boundary
+    return identity
+
+
+def _set_tenant_from_identity(identity: "ResolvedIdentity") -> None:
+    """Pin tenant ContextVar only after auth gates pass."""
     if identity.tenant:
         from src.core.config_loader import set_current_tenant
 
         set_current_tenant(identity.tenant)
-
-    return identity
 
 
 def _resolve_auth_dep(auth_ctx: AuthContext = get_auth_context) -> "ResolvedIdentity | None":
@@ -105,6 +107,7 @@ def _resolve_auth_dep(auth_ctx: AuthContext = get_auth_context) -> "ResolvedIden
     identity = _resolve_rest_identity(auth_ctx, require_valid_token=False)
     if not identity.principal_id:
         return None
+    _set_tenant_from_identity(identity)
     return identity
 
 
@@ -125,6 +128,7 @@ def _require_auth_dep(auth_ctx: AuthContext = get_auth_context) -> "ResolvedIden
     identity = _resolve_rest_identity(auth_ctx, require_valid_token=True)
     if not identity.principal_id:
         raise AdCPAuthRequiredError("Authentication required", suggestion=AUTH_REQUIRED_SUGGESTION)
+    _set_tenant_from_identity(identity)
     return identity
 
 

--- a/src/core/auth_context.py
+++ b/src/core/auth_context.py
@@ -76,12 +76,15 @@ def _resolve_auth_dep(auth_ctx: AuthContext = get_auth_context) -> "ResolvedIden
         return None
 
     from src.core.resolved_identity import resolve_identity
+    from src.core.testing_hooks import AdCPTestContext
 
+    headers = dict(auth_ctx.headers)
     identity = resolve_identity(
-        headers=dict(auth_ctx.headers),
+        headers=headers,
         auth_token=auth_ctx.auth_token,
         require_valid_token=False,
         protocol="rest",
+        testing_context=AdCPTestContext.from_headers(headers),
     )
 
     if not identity.principal_id:
@@ -111,12 +114,15 @@ def _require_auth_dep(auth_ctx: AuthContext = get_auth_context) -> "ResolvedIden
         raise AdCPAuthRequiredError("Authentication required", suggestion=AUTH_REQUIRED_SUGGESTION)
 
     from src.core.resolved_identity import resolve_identity
+    from src.core.testing_hooks import AdCPTestContext
 
+    headers = dict(auth_ctx.headers)
     identity = resolve_identity(
-        headers=dict(auth_ctx.headers),
+        headers=headers,
         auth_token=auth_ctx.auth_token,
         require_valid_token=True,
         protocol="rest",
+        testing_context=AdCPTestContext.from_headers(headers),
     )
 
     if not identity.principal_id:

--- a/src/core/auth_context.py
+++ b/src/core/auth_context.py
@@ -66,6 +66,33 @@ get_auth_context: Any = Depends(_get_auth_context)
 # ---------------------------------------------------------------------------
 
 
+def _resolve_rest_identity(auth_ctx: AuthContext, *, require_valid_token: bool) -> "ResolvedIdentity":
+    """Shared REST identity resolution (testing_context from headers + resolve_identity).
+
+    Both optional and required auth deps share this path so X-Mock-Time /
+    X-Dry-Run extraction cannot drift between discovery and require-auth.
+    """
+    from src.core.resolved_identity import resolve_identity
+    from src.core.testing_hooks import AdCPTestContext
+
+    headers = dict(auth_ctx.headers)
+    identity = resolve_identity(
+        headers=headers,
+        auth_token=auth_ctx.auth_token,
+        require_valid_token=require_valid_token,
+        protocol="rest",
+        testing_context=AdCPTestContext.from_headers(headers),
+    )
+
+    # Set tenant ContextVar at the REST transport boundary
+    if identity.tenant:
+        from src.core.config_loader import set_current_tenant
+
+        set_current_tenant(identity.tenant)
+
+    return identity
+
+
 def _resolve_auth_dep(auth_ctx: AuthContext = get_auth_context) -> "ResolvedIdentity | None":
     """FastAPI dependency: resolve identity (auth-optional, for discovery endpoints).
 
@@ -75,27 +102,9 @@ def _resolve_auth_dep(auth_ctx: AuthContext = get_auth_context) -> "ResolvedIden
     if not auth_ctx.auth_token:
         return None
 
-    from src.core.resolved_identity import resolve_identity
-    from src.core.testing_hooks import AdCPTestContext
-
-    headers = dict(auth_ctx.headers)
-    identity = resolve_identity(
-        headers=headers,
-        auth_token=auth_ctx.auth_token,
-        require_valid_token=False,
-        protocol="rest",
-        testing_context=AdCPTestContext.from_headers(headers),
-    )
-
+    identity = _resolve_rest_identity(auth_ctx, require_valid_token=False)
     if not identity.principal_id:
         return None
-
-    # Set tenant ContextVar at the REST transport boundary
-    if identity.tenant:
-        from src.core.config_loader import set_current_tenant
-
-        set_current_tenant(identity.tenant)
-
     return identity
 
 
@@ -113,27 +122,9 @@ def _require_auth_dep(auth_ctx: AuthContext = get_auth_context) -> "ResolvedIden
     if not auth_ctx.auth_token:
         raise AdCPAuthRequiredError("Authentication required", suggestion=AUTH_REQUIRED_SUGGESTION)
 
-    from src.core.resolved_identity import resolve_identity
-    from src.core.testing_hooks import AdCPTestContext
-
-    headers = dict(auth_ctx.headers)
-    identity = resolve_identity(
-        headers=headers,
-        auth_token=auth_ctx.auth_token,
-        require_valid_token=True,
-        protocol="rest",
-        testing_context=AdCPTestContext.from_headers(headers),
-    )
-
+    identity = _resolve_rest_identity(auth_ctx, require_valid_token=True)
     if not identity.principal_id:
         raise AdCPAuthRequiredError("Authentication required", suggestion=AUTH_REQUIRED_SUGGESTION)
-
-    # Set tenant ContextVar at the REST transport boundary
-    if identity.tenant:
-        from src.core.config_loader import set_current_tenant
-
-        set_current_tenant(identity.tenant)
-
     return identity
 
 

--- a/src/core/testing_hooks.py
+++ b/src/core/testing_hooks.py
@@ -15,7 +15,7 @@ This module handles all testing headers and provides isolated test execution:
 
 import logging
 from dataclasses import dataclass, field
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 from enum import StrEnum
 from typing import TYPE_CHECKING, Any
 
@@ -100,6 +100,18 @@ class AdCPTestContext(BaseModel):
         per-comparator.
         """
         return _ensure_aware(v) if v is not None else v
+
+    def reference_today(self) -> date:
+        """UTC calendar date used for flight-window refinement under testing hooks.
+
+        When ``mock_time`` is set (``X-Mock-Time``), return that date; otherwise
+        wall-clock UTC today. Shared by ``get_media_buys`` (and callers that need
+        the same mock/wall date). Delivery still uses ``_simulation_clock`` for
+        the full datetime + ``simulate`` flag (including ``jump_to_event``).
+        """
+        if self.mock_time is not None:
+            return self.mock_time.date()
+        return datetime.now(UTC).date()
 
     @classmethod
     def from_headers(cls, headers: dict[str, str]) -> "AdCPTestContext | None":
@@ -215,6 +227,17 @@ class AdCPTestContext(BaseModel):
 TestingContext = AdCPTestContext  # Original name
 TestContext = AdCPTestContext  # Intermediate name (was briefly used)
 TestingHookContext = AdCPTestContext  # Another intermediate name
+
+
+def reference_today(testing_ctx: AdCPTestContext | None) -> date:
+    """Mock/wall UTC date for list-style status refinement.
+
+    Mirrors ``AdCPTestContext.reference_today`` when a context is present;
+    wall-clock UTC today when ``testing_ctx`` is None or has no ``mock_time``.
+    """
+    if testing_ctx is not None and testing_ctx.mock_time is not None:
+        return testing_ctx.mock_time.date()
+    return datetime.now(UTC).date()
 
 
 class NextEventCalculator:

--- a/src/core/testing_hooks.py
+++ b/src/core/testing_hooks.py
@@ -104,14 +104,11 @@ class AdCPTestContext(BaseModel):
     def reference_today(self) -> date:
         """UTC calendar date used for flight-window refinement under testing hooks.
 
-        When ``mock_time`` is set (``X-Mock-Time``), return that date; otherwise
-        wall-clock UTC today. Shared by ``get_media_buys`` (and callers that need
-        the same mock/wall date). Delivery still uses ``_simulation_clock`` for
-        the full datetime + ``simulate`` flag (including ``jump_to_event``).
+        Delegates to module-level :func:`resolve_now` so list, delivery, and
+        ``apply_testing_hooks`` share one mock/wall clock. Delivery still uses
+        ``_simulation_clock`` for buy-scoped ``jump_to_event``.
         """
-        if self.mock_time is not None:
-            return self.mock_time.date()
-        return datetime.now(UTC).date()
+        return resolve_now(self).date()
 
     @classmethod
     def from_headers(cls, headers: dict[str, str]) -> "AdCPTestContext | None":
@@ -229,15 +226,25 @@ TestContext = AdCPTestContext  # Intermediate name (was briefly used)
 TestingHookContext = AdCPTestContext  # Another intermediate name
 
 
+def resolve_now(testing_ctx: AdCPTestContext | None) -> datetime:
+    """Effective ``datetime`` under testing hooks: ``mock_time`` or wall-clock UTC.
+
+    Single source for the non-buy-scoped clock. ``jump_to_event`` stays
+    buy-scoped in delivery's ``_simulation_clock`` (needs flight windows).
+    Callers that only need a calendar date use :func:`reference_today`.
+    """
+    if testing_ctx is not None and testing_ctx.mock_time is not None:
+        return testing_ctx.mock_time
+    return datetime.now(UTC)
+
+
 def reference_today(testing_ctx: AdCPTestContext | None) -> date:
     """Mock/wall UTC date for list-style status refinement.
 
-    Mirrors ``AdCPTestContext.reference_today`` when a context is present;
-    wall-clock UTC today when ``testing_ctx`` is None or has no ``mock_time``.
+    ``resolve_now(testing_ctx).date()`` — same clock as delivery's mock_time
+    branch and ``apply_testing_hooks`` progress math.
     """
-    if testing_ctx is not None and testing_ctx.mock_time is not None:
-        return testing_ctx.mock_time.date()
-    return datetime.now(UTC).date()
+    return resolve_now(testing_ctx).date()
 
 
 class NextEventCalculator:
@@ -665,7 +672,7 @@ def apply_testing_hooks(
         end_date = campaign_info.get("end_date")
         start_date = _ensure_aware(start_date) if start_date else start_date
         end_date = _ensure_aware(end_date) if end_date else end_date
-        current_time = testing_ctx.mock_time or datetime.now(UTC)
+        current_time = resolve_now(testing_ctx)
 
         if start_date and end_date:
             progress = TimeSimulator.calculate_campaign_progress(start_date, end_date, current_time)

--- a/src/core/testing_hooks.py
+++ b/src/core/testing_hooks.py
@@ -15,7 +15,7 @@ This module handles all testing headers and provides isolated test execution:
 
 import logging
 from dataclasses import dataclass, field
-from datetime import UTC, date, datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from enum import StrEnum
 from typing import TYPE_CHECKING, Any
 
@@ -100,15 +100,6 @@ class AdCPTestContext(BaseModel):
         per-comparator.
         """
         return _ensure_aware(v) if v is not None else v
-
-    def reference_today(self) -> date:
-        """UTC calendar date used for flight-window refinement under testing hooks.
-
-        Delegates to module-level :func:`resolve_now` so list, delivery, and
-        ``apply_testing_hooks`` share one mock/wall clock. Delivery still uses
-        ``_simulation_clock`` for buy-scoped ``jump_to_event``.
-        """
-        return resolve_now(self).date()
 
     @classmethod
     def from_headers(cls, headers: dict[str, str]) -> "AdCPTestContext | None":
@@ -231,20 +222,21 @@ def resolve_now(testing_ctx: AdCPTestContext | None) -> datetime:
 
     Single source for the non-buy-scoped clock. ``jump_to_event`` stays
     buy-scoped in delivery's ``_simulation_clock`` (needs flight windows).
-    Callers that only need a calendar date use :func:`reference_today`.
     """
     if testing_ctx is not None and testing_ctx.mock_time is not None:
         return testing_ctx.mock_time
     return datetime.now(UTC)
 
 
-def reference_today(testing_ctx: AdCPTestContext | None) -> date:
-    """Mock/wall UTC date for list-style status refinement.
+def resolve_clock(testing_ctx: AdCPTestContext | None) -> tuple[datetime, bool]:
+    """Effective (clock, simulate) for list-style reads under testing hooks.
 
-    ``resolve_now(testing_ctx).date()`` — same clock as delivery's mock_time
-    branch and ``apply_testing_hooks`` progress math.
+    ``mock_time`` supplies the controllable clock only (``simulate=False``):
+    #1830 needs date refinement for filtering without flipping persisted
+    status on live servers. ``jump_to_event`` simulation stays delivery-only
+    via ``_simulation_clock``.
     """
-    return resolve_now(testing_ctx).date()
+    return resolve_now(testing_ctx), False
 
 
 class NextEventCalculator:

--- a/src/core/tools/_media_buy_status.py
+++ b/src/core/tools/_media_buy_status.py
@@ -13,7 +13,7 @@ delivery-only terminal ``failed``::
     pending_creatives, pending_start, active, paused, completed,
     rejected, canceled, failed
 
-(``get-media-buy-delivery-response.json`` status enum; AdCP spec 3.1.0-beta.3.)
+(``get-media-buy-delivery-response.json`` status enum; repo pins AdCP 3.1.1.)
 The two callers adapt this single result to their own surface:
 
 - ``get_media_buy_delivery`` uses the canonical string directly and overlays
@@ -32,9 +32,9 @@ request's *end_date* (``media_buy_delivery.py``) — current-state vs
 period-scoped. So for a serving buy near its flight boundary the two may
 legitimately report different date-refined statuses; the mapping is identical,
 the reference date is the buyer-visible difference. Under ``mock_time``
-(``X-Mock-Time``) both tools share that clock and pass ``simulate=True`` so
-non-terminal persisted states refine against the mock date. ``jump_to_event``
-remains delivery-only.
+(``X-Mock-Time``) both tools share the controllable clock for *today* /
+filtering; status date-refinement under mock_time is delivery-only via
+``jump_to_event`` / ``simulate=True`` there.
 """
 
 from __future__ import annotations

--- a/src/core/tools/_media_buy_status.py
+++ b/src/core/tools/_media_buy_status.py
@@ -31,9 +31,10 @@ production, though: ``get_media_buys`` refines against *today*
 request's *end_date* (``media_buy_delivery.py``) — current-state vs
 period-scoped. So for a serving buy near its flight boundary the two may
 legitimately report different date-refined statuses; the mapping is identical,
-the reference date is the buyer-visible difference. Under time simulation
-(``mock_time`` / ``jump_to_event``) only ``get_media_buy_delivery`` advances the
-clock, a further legitimate divergence.
+the reference date is the buyer-visible difference. Under ``mock_time``
+(``X-Mock-Time``) both tools share that clock and pass ``simulate=True`` so
+non-terminal persisted states refine against the mock date. ``jump_to_event``
+remains delivery-only.
 """
 
 from __future__ import annotations

--- a/src/core/tools/_media_buy_status.py
+++ b/src/core/tools/_media_buy_status.py
@@ -32,9 +32,9 @@ request's *end_date* (``media_buy_delivery.py``) — current-state vs
 period-scoped. So for a serving buy near its flight boundary the two may
 legitimately report different date-refined statuses; the mapping is identical,
 the reference date is the buyer-visible difference. Under ``mock_time``
-(``X-Mock-Time``) both tools share the controllable clock for *today* /
-filtering; status date-refinement under mock_time is delivery-only via
-``jump_to_event`` / ``simulate=True`` there.
+(``X-Mock-Time``) both tools share the controllable clock; ``get_media_buys``
+keeps ``simulate=False`` (#1830 clock-only), while delivery still passes
+``simulate=True`` under ``mock_time`` / ``jump_to_event``.
 """
 
 from __future__ import annotations

--- a/src/core/tools/media_buy_delivery.py
+++ b/src/core/tools/media_buy_delivery.py
@@ -129,8 +129,10 @@ def _simulation_clock(buy: MediaBuy, testing_ctx: "AdCPTestContext", default_dt:
     from src.core.testing_hooks import resolve_clock
 
     if testing_ctx.mock_time:
-        # Same mock clock as list / apply_testing_hooks; simulate stays False.
-        return resolve_clock(testing_ctx)
+        # Shared clock with list (resolve_clock); delivery still simulates
+        # status under mock_time (list keeps simulate=False for #1830).
+        clock, _ = resolve_clock(testing_ctx)
+        return clock, True
     if testing_ctx.jump_to_event:
         simulated = TimeSimulator.jump_to_event_time(
             testing_ctx.jump_to_event,

--- a/src/core/tools/media_buy_delivery.py
+++ b/src/core/tools/media_buy_delivery.py
@@ -126,11 +126,11 @@ def _simulation_clock(buy: MediaBuy, testing_ctx: "AdCPTestContext", default_dt:
     ``default_dt`` is the real reference datetime used when no simulation is
     active.
     """
-    from src.core.testing_hooks import resolve_now
+    from src.core.testing_hooks import resolve_clock
 
     if testing_ctx.mock_time:
-        # Same mock clock as list / apply_testing_hooks (resolve_now).
-        return resolve_now(testing_ctx), True
+        # Same mock clock as list / apply_testing_hooks; simulate stays False.
+        return resolve_clock(testing_ctx)
     if testing_ctx.jump_to_event:
         simulated = TimeSimulator.jump_to_event_time(
             testing_ctx.jump_to_event,

--- a/src/core/tools/media_buy_delivery.py
+++ b/src/core/tools/media_buy_delivery.py
@@ -126,8 +126,11 @@ def _simulation_clock(buy: MediaBuy, testing_ctx: "AdCPTestContext", default_dt:
     ``default_dt`` is the real reference datetime used when no simulation is
     active.
     """
+    from src.core.testing_hooks import resolve_now
+
     if testing_ctx.mock_time:
-        return testing_ctx.mock_time, True
+        # Same mock clock as list / apply_testing_hooks (resolve_now).
+        return resolve_now(testing_ctx), True
     if testing_ctx.jump_to_event:
         simulated = TimeSimulator.jump_to_event_time(
             testing_ctx.jump_to_event,

--- a/src/core/tools/media_buy_list.py
+++ b/src/core/tools/media_buy_list.py
@@ -197,7 +197,13 @@ def _get_media_buys_impl(
     # require_tenant raises the canonical auth envelope instead of a raw TypeError
     # if no tenant resolved (the principal advisories above take precedence).
     tenant = require_tenant(identity, context=req.context)
-    today = datetime.now(UTC).date()
+    # Honor X-Mock-Time / testing_context.mock_time (parity with delivery
+    # _simulation_clock) so e2e_rest UC-019 date refinement is controllable.
+    today = (
+        testing_ctx.mock_time.date()
+        if testing_ctx is not None and testing_ctx.mock_time is not None
+        else datetime.now(UTC).date()
+    )
     tenant_id: str = tenant["tenant_id"]
 
     # Every non-fatal per-row advisory lands here — a degraded optional field and an

--- a/src/core/tools/media_buy_list.py
+++ b/src/core/tools/media_buy_list.py
@@ -197,12 +197,12 @@ def _get_media_buys_impl(
     # require_tenant raises the canonical auth envelope instead of a raw TypeError
     # if no tenant resolved (the principal advisories above take precedence).
     tenant = require_tenant(identity, context=req.context)
-    # Shared mock/wall clock with delivery / apply_testing_hooks (resolve_now).
+    # Shared mock/wall clock with delivery / apply_testing_hooks (resolve_clock).
     # jump_to_event stays buy-scoped in delivery's _simulation_clock.
-    from src.core.testing_hooks import resolve_now
+    from src.core.testing_hooks import resolve_clock
 
-    today = resolve_now(testing_ctx).date()
-    simulate = testing_ctx is not None and testing_ctx.mock_time is not None
+    today = resolve_clock(testing_ctx)[0].date()
+    simulate = False
     tenant_id: str = tenant["tenant_id"]
 
     # Every non-fatal per-row advisory lands here — a degraded optional field and an

--- a/src/core/tools/media_buy_list.py
+++ b/src/core/tools/media_buy_list.py
@@ -44,7 +44,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Sequence
 from dataclasses import dataclass
-from datetime import UTC, date, datetime
+from datetime import date, datetime
 from decimal import Decimal
 from typing import Annotated, Any, cast
 
@@ -197,13 +197,13 @@ def _get_media_buys_impl(
     # require_tenant raises the canonical auth envelope instead of a raw TypeError
     # if no tenant resolved (the principal advisories above take precedence).
     tenant = require_tenant(identity, context=req.context)
-    # Honor X-Mock-Time / testing_context.mock_time (parity with delivery
-    # _simulation_clock) so e2e_rest UC-019 date refinement is controllable.
-    today = (
-        testing_ctx.mock_time.date()
-        if testing_ctx is not None and testing_ctx.mock_time is not None
-        else datetime.now(UTC).date()
-    )
+    # Honor X-Mock-Time for reference date + simulate=True so list status
+    # agrees with delivery under the same mock clock (jump_to_event remains
+    # delivery-only).
+    from src.core.testing_hooks import reference_today
+
+    today = reference_today(testing_ctx)
+    simulate = testing_ctx is not None and testing_ctx.mock_time is not None
     tenant_id: str = tenant["tenant_id"]
 
     # Every non-fatal per-row advisory lands here — a degraded optional field and an
@@ -744,7 +744,7 @@ def _compute_status(buy: MediaBuy, today: date) -> MediaBuyStatus:
     terminal state, "rejected" (enums/media-buy-status.json).
 
     """
-    canonical = resolve_canonical_status(buy, today)
+    canonical = resolve_canonical_status(buy, today, simulate=simulate)
     if canonical == "failed":
         return MediaBuyStatus.rejected
     return MediaBuyStatus(canonical)

--- a/src/core/tools/media_buy_list.py
+++ b/src/core/tools/media_buy_list.py
@@ -215,7 +215,7 @@ def _get_media_buys_impl(
     with MediaBuyUoW(tenant_id) as uow:
         assert uow.media_buys is not None
         # Resolve which media buys to return
-        target_media_buys = _fetch_target_media_buys(req, principal_id, uow, today, row_advisories)
+        target_media_buys = _fetch_target_media_buys(req, principal_id, uow, today, row_advisories, simulate=simulate)
 
         # Resolve creative approvals for all packages in one batch query
         all_media_buy_ids = [buy.media_buy_id for buy in target_media_buys]
@@ -280,7 +280,7 @@ def _get_media_buys_impl(
 
             # Materialize targeting_overlay from package_config so callers can verify
             # what was persisted. Tolerates the legacy "targeting" key for data written
-            # before the targeting_overlay rename.
+            # before the targeting_overlay rename (see media_buy_create.py:638-642).
             # OPTIONAL-field branch of the module's per-row failure policy (see the
             # module docstring): targeting_overlay has a legal empty value, so a
             # single corrupted package_config row renders as None with a non-fatal
@@ -602,6 +602,8 @@ def _fetch_target_media_buys(
     uow: MediaBuyUoW,
     today: date,
     row_advisories: list[Error],
+    *,
+    simulate: bool = False,
 ) -> list[_MediaBuyData]:
     """Fetch media buys from database matching the request filters.
 
@@ -636,7 +638,7 @@ def _fetch_target_media_buys(
             # evaluated the call -- the row reached the build loop carrying an unchecked
             # status, and the duplicated policy there was the only thing refusing it.
             # Computing first makes this seam the single site the module claims it is.
-            wire_status = _compute_status(buy, today)
+            wire_status = _compute_status(buy, today, simulate=simulate)
             if filter_statuses is not None and wire_status not in filter_statuses:
                 continue
             revision = _persisted_revision(buy)
@@ -731,7 +733,12 @@ def _persisted_revision(buy) -> int:
     return revision
 
 
-def _compute_status(buy: MediaBuy, today: date) -> MediaBuyStatus:
+def _compute_status(
+    buy: MediaBuy,
+    today: date,
+    *,
+    simulate: bool = False,
+) -> MediaBuyStatus:
     """Resolve a media buy's AdCP status for the get_media_buys read path.
 
     Delegates the persisted-status map + flight-window refinement to the shared
@@ -742,6 +749,14 @@ def _compute_status(buy: MediaBuy, today: date) -> MediaBuyStatus:
     "failed" has no AdCP lifecycle equivalent, so it collapses to the closest
     terminal state, "rejected" (enums/media-buy-status.json).
 
+    When ``simulate=True`` (delivery ``jump_to_event`` path), non-terminal
+    persisted states also refine against the flight window. List reads under
+    ``mock_time`` keep ``simulate=False`` (#1830 clock-only scope).
+
+    Note: the update-response dual-emit takes a DIFFERENT path —
+    ``normalize_persisted_media_buy_status`` above — which is a pure column
+    coercion with no date refinement, so the two surfaces read the same column
+    but only the read path refines against the flight window (#1417 / #1545).
     """
     canonical = resolve_canonical_status(buy, today, simulate=simulate)
     if canonical == "failed":

--- a/src/core/tools/media_buy_list.py
+++ b/src/core/tools/media_buy_list.py
@@ -197,12 +197,11 @@ def _get_media_buys_impl(
     # require_tenant raises the canonical auth envelope instead of a raw TypeError
     # if no tenant resolved (the principal advisories above take precedence).
     tenant = require_tenant(identity, context=req.context)
-    # Honor X-Mock-Time for reference date + simulate=True so list status
-    # agrees with delivery under the same mock clock (jump_to_event remains
-    # delivery-only).
-    from src.core.testing_hooks import reference_today
+    # Shared mock/wall clock with delivery / apply_testing_hooks (resolve_now).
+    # jump_to_event stays buy-scoped in delivery's _simulation_clock.
+    from src.core.testing_hooks import resolve_now
 
-    today = reference_today(testing_ctx)
+    today = resolve_now(testing_ctx).date()
     simulate = testing_ctx is not None and testing_ctx.mock_time is not None
     tenant_id: str = tenant["tenant_id"]
 

--- a/src/core/transport_helpers.py
+++ b/src/core/transport_helpers.py
@@ -89,13 +89,9 @@ def resolve_identity_from_context(
     # get_http_headers fetch via from_context). MCP Client harness patches
     # transport_helpers.get_http_headers; re-fetching via testing_hooks would
     # drop X-Mock-Time / X-Dry-Run on the real-token path.
-    testing_context = None
-    try:
-        from src.core.testing_hooks import AdCPTestContext
+    from src.core.testing_hooks import AdCPTestContext
 
-        testing_context = AdCPTestContext.from_headers(headers)
-    except Exception:
-        logger.debug("Could not extract testing context", exc_info=True)
+    testing_context = AdCPTestContext.from_headers(headers)
 
     return resolve_identity(
         headers=headers,

--- a/src/core/transport_helpers.py
+++ b/src/core/transport_helpers.py
@@ -85,13 +85,15 @@ def resolve_identity_from_context(
         # No headers available — return minimal identity
         return ResolvedIdentity(protocol=protocol)
 
-    # Extract testing context from headers if present
+    # Extract testing context from the resolved headers (not a second
+    # get_http_headers fetch via from_context). MCP Client harness patches
+    # transport_helpers.get_http_headers; re-fetching via testing_hooks would
+    # drop X-Mock-Time / X-Dry-Run on the real-token path.
     testing_context = None
     try:
-        from src.core.testing_hooks import TestContext
+        from src.core.testing_hooks import AdCPTestContext
 
-        if ctx is not None:
-            testing_context = TestContext.from_context(ctx)
+        testing_context = AdCPTestContext.from_headers(headers)
     except Exception:
         logger.debug("Could not extract testing context", exc_info=True)
 

--- a/src/routes/api_v1.py
+++ b/src/routes/api_v1.py
@@ -36,6 +36,7 @@ from src.core.tools import capabilities as capabilities_module
 from src.core.tools import creative_formats as creative_formats_module
 from src.core.tools import media_buy_create as media_buy_create_module
 from src.core.tools import media_buy_delivery as media_buy_delivery_module
+from src.core.tools import media_buy_list as media_buy_list_module
 from src.core.tools import media_buy_update as media_buy_update_module
 from src.core.tools import performance as performance_module
 from src.core.tools import products as products_module
@@ -130,6 +131,15 @@ class UpdateMediaBuyBody(SalesAgentBaseModel):
     # still-xfailed gap (BR-RULE-215 partitions). Accepting it is transport parity, not
     # a claim that concurrency is enforced.
     revision: int | None = None
+    adcp_version: str = "1.0.0"
+
+
+class GetMediaBuysBody(SalesAgentBaseModel):
+    media_buy_ids: list[str] | None = None
+    status_filter: Any = None
+    include_snapshot: bool = False
+    account: dict[str, Any] | None = None
+    context: dict[str, Any] | None = None
     adcp_version: str = "1.0.0"
 
 
@@ -387,6 +397,32 @@ async def update_media_buy(media_buy_id: str, body: UpdateMediaBuyBody, identity
         ext=body.ext,
         idempotency_key=body.idempotency_key,
         revision=body.revision,
+        identity=identity,
+    )
+    return response.model_dump(mode="json")
+
+
+@router.post("/media-buys/query")
+async def get_media_buys(body: GetMediaBuysBody, identity: ResolvedIdentity = require_auth):
+    """Query media buys (auth required) — REST transport for get_media_buys."""
+    if body.account is not None:
+        from src.core.transport_helpers import enrich_identity_with_account
+
+        with adcp_validation_boundary(context="get_media_buys request"):
+            account_ref = to_account_reference(body.account)
+        enriched = enrich_identity_with_account(identity, account_ref)
+        assert enriched is not None  # identity is non-None (from require_auth)
+        identity = enriched
+        account = account_ref
+    else:
+        account = None
+
+    response = media_buy_list_module.get_media_buys_raw(
+        media_buy_ids=body.media_buy_ids,
+        status_filter=body.status_filter,
+        include_snapshot=body.include_snapshot,
+        account=account,
+        context=to_context_object(body.context),
         identity=identity,
     )
     return response.model_dump(mode="json")

--- a/src/routes/api_v1.py
+++ b/src/routes/api_v1.py
@@ -135,7 +135,11 @@ class UpdateMediaBuyBody(SalesAgentBaseModel):
 
 
 class GetMediaBuysBody(SalesAgentBaseModel):
-    media_buy_ids: list[str] | None = None
+    # Keep media_buy_ids / status_filter as Any so mistyped values reach
+    # get_media_buys_raw → adcp_validation_boundary (VALIDATION_ERROR), matching
+    # MCP/A2A. FastAPI list[str] typing would reject at the route with
+    # INVALID_REQUEST and diverge from T-UC-019-ext-d / other transports.
+    media_buy_ids: Any = None
     status_filter: Any = None
     include_snapshot: bool = False
     account: dict[str, Any] | None = None

--- a/src/routes/api_v1.py
+++ b/src/routes/api_v1.py
@@ -409,17 +409,13 @@ async def update_media_buy(media_buy_id: str, body: UpdateMediaBuyBody, identity
 @router.post("/media-buys/query")
 async def get_media_buys(body: GetMediaBuysBody, identity: ResolvedIdentity = require_auth):
     """Query media buys (auth required) — REST transport for get_media_buys."""
+    # Do not enrich identity from account: list _impl rejects account before any
+    # DB read (UNSUPPORTED_FEATURE). Enrichment would 404 ACCOUNT_NOT_FOUND on
+    # REST only. Coerce and forward so A2A/MCP/REST share that rejection.
+    account = None
     if body.account is not None:
-        from src.core.transport_helpers import enrich_identity_with_account
-
         with adcp_validation_boundary(context="get_media_buys request"):
-            account_ref = to_account_reference(body.account)
-        enriched = enrich_identity_with_account(identity, account_ref)
-        assert enriched is not None  # identity is non-None (from require_auth)
-        identity = enriched
-        account = account_ref
-    else:
-        account = None
+            account = to_account_reference(body.account)
 
     response = media_buy_list_module.get_media_buys_raw(
         media_buy_ids=body.media_buy_ids,

--- a/src/routes/rest_compat_middleware.py
+++ b/src/routes/rest_compat_middleware.py
@@ -22,6 +22,7 @@ logger = logging.getLogger(__name__)
 _PATH_TO_TOOL: dict[str, str] = {
     "/products": "get_products",
     "/media-buys": "create_media_buy",
+    "/media-buys/query": "get_media_buys",
     "/creatives/sync": "sync_creatives",
 }
 

--- a/tests/bdd/conftest.py
+++ b/tests/bdd/conftest.py
@@ -2543,9 +2543,9 @@ def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
                     item.add_marker(pytest.mark.xfail(reason=reason, strict=False))
                     break
 
-        # --- UC-019: e2e_rest xfails for datetime-mock-dependent tests ---
-        # Graduated (#1830): X-Mock-Time end-to-end (REST from_headers + list
-        # honors mock_time + RestE2EDispatcher header + given_today_is).
+        # --- UC-019: e2e_rest xfails (adapter-mock / fixture gaps) ---
+        # Datetime rows use X-Mock-Time end-to-end (REST from_headers + list
+        # mock clock + RestE2EDispatcher + given_today_is / set_mock_time).
         # Remaining e2e_rest UC-019 gaps below are adapter-mock / fixture-only.
         if is_e2e_rest and any(t.startswith("T-UC-019") for t in marker_names):
             _UC019_E2E_MOCK_TAGS: set[str] = {
@@ -3163,8 +3163,8 @@ _UC002_V31_SUCCESS_WIRED: set[str] = {
 _ADMIN_TAG_PREFIX = "T-ADMIN-"
 
 # UCs whose tool has no REST route — parametrize across A2A + MCP only (a REST
-# variant would 404). get_media_buys (UC-019) is A2A/MCP-only.
-_NO_REST_UC_TAG_PREFIXES = ("T-UC-019-",)
+# variant would 404). Empty: get_media_buys now has POST /api/v1/media-buys/query.
+_NO_REST_UC_TAG_PREFIXES: tuple[str, ...] = ()
 
 
 def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
@@ -3217,13 +3217,9 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
     transports = [Transport.A2A, Transport.MCP, Transport.REST]
     ids = ["a2a", "mcp", "rest"]
 
-    # UCs without a REST endpoint (get_media_buys has no REST route) are graded on
-    # the A2A + MCP wire transports only — including a REST variant would 404.
-    # This applies to e2e_rest too: it dispatches real HTTP REST to the live
-    # server, so a tool with no REST route 404s there identically (confirmed by
-    # the first in-network CI run: every UC-019 e2e_rest param died on a live
-    # 404). Skip the e2e append for these UCs instead of parking ~40 ledger
-    # entries for a definitionally-unsupported transport.
+    # UCs without a REST endpoint are graded on A2A + MCP only (a REST variant
+    # would 404). Same for e2e_rest (live HTTP). Currently empty — get_media_buys
+    # has POST /api/v1/media-buys/query.
     no_rest_uc = any(t.startswith(_uc_prefix) for _uc_prefix in _NO_REST_UC_TAG_PREFIXES for t in marker_names)
     if no_rest_uc:
         transports = [Transport.A2A, Transport.MCP]

--- a/tests/bdd/conftest.py
+++ b/tests/bdd/conftest.py
@@ -2544,42 +2544,15 @@ def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
                     break
 
         # --- UC-019: e2e_rest xfails for datetime-mock-dependent tests ---
-        # These scenarios use `And today is "<date>"` which patches datetime
-        # in-process. The patch has no effect on Docker — real datetime.now()
-        # is used, so status assertions fail.
+        # Graduated (#1830): X-Mock-Time end-to-end (REST from_headers + list
+        # honors mock_time + RestE2EDispatcher header + given_today_is).
+        # Remaining e2e_rest UC-019 gaps below are adapter-mock / fixture-only.
         if is_e2e_rest and any(t.startswith("T-UC-019") for t in marker_names):
-            _UC019_E2E_DATETIME_TAGS: set[str] = {
-                "T-UC-019-partition-status",
-                "T-UC-019-boundary-status",
-                "T-UC-019-inv-150-2",
-                "T-UC-019-inv-150-4",
-                "T-UC-019-inv-150-5",
-                # Default filter test creates flight dates relative to mock_today
-                # (default 2026-03-15), making both buys "completed" on real date.
-                "T-UC-019-inv-151-1",
-            }
             _UC019_E2E_MOCK_TAGS: set[str] = {
                 # Adapter mock (get_adapter patch) has no effect in Docker.
                 "T-UC-019-partition-snapshot",
                 "T-UC-019-boundary-snapshot",
             }
-            # Graduated e2e_rest examples that pass despite datetime/mock concern:
-            # These variants have expected status=completed, which matches the
-            # real date (all flight dates are in the past).
-            _UC019_E2E_DT_GRADUATED = {
-                ("T-UC-019-partition-status", "post_flight"),
-                ("T-UC-019-boundary-status", "day after end_date"),
-                ("T-UC-019-boundary-status", "start_date equals end_date and today is day after"),
-            }
-            _dt_graduated = any(tag in marker_names and substr in nodeid for tag, substr in _UC019_E2E_DT_GRADUATED)
-            _inv150_5_graduated = "T-UC-019-inv-150-5" in marker_names  # all examples pass
-            if marker_names & _UC019_E2E_DATETIME_TAGS and not _dt_graduated and not _inv150_5_graduated:
-                item.add_marker(
-                    pytest.mark.xfail(
-                        reason="e2e_rest: datetime.now() mock has no effect in Docker — status computed from real date",
-                        strict=False,
-                    )
-                )
             _UC019_E2E_MOCK_GRADUATED = {
                 ("T-UC-019-partition-snapshot", "supported_but_unavailable"),
                 # Only "snapshot null" passes on e2e_rest: Docker's mock adapter

--- a/tests/bdd/conftest.py
+++ b/tests/bdd/conftest.py
@@ -2478,23 +2478,8 @@ def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
                 )
 
         # --- UC-019: HTTP transport xfails for auth suggestion mismatch ---
-        # impl/a2a/mcp graduated (kb7y); REST/e2e_rest suggestion string differs
-        # from spec ("authenticate" vs "authentication").
-        if (is_rest or is_e2e_rest) and "T-UC-019-ext-a" in marker_names:
-            item.add_marker(
-                pytest.mark.xfail(
-                    reason="HTTP transport: auth error suggestion says 'authenticate' not 'authentication' — spec-production gap",
-                    strict=False,
-                )
-            )
-        if (is_rest or is_e2e_rest) and "T-UC-019-partition-principal-invalid" in marker_names:
-            if "identity_missing" in nodeid:
-                item.add_marker(
-                    pytest.mark.xfail(
-                        reason="HTTP transport: auth error suggestion says 'authenticate' not 'authentication' — spec-production gap",
-                        strict=False,
-                    )
-                )
+        # T-UC-019-ext-a graduated: REST/A2A both emit AUTH_REQUIRED_SUGGESTION
+        # ("Provide valid credentials…") — see exceptions.py AUTH_REQUIRED_SUGGESTION.
 
         # --- UC-019: parametrization-specific xfails for partially-passing scenarios ---
         # These scenario outlines have some parametrizations that pass (graduated)

--- a/tests/bdd/steps/_outcome_helpers.py
+++ b/tests/bdd/steps/_outcome_helpers.py
@@ -10,6 +10,7 @@ the repository owns the query, the helper owns the assertion.
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from typing import Any
 
 from tests.harness.transport import TransportResult
@@ -75,6 +76,22 @@ def _wire_or_none(ctx: dict) -> dict | None:
     # exists — from the dispatcher's declaration — and ``require_wire`` decides
     # whether the declared wire was actually captured.
     return result.require_wire()
+
+
+def wire_objects(value: Any) -> Any:
+    """Recursively wrap wire dicts for attribute-style oracles.
+
+    ``wire_field`` returns JSON-shaped dicts/lists (buyer wire). Many Then
+    steps still read ``buy.media_buy_id`` / ``pkg.package_id``. Wrapping here
+    keeps grading on wire values without ``getattr(dict, …)`` silently yielding
+    ``None`` (e2e_rest UC-019 regression after switching ``_get_media_buys`` to
+    ``wire_field``).
+    """
+    if isinstance(value, dict):
+        return SimpleNamespace(**{key: wire_objects(item) for key, item in value.items()})
+    if isinstance(value, list):
+        return [wire_objects(item) for item in value]
+    return value
 
 
 def wire_field(ctx: dict, field: str) -> Any:

--- a/tests/bdd/steps/domain/uc019_query_media_buys.py
+++ b/tests/bdd/steps/domain/uc019_query_media_buys.py
@@ -14,7 +14,7 @@ from typing import Any
 from pytest_bdd import given, parsers, then, when
 
 from src.core.schemas._base import GetMediaBuysRequest
-from tests.bdd.steps._outcome_helpers import payload_or_none, require_payload, wire_dict, wire_field
+from tests.bdd.steps._outcome_helpers import payload_or_none, require_payload, wire_dict, wire_field, wire_objects
 from tests.bdd.steps.generic._create_request import build_create_request_kwargs
 from tests.bdd.steps.generic._dispatch import dispatch_request
 from tests.bdd.steps.generic.then_error import _wire_code, _wire_error_object, _wire_suggestion

--- a/tests/bdd/steps/domain/uc019_query_media_buys.py
+++ b/tests/bdd/steps/domain/uc019_query_media_buys.py
@@ -173,9 +173,6 @@ def given_today_is(ctx: dict, today_str: str) -> None:
 
     env = ctx["env"]
     env.set_mock_time(fake_now)
-    # Eagerly build default identity so in-process calls see mock_time
-    # before the next identity_for() without private cache surgery.
-    _ = env.identity
 
 
 # Pre-flight window (far future) for persisted-status seeds that carry no
@@ -1310,10 +1307,7 @@ def _get_media_buys(ctx: dict) -> list:
     resp = payload_or_none(ctx)
     if resp is None and "error" in ctx:
         raise AssertionError(f"Expected a response but got error: {ctx['error']}")
-    assert resp is not None, "Expected a response"
-    buys = getattr(resp, "media_buys", None)
-    if buys is None and hasattr(resp, "model_dump"):
-        buys = resp.model_dump().get("media_buys", [])
+    buys = wire_field(ctx, "media_buys")
     return buys or []
 
 

--- a/tests/bdd/steps/domain/uc019_query_media_buys.py
+++ b/tests/bdd/steps/domain/uc019_query_media_buys.py
@@ -1308,7 +1308,7 @@ def _get_media_buys(ctx: dict) -> list:
     if resp is None and "error" in ctx:
         raise AssertionError(f"Expected a response but got error: {ctx['error']}")
     buys = wire_field(ctx, "media_buys")
-    return buys or []
+    return wire_objects(buys or [])
 
 
 @then(parsers.parse('the response should include media buy "{mb_id}" with status "{status}"'))

--- a/tests/bdd/steps/domain/uc019_query_media_buys.py
+++ b/tests/bdd/steps/domain/uc019_query_media_buys.py
@@ -161,9 +161,9 @@ def given_today_is(ctx: dict, today_str: str) -> None:
     """Override 'today' for status computation via testing_context.mock_time.
 
     Production ``get_media_buys`` honors ``identity.testing_context.mock_time``
-    (parity with delivery). For e2e_rest, RestE2EDispatcher forwards
-    ``X-Mock-Time`` from the same clock. Seed helpers still read
-    ``ctx["mock_today"]``.
+    (same mock clock as delivery under X-Mock-Time). For e2e_rest,
+    RestE2EDispatcher forwards ``X-Mock-Time`` from ``env.mock_time``.
+    Seed helpers still read ``ctx["mock_today"]``.
     """
     from datetime import UTC, datetime
 
@@ -172,16 +172,10 @@ def given_today_is(ctx: dict, today_str: str) -> None:
     fake_now = datetime(parsed.year, parsed.month, parsed.day, 12, 0, 0, tzinfo=UTC)
 
     env = ctx["env"]
-    env._mock_time = fake_now
-    # Rebuild identities so all transports carry the simulation clock.
-    env._identity_cache.clear()
-    if "_identity" in env.__dict__:
-        del env.__dict__["_identity"]
-    # Eagerly stamp the default identity so in-process REST overrides /
-    # IMPL calls see mock_time even before the next identity_for().
+    env.set_mock_time(fake_now)
+    # Eagerly build default identity so in-process calls see mock_time
+    # before the next identity_for() without private cache surgery.
     _ = env.identity
-    if env.identity.testing_context is not None:
-        env.identity.testing_context.mock_time = fake_now
 
 
 # Pre-flight window (far future) for persisted-status seeds that carry no

--- a/tests/bdd/steps/domain/uc019_query_media_buys.py
+++ b/tests/bdd/steps/domain/uc019_query_media_buys.py
@@ -158,26 +158,31 @@ def given_principal_owns_media_buy_with_dates(ctx: dict, principal_id: str, mb_i
 
 @given(parsers.parse('today is "{today_str}"'))
 def given_today_is(ctx: dict, today_str: str) -> None:
-    """Override 'today' for status computation.
+    """Override 'today' for status computation via testing_context.mock_time.
 
-    Production code uses ``datetime.now(UTC).date()`` in
-    ``src.core.tools.media_buy_list`` (line 116). We patch ``datetime``
-    in that module so ``now()`` returns a datetime whose ``.date()``
-    yields the desired date.
+    Production ``get_media_buys`` honors ``identity.testing_context.mock_time``
+    (parity with delivery). For e2e_rest, RestE2EDispatcher forwards
+    ``X-Mock-Time`` from the same clock. Seed helpers still read
+    ``ctx["mock_today"]``.
     """
     from datetime import UTC, datetime
-    from unittest.mock import patch
 
     parsed = date.fromisoformat(today_str)
     ctx["mock_today"] = today_str
-
-    # Build a datetime that corresponds to the target date
     fake_now = datetime(parsed.year, parsed.month, parsed.day, 12, 0, 0, tzinfo=UTC)
 
-    patcher = patch("src.core.tools.media_buy_list.datetime", wraps=datetime)
-    mock_dt = patcher.start()
-    mock_dt.now.return_value = fake_now
-    ctx.setdefault("_patchers", []).append(patcher)
+    env = ctx.get("env")
+    if env is not None:
+        env._mock_time = fake_now
+        # Rebuild identities so all transports carry the simulation clock.
+        env._identity_cache.clear()
+        if "_identity" in env.__dict__:
+            del env.__dict__["_identity"]
+        # Eagerly stamp the default identity so in-process REST overrides /
+        # IMPL calls see mock_time even before the next identity_for().
+        _ = env.identity
+        if env.identity.testing_context is not None:
+            env.identity.testing_context.mock_time = fake_now
 
 
 # Pre-flight window (far future) for persisted-status seeds that carry no

--- a/tests/bdd/steps/domain/uc019_query_media_buys.py
+++ b/tests/bdd/steps/domain/uc019_query_media_buys.py
@@ -171,18 +171,17 @@ def given_today_is(ctx: dict, today_str: str) -> None:
     ctx["mock_today"] = today_str
     fake_now = datetime(parsed.year, parsed.month, parsed.day, 12, 0, 0, tzinfo=UTC)
 
-    env = ctx.get("env")
-    if env is not None:
-        env._mock_time = fake_now
-        # Rebuild identities so all transports carry the simulation clock.
-        env._identity_cache.clear()
-        if "_identity" in env.__dict__:
-            del env.__dict__["_identity"]
-        # Eagerly stamp the default identity so in-process REST overrides /
-        # IMPL calls see mock_time even before the next identity_for().
-        _ = env.identity
-        if env.identity.testing_context is not None:
-            env.identity.testing_context.mock_time = fake_now
+    env = ctx["env"]
+    env._mock_time = fake_now
+    # Rebuild identities so all transports carry the simulation clock.
+    env._identity_cache.clear()
+    if "_identity" in env.__dict__:
+        del env.__dict__["_identity"]
+    # Eagerly stamp the default identity so in-process REST overrides /
+    # IMPL calls see mock_time even before the next identity_for().
+    _ = env.identity
+    if env.identity.testing_context is not None:
+        env.identity.testing_context.mock_time = fake_now
 
 
 # Pre-flight window (far future) for persisted-status seeds that carry no

--- a/tests/factories/principal.py
+++ b/tests/factories/principal.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Any
 
 import factory
@@ -35,6 +36,7 @@ class PrincipalFactory(factory.alchemy.SQLAlchemyModelFactory):
         tenant_id: str = "test_tenant",
         protocol: str = "mcp",
         dry_run: bool = False,
+        mock_time: datetime | None = None,
         auth_token: str | None = None,
         tenant: Any = _UNSET,
         testing_context: AdCPTestContext | None = None,
@@ -59,7 +61,7 @@ class PrincipalFactory(factory.alchemy.SQLAlchemyModelFactory):
         if testing_context is None:
             testing_context = AdCPTestContext(
                 dry_run=dry_run,
-                mock_time=None,
+                mock_time=mock_time,
                 jump_to_event=None,
                 test_session_id=None,
             )

--- a/tests/harness/_base.py
+++ b/tests/harness/_base.py
@@ -585,6 +585,8 @@ class BaseTestEnv:
         Coerce through ``AdCPTestContext`` so naive datetimes become UTC-aware
         before header serialization (``apply_testing_hook_headers``).
         """
+        from src.core.testing_hooks import AdCPTestContext
+
         if mock_time is None:
             self._mock_time = None
         else:

--- a/tests/harness/_base.py
+++ b/tests/harness/_base.py
@@ -493,7 +493,6 @@ class BaseTestEnv:
 
         protocol = TRANSPORT_PROTOCOL[transport]
         if protocol not in self._identity_cache:
-            from src.core.testing_hooks import AdCPTestContext
             from tests.factories.principal import PrincipalFactory
 
             # In integration mode, commit factory data first so the token
@@ -510,10 +509,7 @@ class BaseTestEnv:
                 protocol=protocol,
                 dry_run=self._dry_run,
                 auth_token=auth_token,
-                testing_context=AdCPTestContext(
-                    dry_run=self._dry_run,
-                    mock_time=self._mock_time,
-                ),
+                mock_time=self._mock_time,
                 **self._tenant_overrides,
             )
         return self._identity_cache[protocol]
@@ -539,6 +535,17 @@ class BaseTestEnv:
         ).first()
         return token
 
+    def _invalidate_identity(self) -> None:
+        """Drop cached identities so the next access re-stamps from env fields.
+
+        All public writers (``switch_principal``, ``switch_tenant``,
+        ``set_mock_time``) call this — never poke ``_identity_cache`` /
+        ``__dict__["_identity"]`` from step functions.
+        """
+        self._identity_cache.clear()
+        if "_identity" in self.__dict__:
+            del self.__dict__["_identity"]
+
     def switch_principal(self, principal_id: str) -> None:
         """Re-point the env at *principal_id*, clearing cached identity.
 
@@ -549,8 +556,8 @@ class BaseTestEnv:
         picking up a principal row committed after the env was created (in
         integration mode this re-runs the auth-token lookup).
         """
-        self._identity_cache.clear()
         self._principal_id = principal_id
+        self._invalidate_identity()
 
     def switch_tenant(self, tenant_id: str) -> None:
         """Re-point the env at *tenant_id*, clearing cached identity.
@@ -561,8 +568,8 @@ class BaseTestEnv:
         Clearing the cache forces the next identity build to resolve the auth
         token against the new tenant's principal rows.
         """
-        self._identity_cache.clear()
         self._tenant_id = tenant_id
+        self._invalidate_identity()
 
     @property
     def mock_time(self) -> datetime | None:
@@ -575,11 +582,14 @@ class BaseTestEnv:
         Public mutator for Given ``today is …``: steps must not poke
         ``_mock_time`` / ``_identity_cache`` / ``__dict__["_identity"]``.
         ``identity_for`` rebuilds ``AdCPTestContext(mock_time=…)`` on next access.
+        Coerce through ``AdCPTestContext`` so naive datetimes become UTC-aware
+        before header serialization (``apply_testing_hook_headers``).
         """
-        self._mock_time = mock_time
-        self._identity_cache.clear()
-        if "_identity" in self.__dict__:
-            del self.__dict__["_identity"]
+        if mock_time is None:
+            self._mock_time = None
+        else:
+            self._mock_time = AdCPTestContext(mock_time=mock_time).mock_time
+        self._invalidate_identity()
 
     @property
     def identity(self) -> ResolvedIdentity:

--- a/tests/harness/_base.py
+++ b/tests/harness/_base.py
@@ -441,6 +441,8 @@ class BaseTestEnv:
         self._principal_id = principal_id
         self._tenant_id = tenant_id
         self._dry_run = dry_run
+        # Controllable simulation clock for Given "today is …" (e2e_rest X-Mock-Time).
+        self._mock_time: datetime | None = None
         # E2E mode: bind factories to the live server's DB so the HTTP-reached
         # server sees Given-step data. Explicit database_url wins; else the
         # e2e_config's postgres_url. None => normal cached/integration engine.
@@ -491,6 +493,7 @@ class BaseTestEnv:
 
         protocol = TRANSPORT_PROTOCOL[transport]
         if protocol not in self._identity_cache:
+            from src.core.testing_hooks import AdCPTestContext
             from tests.factories.principal import PrincipalFactory
 
             # In integration mode, commit factory data first so the token
@@ -507,6 +510,10 @@ class BaseTestEnv:
                 protocol=protocol,
                 dry_run=self._dry_run,
                 auth_token=auth_token,
+                testing_context=AdCPTestContext(
+                    dry_run=self._dry_run,
+                    mock_time=self._mock_time,
+                ),
                 **self._tenant_overrides,
             )
         return self._identity_cache[protocol]

--- a/tests/harness/_base.py
+++ b/tests/harness/_base.py
@@ -565,6 +565,23 @@ class BaseTestEnv:
         self._tenant_id = tenant_id
 
     @property
+    def mock_time(self) -> datetime | None:
+        """Public simulation clock set by ``set_mock_time`` / Given today is."""
+        return self._mock_time
+
+    def set_mock_time(self, mock_time: datetime | None) -> None:
+        """Set the controllable simulation clock and invalidate cached identities.
+
+        Public mutator for Given ``today is …``: steps must not poke
+        ``_mock_time`` / ``_identity_cache`` / ``__dict__["_identity"]``.
+        ``identity_for`` rebuilds ``AdCPTestContext(mock_time=…)`` on next access.
+        """
+        self._mock_time = mock_time
+        self._identity_cache.clear()
+        if "_identity" in self.__dict__:
+            del self.__dict__["_identity"]
+
+    @property
     def identity(self) -> ResolvedIdentity:
         """Default identity (protocol='mcp'). Backward-compatible.
 
@@ -815,7 +832,7 @@ class BaseTestEnv:
             apply_testing_hook_headers(
                 headers,
                 a2a_identity,
-                fallback_mock_time=self._mock_time,
+                fallback_mock_time=self.mock_time,
             )
             server_context = ServerCallContext(
                 state={AUTH_CONTEXT_STATE_KEY: AuthContext(auth_token=auth_token, headers=headers)}
@@ -972,7 +989,7 @@ class BaseTestEnv:
             apply_testing_hook_headers(
                 headers,
                 mcp_identity,
-                fallback_mock_time=self._mock_time,
+                fallback_mock_time=self.mock_time,
             )
 
             async def _call():

--- a/tests/harness/_base.py
+++ b/tests/harness/_base.py
@@ -804,11 +804,19 @@ class BaseTestEnv:
 
         if auth_token:
             from src.core.auth_context import AUTH_CONTEXT_STATE_KEY, AuthContext
+            from tests.harness.dispatchers import apply_testing_hook_headers
 
             headers = {
                 "x-adcp-auth": auth_token,
                 "x-adcp-tenant": a2a_identity.tenant_id or "",
             }
+            # Real-token path re-resolves identity via from_headers — forward
+            # X-Mock-Time / X-Dry-Run or UC-019 "today is" is wall-clock only.
+            apply_testing_hook_headers(
+                headers,
+                a2a_identity,
+                fallback_mock_time=self._mock_time,
+            )
             server_context = ServerCallContext(
                 state={AUTH_CONTEXT_STATE_KEY: AuthContext(auth_token=auth_token, headers=headers)}
             )
@@ -955,10 +963,17 @@ class BaseTestEnv:
             # Patch get_http_headers in BOTH modules that import it:
             # transport_helpers (called by resolve_identity_from_context) and
             # mcp_auth_middleware (called for context_id extraction).
+            from tests.harness.dispatchers import apply_testing_hook_headers
+
             headers = {
                 "x-adcp-auth": auth_token,
                 "x-adcp-tenant": mcp_identity.tenant_id or "",
             }
+            apply_testing_hook_headers(
+                headers,
+                mcp_identity,
+                fallback_mock_time=self._mock_time,
+            )
 
             async def _call():
                 mock_th = patch("src.core.transport_helpers.get_http_headers", return_value=headers)

--- a/tests/harness/address_table.py
+++ b/tests/harness/address_table.py
@@ -82,7 +82,6 @@ REST_TOOL_ALIASES: dict[str, str] = {}
 REST_ABSENT_TOOLS: frozenset[str] = frozenset(
     {
         "complete_task",
-        "get_media_buys",
         "get_task",
         "list_tasks",
     }

--- a/tests/harness/client.py
+++ b/tests/harness/client.py
@@ -283,6 +283,13 @@ def _deliver_e2e_rest(env: BaseTestEnv, address: ToolAddress, wrapped: dict[str,
 
     resolved_identity = env.identity_for(Transport.E2E_REST) if identity is NO_IDENTITY_OVERRIDE else identity
     headers = {"Content-Type": "application/json", **e2e_identity_headers(resolved_identity)}
+    from tests.harness.dispatchers import apply_testing_hook_headers
+
+    apply_testing_hook_headers(
+        headers,
+        resolved_identity,
+        fallback_mock_time=getattr(env, "mock_time", None),
+    )
     method = address.method or "post"
 
     with httpx.Client(base_url=env.e2e_config.base_url, timeout=30) as client:

--- a/tests/harness/dispatchers.py
+++ b/tests/harness/dispatchers.py
@@ -53,6 +53,29 @@ if TYPE_CHECKING:
 #     catch-all arm that may fire before anything was sent declares False.
 
 
+def apply_testing_hook_headers(
+    headers: dict[str, str],
+    identity: Any | None = None,
+    *,
+    fallback_mock_time: Any | None = None,
+) -> None:
+    """Mutate *headers* with ``X-Dry-Run`` / ``X-Mock-Time`` from identity or env.
+
+    Production A2A/REST/MCP resolve ``AdCPTestContext.from_headers`` — in-process
+    harness paths that rebuild auth headers (real-token A2A/MCP, e2e_rest) must
+    forward the same hooks or ``given_today_is`` is inert and flight status
+    grades against wall clock.
+    """
+    tc = getattr(identity, "testing_context", None) if identity is not None else None
+    if tc is not None and getattr(tc, "dry_run", False):
+        headers["x-dry-run"] = "true"
+    mock_time = getattr(tc, "mock_time", None) if tc is not None else None
+    if mock_time is None:
+        mock_time = fallback_mock_time
+    if mock_time is not None:
+        headers["x-mock-time"] = mock_time.isoformat().replace("+00:00", "Z")
+
+
 class ImplDispatcher:
     """Dispatch via direct ``_impl()`` call.
 

--- a/tests/harness/dispatchers.py
+++ b/tests/harness/dispatchers.py
@@ -26,6 +26,7 @@ from tests.harness.transport import (
 )
 
 if TYPE_CHECKING:
+    from src.core.resolved_identity import ResolvedIdentity
     from tests.harness._base import BaseTestEnv
 
 # _envelope_from_adcp_error lives in transport.py, not here — both this module
@@ -55,9 +56,9 @@ if TYPE_CHECKING:
 
 def apply_testing_hook_headers(
     headers: dict[str, str],
-    identity: Any | None = None,
+    identity: ResolvedIdentity | None = None,
     *,
-    fallback_mock_time: Any | None = None,
+    fallback_mock_time: datetime | None = None,
 ) -> None:
     """Mutate *headers* with ``X-Dry-Run`` / ``X-Mock-Time`` from identity or env.
 
@@ -66,10 +67,10 @@ def apply_testing_hook_headers(
     forward the same hooks or ``given_today_is`` is inert and flight status
     grades against wall clock.
     """
-    tc = getattr(identity, "testing_context", None) if identity is not None else None
-    if tc is not None and getattr(tc, "dry_run", False):
+    tc = identity.testing_context if identity is not None else None
+    if tc is not None and tc.dry_run:
         headers["x-dry-run"] = "true"
-    mock_time = getattr(tc, "mock_time", None) if tc is not None else None
+    mock_time = tc.mock_time if tc is not None else None
     if mock_time is None:
         mock_time = fallback_mock_time
     if mock_time is not None:

--- a/tests/harness/media_buy_create_list.py
+++ b/tests/harness/media_buy_create_list.py
@@ -13,23 +13,20 @@ and route by request type. The get_media_buys dispatch itself is inherited from
 ``MediaBuyListDispatchMixin`` rather than re-implemented, so this env and
 ``MediaBuyListEnv`` grade the same tool through the same code.
 
-REST is intentionally NOT routed: UC-019 is a ``_NO_REST_UC`` (get_media_buys has
-no REST route, tests/bdd/conftest.py:2885-2895), so the create and list REST
-bodies never both apply in one scenario and wiring an ungraded second REST path
-would be speculative. The inherited create REST dispatch is left untouched.
+REST is routed: ``POST /api/v1/media-buys/query`` (PR #1950 / #1830). List requests
+use ``MediaBuyListEnv``'s body builder + query endpoint; everything else falls
+through to the inherited create (or DualEnv update) REST path via ``super()``.
 
-GH #1900
+GH #1900 / #1830
 """
 
 from __future__ import annotations
 
 from typing import Any
 
-import pytest
-
 from src.core.schemas._base import GetMediaBuysRequest
 from tests.harness.media_buy_create import MediaBuyCreateEnv
-from tests.harness.media_buy_list import MediaBuyListDispatchMixin
+from tests.harness.media_buy_list import MediaBuyListDispatchMixin, MediaBuyListEnv
 from tests.harness.transport import DeliverResult
 
 
@@ -53,6 +50,8 @@ class MediaBuyCreateListEnv(MediaBuyListDispatchMixin, MediaBuyCreateEnv):
     and the inherited create patches target the create module only.
     """
 
+    _active_list: bool = False
+
     def call_impl(self, **kwargs: Any) -> Any:
         if _is_list_request(kwargs):
             return self._call_list_impl(**kwargs)
@@ -74,47 +73,55 @@ class MediaBuyCreateListEnv(MediaBuyListDispatchMixin, MediaBuyCreateEnv):
             return self._deliver_list_mcp(**kwargs)
         return super().deliver_mcp(**kwargs)
 
+    def _run_rest_request(self, endpoint: str, **kwargs: Any) -> Any:
+        """In-process RestDispatcher reads ``REST_ENDPOINT`` before body build.
+
+        Mirror ``MediaBuyDualEnv``: re-select the list query URL from request
+        content here so a stale create-collection endpoint cannot be POSTed.
+        Bypass DualEnv's update router (when present in MRO) by calling
+        ``MediaBuyCreateEnv`` directly for the list arm.
+        """
+        self._active_list = _is_list_request(kwargs)
+        if self._active_list:
+            return MediaBuyCreateEnv._run_rest_request(self, "/api/v1/media-buys/query", **kwargs)
+        self._active_list = False
+        return super()._run_rest_request(endpoint, **kwargs)
+
     def build_rest_body(self, **kwargs: Any) -> dict[str, Any]:
-        """Refuse to build a REST body for a list request; delegate everything else.
+        """List → MediaBuyListEnv body; else ``super()`` (create or DualEnv update).
 
-        ``get_media_buys`` has no REST route — ``src/routes/api_v1.py`` routes
-        create, update and delivery for media buys, nothing for the list. Without this
-        the inherited create builder handles the call: it is create-shaped, so it dies
-        inside ``_restore_creative_ids`` reading a ``packages`` attribute the list
-        request does not have, and the test grades a different call than it names.
-
-        Scope, precisely: this refuses the ``req=GetMediaBuysRequest(...)`` arm, keyed
-        on the same ``_is_list_request`` discriminator ``call_impl``/``call_a2a``/
-        ``call_mcp`` use. A flat-kwargs call still routes to create here exactly as it
-        does on every other transport of this env — consistent, not a REST-specific
-        mis-dispatch, and deliberately left alone.
-
-        The refusal is declared HERE, per env, and deliberately not derived from the
-        route table. The two staleness failures are not symmetric: a route DELETED
-        while deriving means the REST arm silently stops being graded and the suite
-        stays green, whereas a route ADDED while declaring means the first REST call
-        fails at this line — which is the line that must change anyway, since the list
-        mixin's body builder is flat-kwargs-only and could not dispatch correctly on
-        its own.
-
-        ``pytest.fail`` and not ``NotImplementedError`` or ``AssertionError``, because
-        this refusal has to survive two launderers to be loud at all:
-        ``tests/bdd/conftest.py`` converts a ``NotImplementedError`` raised in a call
-        phase into a skip + xfail — the silent matrix-shrink this exists to prevent —
-        and ``RestDispatcher.dispatch`` wraps the whole dispatch, this builder
-        included, in ``except Exception`` and returns the refusal as an error-shaped
-        result indistinguishable from a production error response. ``Failed`` derives
-        from ``BaseException`` and is not a ``NotImplementedError``, so neither can
-        eat it. Do not "simplify" the dialect.
+        RestE2EDispatcher reads ``REST_ENDPOINT`` after ``build_rest_body``, so the
+        ``_active_list`` flag must be set here for e2e_rest (same pattern as
+        ``MediaBuyDualEnv._active_update``).
         """
         if _is_list_request(kwargs):
-            pytest.fail(
-                f"{type(self).__name__} cannot build a REST body for a get_media_buys request: "
-                "the tool has no REST route. Dispatch it on A2A or MCP, or add the route "
-                "and a list body builder here together.",
-                pytrace=False,
+            self._active_list = True
+            req = kwargs["req"]
+            return MediaBuyListEnv.build_rest_body(
+                self,
+                media_buy_ids=req.media_buy_ids,
+                status_filter=req.status_filter,
+                include_snapshot=bool(kwargs.get("include_snapshot", False)),
+                account=getattr(req, "account", None),
+                context=getattr(req, "context", None),
             )
+        self._active_list = False
         # super(), not an explicit parent call: MediaBuyCreateUpdateListEnv resolves
         # this through MediaBuyDualEnv's stateful create/update routing, which naming
         # a parent directly would bypass.
         return super().build_rest_body(**kwargs)
+
+    @property
+    def REST_ENDPOINT(self) -> str:  # noqa: N802 — matches the inherited class-attr name
+        """List → query; update (DualEnv) → per-id PUT URL; else create collection."""
+        if self._active_list:
+            return "/api/v1/media-buys/query"
+        if getattr(self, "_active_update", False):
+            return f"/api/v1/media-buys/{getattr(self, '_update_target_id', 'NOT_SEEDED')}"
+        return "/api/v1/media-buys"
+
+    def parse_rest_response(self, data: dict[str, Any]) -> Any:
+        if self._active_list:
+            self._active_list = False
+            return MediaBuyListEnv.parse_rest_response(self, data)
+        return super().parse_rest_response(data)

--- a/tests/harness/media_buy_create_update_list.py
+++ b/tests/harness/media_buy_create_update_list.py
@@ -14,13 +14,12 @@ routes ``req=UpdateMediaBuyRequest`` to the update dispatch and falls through to
 create. Inheriting both linearizes to list -> update -> create, so a third copy of
 either discriminator would be duplication (CLAUDE.md DRY invariant).
 
-REST is intentionally NOT routed, for the same reason ``MediaBuyCreateListEnv``
-gives: get_media_buys has no REST route in the composite's UC (tests/bdd/conftest.py
-``_NO_REST_UC``), so the create/update/list REST bodies never all apply in one
-flow. Use the A2A and MCP wire transports, which stash the real
-``wire_response``.
+REST is routed for all three arms: create collection, update per-id PUT, and
+get_media_buys ``POST /api/v1/media-buys/query`` (via ``MediaBuyCreateListEnv``).
+Use the A2A and MCP wire transports when grading envelope bytes that those
+pipelines stash as ``wire_response``.
 
-GH #1941
+GH #1941 / #1830
 """
 
 from __future__ import annotations

--- a/tests/harness/media_buy_list.py
+++ b/tests/harness/media_buy_list.py
@@ -109,15 +109,10 @@ class MediaBuyListEnv(MediaBuyListDispatchMixin, IntegrationEnv):
     RESPONSE_MODEL = GetMediaBuysResponse
 
     EXTERNAL_PATCHES: dict[str, str] = {}
-    # No REST_ENDPOINT, deliberately: get_media_buys has NO REST route. One was
-    # declared here — `/api/v1/media-buys/query` — for a path that exists nowhere in
-    # src/, so the machinery read as though the transport were available and a REST
-    # parametrization would have failed as if production were broken rather than as
-    # if the route were absent. `src/routes/api_v1.py` exposes only POST /media-buys,
-    # PUT /media-buys/{id} and POST /media-buys/delivery.
-    #
-    # The body builder and response parser below OUTLIVE that endpoint on purpose;
-    # see their docstrings.
+    REST_ENDPOINT = "/api/v1/media-buys/query"
+    # POST /api/v1/media-buys/query in src/routes/api_v1.py — REST transport for
+    # get_media_buys (added GH #1830). The body builder and response parser below
+    # were kept through the no-route period; see their docstrings.
 
     def _configure_mocks(self) -> None:
         """No mocks needed for read-only list operation."""
@@ -167,13 +162,12 @@ class MediaBuyListEnv(MediaBuyListDispatchMixin, IntegrationEnv):
     def build_rest_body(self, **kwargs: Any) -> dict[str, Any]:
         """Convert kwargs to GetMediaBuysBody shape for REST POST.
 
-        Kept even though this env declares no REST_ENDPOINT, and NOT equivalent to
-        the inherited default: ``BaseTestEnv.build_rest_body`` serializes a ``req``
-        model wholesale via ``model_dump(mode="json", exclude_none=True)`` and returns
-        ``{}`` when there is no ``req`` — it cannot shape the flat kwargs this tool is
-        called with. Deleting the override would silently substitute that generic
-        behavior the moment a get_media_buys REST route is added and REST_ENDPOINT is
-        restored, which is exactly when a wrong body is hardest to notice.
+        NOT equivalent to the inherited default: ``BaseTestEnv.build_rest_body``
+        serializes a ``req`` model wholesale via ``model_dump(mode="json",
+        exclude_none=True)`` and returns ``{}`` when there is no ``req`` — it cannot
+        shape the flat kwargs this tool is called with. Deleting the override would
+        silently substitute that generic behavior, which is hardest to notice when
+        the REST route is live.
         """
         body: dict[str, Any] = {}
         for key in ("media_buy_ids", "status_filter", "account_id", "context"):

--- a/tests/harness/test_address_table.py
+++ b/tests/harness/test_address_table.py
@@ -399,13 +399,15 @@ class TestCrossRegistryConsistencyGuard:
         invariant, CLAUDE.md)."""
         table = AddressTable()
         rest_names = table.all_tools(Transport.REST)
-        assert len(rest_names) == 12, rest_names
+        # 13 includes get_media_buys (POST /api/v1/media-buys/query — PR #1950 / #1830).
+        assert len(rest_names) == 13, rest_names
+        assert "get_media_buys" in rest_names
         assert "get_adcp_capabilities" in rest_names  # handler is named after its tool
         assert "get_capabilities" not in rest_names  # raw handler name, not a tool identity
         for absent_tool in REST_ABSENT_TOOLS:
             assert absent_tool not in rest_names
         assert REST_TOOL_ALIASES == {}
-        assert REST_ABSENT_TOOLS == frozenset({"complete_task", "get_media_buys", "get_task", "list_tasks"})
+        assert REST_ABSENT_TOOLS == frozenset({"complete_task", "get_task", "list_tasks"})
 
 
 class TestPathParamRegex:

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -34,6 +34,7 @@ def assert_resolve_auth_dep_passes_token(auth_token: str = "pre-extracted-token"
         auth_token=auth_token,
         require_valid_token=False,
         protocol="rest",
+        testing_context=None,
     )
 
 

--- a/tests/integration/test_harness_rest_refusal.py
+++ b/tests/integration/test_harness_rest_refusal.py
@@ -1,50 +1,21 @@
-"""A transport the harness cannot dispatch must refuse loudly, not dispatch something else.
+"""REST routing for create+list composite — list hits query, create stays collection.
 
-``MediaBuyCreateListEnv`` routes ``req=GetMediaBuysRequest`` to the get_media_buys
-dispatch on IMPL/A2A/MCP, but declares no REST body of its own — so a REST list
-request falls through to ``MediaBuyCreateEnv.build_rest_body``, a *create*-shaped
-builder. There is no get_media_buys REST route to fall through to: ``src/routes/api_v1.py``
-exposes only ``POST /media-buys`` (create), ``PUT /media-buys/{id}`` (update) and
-``POST /media-buys/delivery``.
+``MediaBuyCreateListEnv`` routes ``req=GetMediaBuysRequest`` to get_media_buys on
+every transport, including REST via ``POST /api/v1/media-buys/query`` (PR #1950 /
+#1830). Before that route existed the list REST arm refused loudly with
+``pytest.fail`` so a create-shaped body could not silently POST the collection;
+that refusal is gone now that the route + list body builder are wired together.
 
-What the inherited create builder does with a list request today, measured at HEAD
-629230123 — and deliberately NOT what these tests assert, because both arms are
-accidents rather than a contract:
+What still must not regress:
 
-  * ``req=`` arm: ``AttributeError: 'GetMediaBuysRequest' object has no attribute
-    'packages'``, raised inside ``_restore_creative_ids`` (media_buy_create.py:54
-    via :406) — an obscure crash in a create-only helper, not a refusal.
-  * flat-kwargs arm: builds ``{"media_buy_ids": [...], "idempotency_key": ...}`` and
-    POSTs it, create-SHAPED, to the create collection ``/api/v1/media-buys``.
+  * List REST uses the query endpoint and list-shaped body (not create collection).
+  * Non-list arms still ``super()`` into DualEnv create/update routing
+    (``MediaBuyCreateUpdateListEnv``).
+  * Weaker refusal dialects (``NotImplementedError`` / ``AssertionError``) remain
+    swallowed by ``RestDispatcher`` — pinned so a future "simplify back to
+    NotImplementedError" cannot silently shrink the matrix.
 
-The obligation these tests grade is the refusal itself, and — the part that is easy
-to get wrong — that the refusal SURVIVES to the caller. Two launderers sit between
-the raise and the report:
-
-  (a) ``tests/bdd/conftest.py:103-105`` converts any ``NotImplementedError`` raised
-      in a BDD call phase into ``report.outcome = "skipped"`` + ``wasxfail``. A
-      NotImplementedError refusal is therefore a silent shrink of the test matrix.
-  (b) ``RestDispatcher.dispatch`` (dispatchers.py:151-181) wraps the whole in-process
-      REST dispatch — INCLUDING ``env.build_rest_body`` — in ``except Exception ->
-      TransportResult(error=exc)``. An ``Exception``-derived refusal comes back as an
-      error-shaped result, indistinguishable from a production error response, so any
-      Then step that only checks "an error was returned" goes GREEN on the harness
-      refusing to dispatch.
-
-``pytest.fail(..., pytrace=False)`` raises ``_pytest.outcomes.Failed``, whose MRO is
-``(Failed, OutcomeException, BaseException)``: it is not an ``Exception`` (escapes (b))
-and not a ``NotImplementedError`` (escapes (a)). ``test_weaker_refusal_dialects_are_swallowed``
-below is the mechanical demonstration, against the real dispatcher.
-
-Scope note, stated rather than faked: launderer (a) is graded here by the type
-property only, not end to end. UC-019 is in ``_NO_REST_UC_TAG_PREFIXES``
-(tests/bdd/conftest.py:2833), so its scenarios are parametrized a2a+mcp and the REST
-arm never runs under BDD at all — no BDD test reaches this seam, and driving the
-``pytest_runtest_makereport`` hook for real would need a nested pytest run rather than
-a test. The integration pin in this file is the grading path for the seam; the BDD
-conftest hook does not apply to it.
-
-GH #1941 (review finding F18); precedent for shape: tests/integration/test_harness_wire_response.py
+GH #1941 (review finding F18); GH #1830 REST query enablement.
 """
 
 from __future__ import annotations
@@ -62,52 +33,26 @@ pytestmark = [pytest.mark.integration, pytest.mark.requires_db]
 
 
 @pytest.mark.requires_db
-class TestUnroutedRestDispatchRefuses:
-    """The un-routed REST arm of the create+list env refuses instead of dispatching."""
+class TestRestListDispatchRoutesToQuery:
+    """List REST arm hits /media-buys/query with a list-shaped body."""
 
-    def test_rest_list_request_refuses_through_call_via(self, integration_db):
-        """A REST get_media_buys call raises out of ``call_via``, it does not return a result.
+    def test_rest_list_request_routes_through_call_via(self, integration_db):
+        """A REST get_media_buys call dispatches — it does not pytest.fail refuse.
 
-        Driven through ``env.call_via(Transport.REST, ...)`` — the whole dispatch — and
-        NOT through a direct ``build_rest_body()`` call. A direct-call pin passes while
-        launderer (b) still eats the refusal one call-frame over, which is greening the
-        cited test while the disease persists.
-
-        ``pytest.raises`` is what mechanically locks the dialect: downgrade the refusal
-        to ``NotImplementedError`` or ``AssertionError`` and ``RestDispatcher`` swallows
-        it into an error-shaped ``TransportResult``, nothing propagates, and this test
-        reddens with DID NOT RAISE.
-
-        The message must name what refused and why, so the reader of a failing run does
-        not have to re-derive the route table: the tool and the transport.
+        Driven through ``env.call_via(Transport.REST, ...)`` so endpoint selection
+        and body build both run (RestDispatcher reads endpoint before body build;
+        ``_run_rest_request`` must re-select the query URL from request content).
         """
         with MediaBuyCreateListEnv() as env:
-            with pytest.raises(pytest.fail.Exception) as excinfo:
-                env.call_via(Transport.REST, req=GetMediaBuysRequest(media_buy_ids=["mb_absent"]))
+            body = env.build_rest_body(req=GetMediaBuysRequest(media_buy_ids=["mb_absent"]))
+            assert env.REST_ENDPOINT == "/api/v1/media-buys/query"
+            assert body.get("media_buy_ids") == ["mb_absent"]
+            assert "packages" not in body
 
-        message = str(excinfo.value)
-        assert "get_media_buys" in message, f"refusal does not name the tool it refused: {message!r}"
-        assert "REST" in message or "rest" in message, f"refusal does not name the transport: {message!r}"
+            result = env.call_via(Transport.REST, req=GetMediaBuysRequest(media_buy_ids=["mb_absent"]))
 
-    def test_refusal_escapes_both_launderers_by_type(self):
-        """The refusal type is outside the reach of both launderers on the dispatch path.
-
-        This is the property the choice of ``pytest.fail`` rests on, pinned so a future
-        "simplification" back to ``NotImplementedError`` (which re-arms both) cannot pass
-        silently. Launderer (b) is additionally demonstrated end-to-end against the real
-        dispatcher in ``test_weaker_refusal_dialects_are_swallowed``.
-        """
-        failed = pytest.fail.Exception
-        assert not issubclass(failed, Exception), (
-            f"{failed.__name__} is an Exception subclass — RestDispatcher's "
-            "`except Exception` (dispatchers.py:180) would swallow the refusal into an "
-            "error-shaped TransportResult"
-        )
-        assert not issubclass(failed, NotImplementedError), (
-            f"{failed.__name__} is a NotImplementedError subclass — tests/bdd/conftest.py:103-105 "
-            "would convert the refusal into skipped + wasxfail"
-        )
-        assert issubclass(failed, BaseException)
+        assert result.error is None, f"list REST dispatch failed: {result.error!r}"
+        assert result.payload is not None
 
 
 class _RefusalDialectEnv(MediaBuyCreateListEnv):
@@ -121,7 +66,7 @@ class _RefusalDialectEnv(MediaBuyCreateListEnv):
 
 @pytest.mark.requires_db
 class TestRefusalDialectSurvivesTheDispatcher:
-    """Why the dialect is ``pytest.fail`` and not the ``_outcome_helpers`` AssertionError."""
+    """Why a harness refusal must use ``pytest.fail`` and not Exception subclasses."""
 
     @pytest.mark.parametrize(
         "refusal",
@@ -131,14 +76,7 @@ class TestRefusalDialectSurvivesTheDispatcher:
         ],
     )
     def test_weaker_refusal_dialects_are_swallowed(self, integration_db, refusal):
-        """An ``Exception``-derived refusal returns as an error-shaped result, not a raise.
-
-        The refusal becomes ``TransportResult(error=...)`` — the same shape a real
-        production error response produces — so a Then step asserting only "an error was
-        returned" cannot tell "the seller rejected the request" from "the harness declined
-        to dispatch". That is the launderer the pin above exists to route around, measured
-        here against the production ``RestDispatcher`` rather than argued.
-        """
+        """An ``Exception``-derived refusal returns as an error-shaped result, not a raise."""
         env_class = type("_Dialect", (_RefusalDialectEnv,), {"refusal": refusal})
         with env_class() as env:
             result = env.call_via(Transport.REST, req=GetMediaBuysRequest(media_buy_ids=["mb_absent"]))
@@ -162,6 +100,19 @@ class TestRefusalDialectSurvivesTheDispatcher:
             with pytest.raises(pytest.fail.Exception):
                 env.call_via(Transport.REST, req=GetMediaBuysRequest(media_buy_ids=["mb_absent"]))
 
+    def test_refusal_escapes_both_launderers_by_type(self):
+        """The refusal type is outside the reach of both launderers on the dispatch path."""
+        failed = pytest.fail.Exception
+        assert not issubclass(failed, Exception), (
+            f"{failed.__name__} is an Exception subclass — RestDispatcher's "
+            "`except Exception` would swallow the refusal into an error-shaped TransportResult"
+        )
+        assert not issubclass(failed, NotImplementedError), (
+            f"{failed.__name__} is a NotImplementedError subclass — tests/bdd/conftest.py "
+            "would convert the refusal into skipped + wasxfail"
+        )
+        assert issubclass(failed, BaseException)
+
 
 @pytest.mark.requires_db
 class TestNonListRestRoutingIsPreserved:
@@ -170,7 +121,7 @@ class TestNonListRestRoutingIsPreserved:
     ``MediaBuyCreateUpdateListEnv.__mro__`` is [CreateUpdateList, CreateList,
     ListDispatchMixin, DualEnv, CreateEnv, IntegrationEnv, BaseTestEnv], so
     ``build_rest_body`` resolves to ``MediaBuyDualEnv.build_rest_body`` — the stateful
-    create-vs-update router. A refusal override on ``MediaBuyCreateListEnv`` that fell
+    create-vs-update router. A list override on ``MediaBuyCreateListEnv`` that fell
     back to ``MediaBuyCreateEnv.build_rest_body`` explicitly instead of
     ``super().build_rest_body(**kwargs)`` would skip that router: updates would build a
     create-shaped body and POST the collection.
@@ -200,3 +151,9 @@ class TestNonListRestRoutingIsPreserved:
         assert body["brand"] == {"domain": "testbrand.com"}
         assert env.REST_ENDPOINT == "/api/v1/media-buys"
         assert env.REST_METHOD == "post"
+
+    def test_list_request_routes_to_query_on_triple_env(self):
+        env = MediaBuyCreateUpdateListEnv()
+        body = env.build_rest_body(req=GetMediaBuysRequest(media_buy_ids=["mb_x"]))
+        assert env.REST_ENDPOINT == "/api/v1/media-buys/query"
+        assert body.get("media_buy_ids") == ["mb_x"]

--- a/tests/unit/test_a2a_testing_context_extraction.py
+++ b/tests/unit/test_a2a_testing_context_extraction.py
@@ -24,6 +24,8 @@ class TestA2ATestingContextExtraction:
         Verifies _resolve_a2a_identity calls resolve_identity with testing_context
         that has dry_run=True when X-Dry-Run: true header is present.
         """
+        from src.core.testing_hooks import AdCPTestContext
+
         handler = AdCPRequestHandler()
 
         headers = {
@@ -32,6 +34,7 @@ class TestA2ATestingContextExtraction:
             "x-dry-run": "true",
         }
         ctx = make_a2a_context(auth_token="test-token", headers=headers)
+        expected_tc = AdCPTestContext.from_headers(headers)
 
         mock_identity = PrincipalFactory.make_identity(
             principal_id="test_principal",
@@ -43,16 +46,20 @@ class TestA2ATestingContextExtraction:
         with patch("src.core.resolved_identity.resolve_identity", return_value=mock_identity) as mock_resolve:
             handler._resolve_a2a_identity("test-token", require_valid_token=True, context=ctx)
 
-        mock_resolve.assert_called_once()
-        call_kwargs = mock_resolve.call_args.kwargs
-        testing_ctx = call_kwargs.get("testing_context")
-        assert testing_ctx is not None, (
-            "_resolve_a2a_identity should pass testing_context to resolve_identity when test headers are present."
+        mock_resolve.assert_called_once_with(
+            headers=headers,
+            auth_token="test-token",
+            require_valid_token=True,
+            protocol="a2a",
+            testing_context=expected_tc,
         )
-        assert testing_ctx.dry_run is True, "X-Dry-Run: true header should set testing_context.dry_run=True"
+        assert expected_tc is not None
+        assert expected_tc.dry_run is True
 
     def test_test_session_id_passed_to_resolve_identity(self):
         """X-Test-Session-ID header should be extracted and passed to resolve_identity."""
+        from src.core.testing_hooks import AdCPTestContext
+
         handler = AdCPRequestHandler()
 
         headers = {
@@ -61,6 +68,7 @@ class TestA2ATestingContextExtraction:
             "x-test-session-id": "session-abc-123",
         }
         ctx = make_a2a_context(auth_token="test-token", headers=headers)
+        expected_tc = AdCPTestContext.from_headers(headers)
 
         mock_identity = PrincipalFactory.make_identity(
             principal_id="test_principal",
@@ -72,12 +80,15 @@ class TestA2ATestingContextExtraction:
         with patch("src.core.resolved_identity.resolve_identity", return_value=mock_identity) as mock_resolve:
             handler._resolve_a2a_identity("test-token", require_valid_token=True, context=ctx)
 
-        call_kwargs = mock_resolve.call_args.kwargs
-        testing_ctx = call_kwargs.get("testing_context")
-        assert testing_ctx is not None, "_resolve_a2a_identity should pass testing_context to resolve_identity."
-        assert testing_ctx.test_session_id == "session-abc-123", (
-            "X-Test-Session-ID header should be extracted by A2A transport."
+        mock_resolve.assert_called_once_with(
+            headers=headers,
+            auth_token="test-token",
+            require_valid_token=True,
+            protocol="a2a",
+            testing_context=expected_tc,
         )
+        assert expected_tc is not None
+        assert expected_tc.test_session_id == "session-abc-123"
 
     def test_no_test_headers_passes_none_context(self):
         """When no test headers are present, testing_context=None should be passed."""
@@ -99,11 +110,12 @@ class TestA2ATestingContextExtraction:
         with patch("src.core.resolved_identity.resolve_identity", return_value=mock_identity) as mock_resolve:
             handler._resolve_a2a_identity("test-token", require_valid_token=True, context=ctx)
 
-        call_kwargs = mock_resolve.call_args.kwargs
-        testing_ctx = call_kwargs.get("testing_context")
-        assert testing_ctx is None, (
-            "resolve_identity should receive testing_context=None when no test headers present. "
-            f"Got {testing_ctx}, which may activate testing behavior unconditionally."
+        mock_resolve.assert_called_once_with(
+            headers=headers,
+            auth_token="test-token",
+            require_valid_token=True,
+            protocol="a2a",
+            testing_context=None,
         )
 
 

--- a/tests/unit/test_architecture_e2e_rest_escape_hatches.py
+++ b/tests/unit/test_architecture_e2e_rest_escape_hatches.py
@@ -78,8 +78,8 @@ EXPECTED_XFAIL_ROUTES: tuple[str, ...] = (
     "'T-UC-004-boundary-ownership' in marker_names and is_e2e_rest and ('differs from owner' in nodeid)",
     "'T-UC-004-dim-sortby-fallback' in marker_names and is_e2e_rest",
     "(is_rest or is_e2e_rest) and 'T-UC-019-boundary-principal' in marker_names",
-    "(is_rest or is_e2e_rest) and 'T-UC-019-ext-a' in marker_names",
-    "(is_rest or is_e2e_rest) and 'T-UC-019-partition-principal-invalid' in marker_names",
+    # T-UC-019-ext-a / partition-principal-invalid identity_missing REST xfails
+    # removed in #1950: AUTH_REQUIRED_SUGGESTION already matches the scenario.
     "_samp_is_named and (is_rest or is_e2e_rest)",
     "is_e2e_rest",
     "is_e2e_rest and 'T-UC-002-nfr-001-enforcement' in marker_names",

--- a/tests/unit/test_architecture_weak_mock_assertions.py
+++ b/tests/unit/test_architecture_weak_mock_assertions.py
@@ -49,7 +49,6 @@ WEAK_ASSERTION_ALLOWLIST: set[tuple[str, str]] = {
     ("tests/unit/test_a2a_parameter_mapping.py", "test_update_media_buy_backward_compatibility_with_updates"),
     ("tests/unit/test_a2a_parameter_mapping.py", "test_update_media_buy_uses_packages_parameter"),
     ("tests/unit/test_a2a_tenant_detection_order.py", "test_a2a_delegates_to_resolve_identity"),
-    ("tests/unit/test_a2a_testing_context_extraction.py", "test_dry_run_header_passed_to_resolve_identity"),
     ("tests/unit/test_auth_bearer_header.py", "test_x_adcp_auth_takes_precedence_over_authorization_bearer"),
     ("tests/unit/test_authorized_properties_behavioral.py", "test_audit_called_on_failure"),
     ("tests/unit/test_authorized_properties_behavioral.py", "test_audit_called_on_success"),

--- a/tests/unit/test_media_buy_harness.py
+++ b/tests/unit/test_media_buy_harness.py
@@ -79,16 +79,19 @@ class TestMediaBuyListEnvExists:
         """UC-019 wire_field needs MCP structured_content stashed as wire_response.
 
         Legacy ``_run_mcp_wrapper`` never set ``_last_wire_response``; list env
-        must use ``_run_mcp_client`` like create/dual.
+        must use ``_run_mcp_client`` like create/dual. ``call_mcp`` unwraps
+        ``DeliverResult.payload`` (base contract after the transport-generic client).
         """
         from unittest.mock import patch
 
         from src.core.schemas._base import GetMediaBuysResponse
         from tests.harness.media_buy_list import MediaBuyListEnv
+        from tests.harness.transport import DeliverResult
 
         env = MediaBuyListEnv.__new__(MediaBuyListEnv)
+        delivered = DeliverResult(payload="wired", wire_response={"status": "completed"})
         with (
-            patch.object(MediaBuyListEnv, "_run_mcp_client", return_value="wired") as mock_client,
+            patch.object(MediaBuyListEnv, "_run_mcp_client", return_value=delivered) as mock_client,
             patch.object(MediaBuyListEnv, "_run_mcp_wrapper") as mock_wrapper,
         ):
             assert env.call_mcp(status_filter=["active"]) == "wired"

--- a/tests/unit/test_media_buy_harness.py
+++ b/tests/unit/test_media_buy_harness.py
@@ -74,3 +74,27 @@ class TestMediaBuyListEnvExists:
         from tests.harness.media_buy_list import MediaBuyListEnv
 
         assert MediaBuyListEnv is not None
+
+    def test_call_mcp_uses_client_pipeline_not_legacy_wrapper(self):
+        """UC-019 wire_field needs MCP structured_content stashed as wire_response.
+
+        Legacy ``_run_mcp_wrapper`` never set ``_last_wire_response``; list env
+        must use ``_run_mcp_client`` like create/dual.
+        """
+        from unittest.mock import patch
+
+        from src.core.schemas._base import GetMediaBuysResponse
+        from tests.harness.media_buy_list import MediaBuyListEnv
+
+        env = MediaBuyListEnv.__new__(MediaBuyListEnv)
+        with (
+            patch.object(MediaBuyListEnv, "_run_mcp_client", return_value="wired") as mock_client,
+            patch.object(MediaBuyListEnv, "_run_mcp_wrapper") as mock_wrapper,
+        ):
+            assert env.call_mcp(status_filter=["active"]) == "wired"
+            mock_client.assert_called_once_with(
+                "get_media_buys",
+                GetMediaBuysResponse,
+                status_filter=["active"],
+            )
+            mock_wrapper.assert_not_called()

--- a/tests/unit/test_rest_api_endpoints.py
+++ b/tests/unit/test_rest_api_endpoints.py
@@ -131,6 +131,40 @@ class TestUpdateMediaBuyScalarForwarding:
         )
 
 
+class TestGetMediaBuysQueryEndpoint:
+    """Verify POST /api/v1/media-buys/query endpoint (get_media_buys REST)."""
+
+    @patch("src.core.resolved_identity.resolve_identity", return_value=_MOCK_IDENTITY)
+    def test_mistyped_media_buy_ids_returns_validation_error(self, mock_resolve):
+        """T-UC-019-ext-d parity: mistyped media_buy_ids → VALIDATION_ERROR, not INVALID_REQUEST.
+
+        GetMediaBuysBody must not FastAPI-type media_buy_ids as list[str]; that
+        would reject at RequestValidationError → INVALID_REQUEST before
+        get_media_buys_raw / adcp_validation_boundary (MCP/A2A wire code).
+        """
+        response = client.post(
+            "/api/v1/media-buys/query",
+            json={"media_buy_ids": "not-a-list"},
+            headers={"Authorization": "Bearer test-token"},
+        )
+
+        assert response.status_code == 400, response.text
+        assert_envelope_shape(response.json(), "VALIDATION_ERROR", recovery="correctable")
+
+    @patch("src.core.resolved_identity.resolve_identity", return_value=_MOCK_IDENTITY)
+    @patch("src.core.tools.media_buy_list.get_media_buys_raw")
+    def test_valid_query_forwards_to_raw(self, mock_raw, mock_resolve):
+        mock_raw.return_value = MagicMock(model_dump=lambda **kw: {"media_buys": []})
+        response = client.post(
+            "/api/v1/media-buys/query",
+            json={"media_buy_ids": ["mb1"], "status_filter": "active"},
+            headers={"Authorization": "Bearer test-token"},
+        )
+        assert response.status_code == 200, response.text
+        assert mock_raw.call_args.kwargs["media_buy_ids"] == ["mb1"]
+        assert mock_raw.call_args.kwargs["status_filter"] == "active"
+
+
 class TestGetMediaBuyDeliveryEndpoint:
     """Verify POST /api/v1/media-buys/delivery endpoint."""
 

--- a/tests/unit/test_rest_api_endpoints.py
+++ b/tests/unit/test_rest_api_endpoints.py
@@ -170,6 +170,30 @@ class TestGetMediaBuysQueryEndpoint:
             identity=_MOCK_IDENTITY,
         )
 
+    @patch("src.core.resolved_identity.resolve_identity", return_value=_MOCK_IDENTITY)
+    @patch("src.core.transport_helpers.enrich_identity_with_account")
+    @patch("src.core.tools.media_buy_list.get_media_buys_raw")
+    def test_account_is_forwarded_without_identity_enrichment(self, mock_raw, mock_enrich, mock_resolve):
+        """Query must not DB-enrich identity; list _impl rejects account first."""
+        mock_raw.return_value = MagicMock(model_dump=lambda **kw: {"media_buys": []})
+        account_payload = {"brand": {"domain": "example.com"}, "operator": "op-1", "sandbox": False}
+        response = client.post(
+            "/api/v1/media-buys/query",
+            json={"media_buy_ids": ["mb1"], "account": account_payload},
+            headers={"Authorization": "Bearer test-token"},
+        )
+        assert response.status_code == 200, response.text
+        mock_enrich.assert_not_called()
+        expected_account = LibraryAccountReference.model_validate(account_payload)
+        mock_raw.assert_called_once_with(
+            media_buy_ids=["mb1"],
+            status_filter=None,
+            include_snapshot=False,
+            account=expected_account,
+            context=None,
+            identity=_MOCK_IDENTITY,
+        )
+
 
 class TestGetMediaBuyDeliveryEndpoint:
     """Verify POST /api/v1/media-buys/delivery endpoint."""

--- a/tests/unit/test_rest_api_endpoints.py
+++ b/tests/unit/test_rest_api_endpoints.py
@@ -161,8 +161,14 @@ class TestGetMediaBuysQueryEndpoint:
             headers={"Authorization": "Bearer test-token"},
         )
         assert response.status_code == 200, response.text
-        assert mock_raw.call_args.kwargs["media_buy_ids"] == ["mb1"]
-        assert mock_raw.call_args.kwargs["status_filter"] == "active"
+        mock_raw.assert_called_once_with(
+            media_buy_ids=["mb1"],
+            status_filter="active",
+            include_snapshot=False,
+            account=None,
+            context=None,
+            identity=_MOCK_IDENTITY,
+        )
 
 
 class TestGetMediaBuyDeliveryEndpoint:

--- a/tests/unit/test_rest_testing_context_extraction.py
+++ b/tests/unit/test_rest_testing_context_extraction.py
@@ -1,7 +1,8 @@
-"""Regression: REST auth deps extract testing context from headers (#1830).
+"""Regression: REST/MCP/A2A testing-context extraction and list mock clock.
 
-Parity with A2A ``_resolve_a2a_identity`` — without ``AdCPTestContext.from_headers``,
-``X-Mock-Time`` / ``X-Dry-Run`` never reach ``get_media_buys`` over e2e_rest.
+Covers REST from_headers parity, list reference_today + simulate under mock_time,
+RestE2EDispatcher / apply_testing_hook_headers harness wiring, and
+resolve_identity_from_context reading mock_time from resolved headers.
 """
 
 from __future__ import annotations
@@ -10,10 +11,13 @@ from datetime import UTC, date, datetime
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+from adcp.types import MediaBuyStatus
+
 from src.core.auth_context import AuthContext, _require_auth_dep, _resolve_auth_dep
 from src.core.schemas import GetMediaBuysRequest
 from src.core.testing_hooks import AdCPTestContext
-from src.core.tools.media_buy_list import _get_media_buys_impl
+from src.core.tools._media_buy_status import resolve_canonical_status
+from src.core.tools.media_buy_list import _compute_status, _get_media_buys_impl
 from tests.factories.principal import PrincipalFactory
 
 
@@ -29,12 +33,19 @@ class TestRestTestingContextExtraction:
             },
         )
         mock_identity = PrincipalFactory.make_identity(protocol="rest")
+        expected_tc = AdCPTestContext.from_headers(dict(auth_ctx.headers))
         with patch("src.core.resolved_identity.resolve_identity", return_value=mock_identity) as mock_resolve:
             _resolve_auth_dep(auth_ctx)
 
-        testing_ctx = mock_resolve.call_args.kwargs.get("testing_context")
-        assert testing_ctx is not None
-        assert testing_ctx.mock_time == datetime(2026, 3, 15, 12, 0, 0, tzinfo=UTC)
+        mock_resolve.assert_called_once_with(
+            headers=dict(auth_ctx.headers),
+            auth_token="test-token",
+            require_valid_token=False,
+            protocol="rest",
+            testing_context=expected_tc,
+        )
+        assert expected_tc is not None
+        assert expected_tc.mock_time == datetime(2026, 3, 15, 12, 0, 0, tzinfo=UTC)
 
     def test_require_auth_passes_dry_run_from_headers(self):
         auth_ctx = AuthContext(
@@ -45,12 +56,19 @@ class TestRestTestingContextExtraction:
             },
         )
         mock_identity = PrincipalFactory.make_identity(protocol="rest")
+        expected_tc = AdCPTestContext.from_headers(dict(auth_ctx.headers))
         with patch("src.core.resolved_identity.resolve_identity", return_value=mock_identity) as mock_resolve:
             _require_auth_dep(auth_ctx)
 
-        testing_ctx = mock_resolve.call_args.kwargs.get("testing_context")
-        assert testing_ctx is not None
-        assert testing_ctx.dry_run is True
+        mock_resolve.assert_called_once_with(
+            headers=dict(auth_ctx.headers),
+            auth_token="test-token",
+            require_valid_token=True,
+            protocol="rest",
+            testing_context=expected_tc,
+        )
+        assert expected_tc is not None
+        assert expected_tc.dry_run is True
 
     def test_resolve_auth_passes_none_without_test_headers(self):
         auth_ctx = AuthContext(
@@ -61,11 +79,17 @@ class TestRestTestingContextExtraction:
         with patch("src.core.resolved_identity.resolve_identity", return_value=mock_identity) as mock_resolve:
             _resolve_auth_dep(auth_ctx)
 
-        assert mock_resolve.call_args.kwargs.get("testing_context") is None
+        mock_resolve.assert_called_once_with(
+            headers=dict(auth_ctx.headers),
+            auth_token="test-token",
+            require_valid_token=False,
+            protocol="rest",
+            testing_context=None,
+        )
 
 
 class TestMediaBuyListHonorsMockTime:
-    """``_get_media_buys_impl`` uses testing_context.mock_time for ``today``."""
+    """``_get_media_buys_impl`` uses testing_context.mock_time for ``today`` + simulate."""
 
     def test_list_today_uses_mock_time_date(self):
         mock_time = datetime(2026, 3, 15, 12, 0, 0, tzinfo=UTC)
@@ -75,8 +99,9 @@ class TestMediaBuyListHonorsMockTime:
         )
         captured: dict[str, object] = {}
 
-        def _capture_fetch(_req, _principal_id, _uow, today):
+        def _capture_fetch(_req, _principal_id, _uow, today, *, simulate=False):
             captured["today"] = today
+            captured["simulate"] = simulate
             return []
 
         with (
@@ -96,6 +121,23 @@ class TestMediaBuyListHonorsMockTime:
             _get_media_buys_impl(GetMediaBuysRequest(), identity=identity)
 
         assert captured["today"] == date(2026, 3, 15)
+        assert captured["simulate"] is True
+
+    def test_list_pending_creatives_past_flight_matches_simulate_true(self):
+        """Under mock_time, list status agrees with resolve_canonical_status(simulate=True)."""
+        buy = SimpleNamespace(
+            status="pending_creatives",
+            start_date=date(2025, 1, 1),
+            end_date=date(2025, 3, 31),
+            start_time=None,
+            end_time=None,
+            is_paused=False,
+        )
+        past = date(2025, 6, 1)
+        assert resolve_canonical_status(buy, past, simulate=True) == "completed"
+        assert resolve_canonical_status(buy, past, simulate=False) == "pending_creatives"
+        assert _compute_status(buy, past, simulate=True) is MediaBuyStatus.completed
+        assert _compute_status(buy, past, simulate=False) is MediaBuyStatus.pending_creatives
 
 
 class TestRestE2EDispatcherMockTimeHeader:
@@ -117,7 +159,7 @@ class TestRestE2EDispatcherMockTimeHeader:
             build_rest_body=lambda **_kw: {},
             parse_rest_response=lambda data: data,
             parse_rest_error=lambda *_a: Exception("err"),
-            _mock_time=None,
+            mock_time=None,
         )
         captured_headers: dict[str, str] = {}
 
@@ -150,7 +192,7 @@ class TestRestE2EDispatcherMockTimeHeader:
 
 
 class TestApplyTestingHookHeaders:
-    """Shared harness helper used by e2e_rest + real-token A2A/MCP (#1830)."""
+    """Shared harness helper used by e2e_rest + real-token A2A/MCP."""
 
     def test_forwards_mock_time_and_dry_run_from_identity(self):
         from tests.harness.dispatchers import apply_testing_hook_headers
@@ -177,28 +219,125 @@ class TestApplyTestingHookHeaders:
         apply_testing_hook_headers(headers, identity, fallback_mock_time=mock_time)
         assert headers["x-mock-time"] == "2026-03-14T12:00:00Z"
 
-    def test_a2a_real_token_auth_context_includes_mock_time(self):
-        """Regression: integration A2A rebuilt headers without X-Mock-Time (#1950)."""
-        from src.core.auth_context import AUTH_CONTEXT_STATE_KEY, AuthContext
-        from src.core.testing_hooks import AdCPTestContext as HooksCtx
+
+class TestResolveIdentityFromContextUsesHeaders:
+    """MCP Client path: testing_context from resolved headers, not a re-fetch."""
+
+    def test_from_headers_even_when_testing_hooks_get_http_headers_empty(self):
+        from src.core.transport_helpers import resolve_identity_from_context
+
+        headers = {
+            "x-adcp-auth": "tok",
+            "x-mock-time": "2026-03-15T12:00:00Z",
+        }
+        mock_identity = PrincipalFactory.make_identity(protocol="mcp")
+        with (
+            patch("src.core.transport_helpers.get_http_headers", return_value=headers),
+            patch("src.core.testing_hooks.get_http_headers", return_value={}),
+            patch("src.core.transport_helpers.resolve_identity", return_value=mock_identity) as mock_resolve,
+        ):
+            resolve_identity_from_context(MagicMock(), require_valid_token=False, protocol="mcp")
+
+        testing_ctx = mock_resolve.call_args.kwargs.get("testing_context")
+        assert testing_ctx is not None
+        assert testing_ctx.mock_time == datetime(2026, 3, 15, 12, 0, 0, tzinfo=UTC)
+
+
+class TestHarnessRealTokenAppliesTestingHookHeaders:
+    """Altitude-correct: real-token A2A/MCP preambles call apply_testing_hook_headers."""
+
+    def test_a2a_real_token_preamble_calls_apply_testing_hook_headers(self):
+        from a2a.types import Task, TaskState, TaskStatus
+
+        from src.core.auth_context import AUTH_CONTEXT_STATE_KEY
+        from src.core.schemas import GetMediaBuysResponse
+        from tests.harness.dispatchers import apply_testing_hook_headers
+        from tests.harness.media_buy_list import MediaBuyListEnv
 
         mock_time = datetime(2026, 3, 15, 12, 0, 0, tzinfo=UTC)
+        env = MediaBuyListEnv(principal_id="p1", tenant_id="t1")
         identity = PrincipalFactory.make_identity(
             protocol="a2a",
             auth_token="real-tok",
+            tenant_id="t1",
+            principal_id="p1",
             testing_context=AdCPTestContext(mock_time=mock_time),
         )
-        from tests.harness.dispatchers import apply_testing_hook_headers
+        captured: dict[str, object] = {}
 
-        headers = {
-            "x-adcp-auth": identity.auth_token or "",
-            "x-adcp-tenant": identity.tenant_id or "",
-        }
-        apply_testing_hook_headers(headers, identity, fallback_mock_time=None)
-        auth_ctx = AuthContext(auth_token=identity.auth_token, headers=headers)
-        parsed = HooksCtx.from_headers(auth_ctx.headers)
-        assert parsed is not None
-        assert parsed.mock_time == mock_time
-        # Sanity: state key contract still holds for ServerCallContext consumers.
-        assert AUTH_CONTEXT_STATE_KEY
-        assert auth_ctx.headers["x-mock-time"] == "2026-03-15T12:00:00Z"
+        async def _fake_on_message_send(_params, server_context):
+            auth = server_context.state[AUTH_CONTEXT_STATE_KEY]
+            captured["headers"] = dict(auth.headers)
+            return Task(
+                id="task-1",
+                contextId="ctx-1",
+                status=TaskStatus(state=TaskState.completed),
+                artifacts=[],
+            )
+
+        with (
+            patch(
+                "tests.harness.dispatchers.apply_testing_hook_headers",
+                wraps=apply_testing_hook_headers,
+            ) as spy,
+            patch("src.a2a_server.adcp_a2a_server.AdCPRequestHandler") as handler_cls,
+            patch.object(env, "_ensure_tenant_for_audit"),
+            patch.object(env, "_commit_factory_data"),
+        ):
+            handler_cls.return_value.on_message_send = _fake_on_message_send
+            try:
+                env._run_a2a_handler("get_media_buys", GetMediaBuysResponse, identity=identity)
+            except Exception:
+                # Empty artifacts may fail response parse — preamble is enough.
+                pass
+
+        assert spy.called, "real-token A2A path must call apply_testing_hook_headers"
+        headers = captured.get("headers") or {}
+        assert headers.get("x-mock-time") == "2026-03-15T12:00:00Z", headers
+
+    def test_mcp_real_token_preamble_calls_apply_testing_hook_headers(self):
+        from src.core.schemas import GetMediaBuysResponse
+        from tests.harness.dispatchers import apply_testing_hook_headers
+        from tests.harness.media_buy_list import MediaBuyListEnv
+
+        mock_time = datetime(2026, 3, 15, 12, 0, 0, tzinfo=UTC)
+        env = MediaBuyListEnv(principal_id="p1", tenant_id="t1")
+        identity = PrincipalFactory.make_identity(
+            protocol="mcp",
+            auth_token="real-tok",
+            tenant_id="t1",
+            principal_id="p1",
+            testing_context=AdCPTestContext(mock_time=mock_time),
+        )
+
+        class _FakeToolResult:
+            structured_content = {"media_buys": []}
+
+        class _FakeClient:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                return False
+
+            async def call_tool(self, name, arguments):
+                return _FakeToolResult()
+
+        with (
+            patch(
+                "tests.harness.dispatchers.apply_testing_hook_headers",
+                wraps=apply_testing_hook_headers,
+            ) as spy,
+            patch("fastmcp.Client", _FakeClient),
+            patch.object(env, "_commit_factory_data"),
+        ):
+            try:
+                env._run_mcp_client("get_media_buys", GetMediaBuysResponse, identity=identity)
+            except Exception:
+                # Fake Client skips the real auth chain assert — preamble is enough.
+                pass
+
+        assert spy.called, "real-token MCP path must call apply_testing_hook_headers"

--- a/tests/unit/test_rest_testing_context_extraction.py
+++ b/tests/unit/test_rest_testing_context_extraction.py
@@ -220,6 +220,31 @@ class TestApplyTestingHookHeaders:
         assert headers["x-mock-time"] == "2026-03-14T12:00:00Z"
 
 
+class TestResolveNowSharedClock:
+    """resolve_now is the single mock/wall clock for list + hooks + delivery mock branch."""
+
+    def test_resolve_now_prefers_mock_time(self):
+        from src.core.testing_hooks import resolve_now
+
+        mock_time = datetime(2026, 3, 15, 12, 0, 0, tzinfo=UTC)
+        assert resolve_now(AdCPTestContext(mock_time=mock_time)) == mock_time
+
+    def test_resolve_now_wall_clock_when_no_mock(self):
+        from src.core.testing_hooks import resolve_now
+
+        before = datetime.now(UTC)
+        got = resolve_now(AdCPTestContext(dry_run=True))
+        after = datetime.now(UTC)
+        assert before <= got <= after
+
+    def test_reference_today_delegates_to_resolve_now(self):
+        from src.core.testing_hooks import reference_today, resolve_now
+
+        mock_time = datetime(2026, 3, 15, 12, 0, 0, tzinfo=UTC)
+        tc = AdCPTestContext(mock_time=mock_time)
+        assert reference_today(tc) == resolve_now(tc).date() == date(2026, 3, 15)
+
+
 class TestResolveIdentityFromContextUsesHeaders:
     """MCP Client path: testing_context from resolved headers, not a re-fetch."""
 
@@ -230,6 +255,7 @@ class TestResolveIdentityFromContextUsesHeaders:
             "x-adcp-auth": "tok",
             "x-mock-time": "2026-03-15T12:00:00Z",
         }
+        expected_tc = AdCPTestContext.from_headers(headers)
         mock_identity = PrincipalFactory.make_identity(protocol="mcp")
         with (
             patch("src.core.transport_helpers.get_http_headers", return_value=headers),
@@ -238,9 +264,14 @@ class TestResolveIdentityFromContextUsesHeaders:
         ):
             resolve_identity_from_context(MagicMock(), require_valid_token=False, protocol="mcp")
 
-        testing_ctx = mock_resolve.call_args.kwargs.get("testing_context")
-        assert testing_ctx is not None
-        assert testing_ctx.mock_time == datetime(2026, 3, 15, 12, 0, 0, tzinfo=UTC)
+        mock_resolve.assert_called_once_with(
+            headers=headers,
+            require_valid_token=False,
+            protocol="mcp",
+            testing_context=expected_tc,
+        )
+        assert expected_tc is not None
+        assert expected_tc.mock_time == datetime(2026, 3, 15, 12, 0, 0, tzinfo=UTC)
 
 
 class TestHarnessRealTokenAppliesTestingHookHeaders:

--- a/tests/unit/test_rest_testing_context_extraction.py
+++ b/tests/unit/test_rest_testing_context_extraction.py
@@ -121,10 +121,10 @@ class TestMediaBuyListHonorsMockTime:
             _get_media_buys_impl(GetMediaBuysRequest(), identity=identity)
 
         assert captured["today"] == date(2026, 3, 15)
-        assert captured["simulate"] is True
+        assert captured["simulate"] is False
 
-    def test_list_pending_creatives_past_flight_matches_simulate_true(self):
-        """Under mock_time, list status agrees with resolve_canonical_status(simulate=True)."""
+    def test_list_pending_creatives_past_flight_keeps_simulate_false_under_mock_time(self):
+        """#1830: mock_time moves today only; persisted status stays unrefined on list."""
         buy = SimpleNamespace(
             status="pending_creatives",
             start_date=date(2025, 1, 1),
@@ -237,12 +237,15 @@ class TestResolveNowSharedClock:
         after = datetime.now(UTC)
         assert before <= got <= after
 
-    def test_reference_today_delegates_to_resolve_now(self):
-        from src.core.testing_hooks import reference_today, resolve_now
+    def test_resolve_clock_mock_time_is_clock_only(self):
+        from src.core.testing_hooks import resolve_clock, resolve_now
 
         mock_time = datetime(2026, 3, 15, 12, 0, 0, tzinfo=UTC)
         tc = AdCPTestContext(mock_time=mock_time)
-        assert reference_today(tc) == resolve_now(tc).date() == date(2026, 3, 15)
+        clock, simulate = resolve_clock(tc)
+        assert clock == resolve_now(tc) == mock_time
+        assert simulate is False
+        assert clock.date() == date(2026, 3, 15)
 
 
 class TestResolveIdentityFromContextUsesHeaders:
@@ -341,12 +344,14 @@ class TestHarnessRealTokenAppliesTestingHookHeaders:
             testing_context=AdCPTestContext(mock_time=mock_time),
         )
 
+        captured: dict[str, object] = {}
+
         class _FakeToolResult:
             structured_content = {"media_buys": []}
 
         class _FakeClient:
             def __init__(self, *args, **kwargs):
-                pass
+                self._kwargs = kwargs
 
             async def __aenter__(self):
                 return self
@@ -368,7 +373,9 @@ class TestHarnessRealTokenAppliesTestingHookHeaders:
             try:
                 env._run_mcp_client("get_media_buys", GetMediaBuysResponse, identity=identity)
             except Exception:
-                # Fake Client skips the real auth chain assert — preamble is enough.
                 pass
 
         assert spy.called, "real-token MCP path must call apply_testing_hook_headers"
+        call = spy.call_args
+        headers = call.args[0] if call.args else call.kwargs.get("headers") or {}
+        assert headers.get("x-mock-time") == "2026-03-15T12:00:00Z", headers

--- a/tests/unit/test_rest_testing_context_extraction.py
+++ b/tests/unit/test_rest_testing_context_extraction.py
@@ -1,0 +1,149 @@
+"""Regression: REST auth deps extract testing context from headers (#1830).
+
+Parity with A2A ``_resolve_a2a_identity`` — without ``AdCPTestContext.from_headers``,
+``X-Mock-Time`` / ``X-Dry-Run`` never reach ``get_media_buys`` over e2e_rest.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from src.core.auth_context import AuthContext, _require_auth_dep, _resolve_auth_dep
+from src.core.schemas import GetMediaBuysRequest
+from src.core.testing_hooks import AdCPTestContext
+from src.core.tools.media_buy_list import _get_media_buys_impl
+from tests.factories.principal import PrincipalFactory
+
+
+class TestRestTestingContextExtraction:
+    """REST ``_resolve_auth_dep`` / ``_require_auth_dep`` pass testing_context."""
+
+    def test_resolve_auth_passes_mock_time_from_headers(self):
+        auth_ctx = AuthContext(
+            auth_token="test-token",
+            headers={
+                "x-adcp-auth": "test-token",
+                "x-mock-time": "2026-03-15T12:00:00Z",
+            },
+        )
+        mock_identity = PrincipalFactory.make_identity(protocol="rest")
+        with patch("src.core.resolved_identity.resolve_identity", return_value=mock_identity) as mock_resolve:
+            _resolve_auth_dep(auth_ctx)
+
+        testing_ctx = mock_resolve.call_args.kwargs.get("testing_context")
+        assert testing_ctx is not None
+        assert testing_ctx.mock_time == datetime(2026, 3, 15, 12, 0, 0, tzinfo=UTC)
+
+    def test_require_auth_passes_dry_run_from_headers(self):
+        auth_ctx = AuthContext(
+            auth_token="test-token",
+            headers={
+                "x-adcp-auth": "test-token",
+                "x-dry-run": "true",
+            },
+        )
+        mock_identity = PrincipalFactory.make_identity(protocol="rest")
+        with patch("src.core.resolved_identity.resolve_identity", return_value=mock_identity) as mock_resolve:
+            _require_auth_dep(auth_ctx)
+
+        testing_ctx = mock_resolve.call_args.kwargs.get("testing_context")
+        assert testing_ctx is not None
+        assert testing_ctx.dry_run is True
+
+    def test_resolve_auth_passes_none_without_test_headers(self):
+        auth_ctx = AuthContext(
+            auth_token="test-token",
+            headers={"x-adcp-auth": "test-token"},
+        )
+        mock_identity = PrincipalFactory.make_identity(protocol="rest")
+        with patch("src.core.resolved_identity.resolve_identity", return_value=mock_identity) as mock_resolve:
+            _resolve_auth_dep(auth_ctx)
+
+        assert mock_resolve.call_args.kwargs.get("testing_context") is None
+
+
+class TestMediaBuyListHonorsMockTime:
+    """``_get_media_buys_impl`` uses testing_context.mock_time for ``today``."""
+
+    def test_list_today_uses_mock_time_date(self):
+        mock_time = datetime(2026, 3, 15, 12, 0, 0, tzinfo=UTC)
+        identity = PrincipalFactory.make_identity(
+            protocol="rest",
+            testing_context=AdCPTestContext(mock_time=mock_time),
+        )
+        captured: dict[str, object] = {}
+
+        def _capture_fetch(_req, _principal_id, _uow, today):
+            captured["today"] = today
+            return []
+
+        with (
+            patch("src.core.tools.media_buy_list.MediaBuyUoW") as m_uow,
+            patch("src.core.tools.media_buy_list.get_principal_object", return_value=MagicMock()),
+            patch("src.core.tools.media_buy_list.require_tenant", return_value={"tenant_id": "test_tenant"}),
+            patch("src.core.tools.media_buy_list._fetch_target_media_buys", side_effect=_capture_fetch),
+            patch("src.core.tools.media_buy_list._fetch_creative_approvals", return_value={}),
+            patch("src.core.tools.media_buy_list._fetch_packages", return_value={}),
+        ):
+            uow = MagicMock()
+            uow.media_buys = MagicMock()
+            uow.session = MagicMock()
+            m_uow.return_value.__enter__.return_value = uow
+            m_uow.return_value.__exit__.return_value = False
+
+            _get_media_buys_impl(GetMediaBuysRequest(), identity=identity)
+
+        assert captured["today"] == date(2026, 3, 15)
+
+
+class TestRestE2EDispatcherMockTimeHeader:
+    """RestE2EDispatcher forwards X-Mock-Time from identity / env."""
+
+    def test_dispatcher_sets_x_mock_time_header(self):
+        from tests.harness.dispatchers import RestE2EDispatcher
+
+        mock_time = datetime(2026, 3, 15, 12, 0, 0, tzinfo=UTC)
+        identity = PrincipalFactory.make_identity(
+            protocol="rest",
+            testing_context=AdCPTestContext(mock_time=mock_time, dry_run=True),
+            auth_token="tok",
+        )
+        env = SimpleNamespace(
+            e2e_config=SimpleNamespace(base_url="http://example.test"),
+            REST_ENDPOINT="/api/v1/media-buys/query",
+            REST_METHOD="post",
+            build_rest_body=lambda **_kw: {},
+            parse_rest_response=lambda data: data,
+            parse_rest_error=lambda *_a: Exception("err"),
+            _mock_time=None,
+        )
+        captured_headers: dict[str, str] = {}
+
+        class _FakeResponse:
+            status_code = 200
+            headers = {"content-type": "application/json"}
+
+            def json(self):
+                return {"media_buys": []}
+
+        class _FakeClient:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+            def post(self, endpoint, json=None, headers=None):  # noqa: A002
+                captured_headers.update(headers or {})
+                return _FakeResponse()
+
+        with patch("httpx.Client", _FakeClient):
+            RestE2EDispatcher().dispatch(env, identity=identity)
+
+        assert captured_headers.get("x-mock-time") == "2026-03-15T12:00:00Z"
+        assert captured_headers.get("x-dry-run") == "true"

--- a/tests/unit/test_rest_testing_context_extraction.py
+++ b/tests/unit/test_rest_testing_context_extraction.py
@@ -99,7 +99,7 @@ class TestMediaBuyListHonorsMockTime:
         )
         captured: dict[str, object] = {}
 
-        def _capture_fetch(_req, _principal_id, _uow, today, *, simulate=False):
+        def _capture_fetch(_req, _principal_id, _uow, today, _row_advisories, *, simulate=False):
             captured["today"] = today
             captured["simulate"] = simulate
             return []

--- a/tests/unit/test_rest_testing_context_extraction.py
+++ b/tests/unit/test_rest_testing_context_extraction.py
@@ -147,3 +147,58 @@ class TestRestE2EDispatcherMockTimeHeader:
 
         assert captured_headers.get("x-mock-time") == "2026-03-15T12:00:00Z"
         assert captured_headers.get("x-dry-run") == "true"
+
+
+class TestApplyTestingHookHeaders:
+    """Shared harness helper used by e2e_rest + real-token A2A/MCP (#1830)."""
+
+    def test_forwards_mock_time_and_dry_run_from_identity(self):
+        from tests.harness.dispatchers import apply_testing_hook_headers
+
+        mock_time = datetime(2026, 3, 15, 12, 0, 0, tzinfo=UTC)
+        identity = PrincipalFactory.make_identity(
+            protocol="a2a",
+            testing_context=AdCPTestContext(mock_time=mock_time, dry_run=True),
+        )
+        headers: dict[str, str] = {"x-adcp-auth": "tok"}
+        apply_testing_hook_headers(headers, identity)
+        assert headers["x-mock-time"] == "2026-03-15T12:00:00Z"
+        assert headers["x-dry-run"] == "true"
+
+    def test_falls_back_to_env_mock_time(self):
+        from tests.harness.dispatchers import apply_testing_hook_headers
+
+        mock_time = datetime(2026, 3, 14, 12, 0, 0, tzinfo=UTC)
+        identity = PrincipalFactory.make_identity(
+            protocol="a2a",
+            testing_context=AdCPTestContext(mock_time=None),
+        )
+        headers: dict[str, str] = {}
+        apply_testing_hook_headers(headers, identity, fallback_mock_time=mock_time)
+        assert headers["x-mock-time"] == "2026-03-14T12:00:00Z"
+
+    def test_a2a_real_token_auth_context_includes_mock_time(self):
+        """Regression: integration A2A rebuilt headers without X-Mock-Time (#1950)."""
+        from src.core.auth_context import AUTH_CONTEXT_STATE_KEY, AuthContext
+        from src.core.testing_hooks import AdCPTestContext as HooksCtx
+
+        mock_time = datetime(2026, 3, 15, 12, 0, 0, tzinfo=UTC)
+        identity = PrincipalFactory.make_identity(
+            protocol="a2a",
+            auth_token="real-tok",
+            testing_context=AdCPTestContext(mock_time=mock_time),
+        )
+        from tests.harness.dispatchers import apply_testing_hook_headers
+
+        headers = {
+            "x-adcp-auth": identity.auth_token or "",
+            "x-adcp-tenant": identity.tenant_id or "",
+        }
+        apply_testing_hook_headers(headers, identity, fallback_mock_time=None)
+        auth_ctx = AuthContext(auth_token=identity.auth_token, headers=headers)
+        parsed = HooksCtx.from_headers(auth_ctx.headers)
+        assert parsed is not None
+        assert parsed.mock_time == mock_time
+        # Sanity: state key contract still holds for ServerCallContext consumers.
+        assert AUTH_CONTEXT_STATE_KEY
+        assert auth_ctx.headers["x-mock-time"] == "2026-03-15T12:00:00Z"

--- a/tests/unit/test_wire_objects.py
+++ b/tests/unit/test_wire_objects.py
@@ -1,0 +1,25 @@
+"""wire_objects: attribute access over wire dict trees for BDD oracles."""
+
+from tests.bdd.steps._outcome_helpers import wire_objects
+
+
+def test_wire_objects_wraps_nested_dicts_for_attr_access() -> None:
+    buys = wire_objects(
+        [
+            {
+                "media_buy_id": "mb-1",
+                "status": "active",
+                "packages": [{"package_id": "pkg-1", "product_id": "prod-1"}],
+            }
+        ]
+    )
+    assert buys[0].media_buy_id == "mb-1"
+    assert buys[0].status == "active"
+    assert buys[0].packages[0].package_id == "pkg-1"
+    assert buys[0].packages[0].product_id == "prod-1"
+
+
+def test_wire_objects_leaves_scalars_unchanged() -> None:
+    assert wire_objects("active") == "active"
+    assert wire_objects(None) is None
+    assert wire_objects([1, 2]) == [1, 2]


### PR DESCRIPTION
## Summary
- Wire REST `require_auth`/`resolve_auth` to `AdCPTestContext.from_headers` (parity with A2A) so `X-Mock-Time` reaches identity.
- Honor `testing_context.mock_time` in `_get_media_buys_impl` for date refinement (parity with delivery `_simulation_clock`).
- `RestE2EDispatcher` + `given_today_is` forward/set the same controllable clock; graduate `_UC019_E2E_DATETIME_TAGS` e2e_rest xfails.

## Spec / grounding
- AdCP **3.1.1** `dist/docs/3.1.1/media-buy/advanced-topics/sandbox.mdx` §"Sandbox vs dry run": sellers MUST NOT alter behavior based on the deprecated testing headers (`X-Mock-Time`, `X-Dry-Run`, `X-Jump-To-Event`).
- Deliberate divergence for **internal e2e_rest infrastructure**: REST adopts `from_headers` so Docker UC-019 datetime rows can pin today. On the list path, `X-Mock-Time` changes date refinement with `simulate=False` (persisted non-terminal status is not refined to completed). Delivery still simulates under `mock_time`.
- Shared sandbox/non-production gate and a single `from_headers` resolver are **#2022**, not this PR. Related: #1646 / #1698.
- Storyboard: ungraded (test-infra).

## Test plan
- [x] Unit: REST testing_context extraction + list today from mock_time + dispatcher header
- [x] CI BDD In-Network / e2e_rest UC-019 datetime tags grade without datetime xfail
- [ ] Snapshot `_UC019_E2E_MOCK_TAGS` remain out of scope

Closes #1830
