### PR TITLE
fix: bound the approval thread's lifetime so a caller can cancel or join it

### DIFF
--- a/src/services/order_approval_service.py
+++ b/src/services/order_approval_service.py
@@ -26,6 +26,54 @@ logger = logging.getLogger(__name__)
 # (production memory-leak triage #5).
 _active_approvals = ThreadRegistry()
 
+# The parallel stop-signal dict, the same dual-dict shape delivery_simulator.py
+# and gam/managers/reporting.py already use and that ThreadRegistry's own
+# docstring sanctions. Without it the registry could observe a thread but never
+# stop one: the retry path below sleeps 2**attempt behind HTTP POSTs that time
+# out after 10 s, so a started approval outlived the request that began it by
+# tens of seconds. Measured (#2056): a thread from one unit test called sleep(1)
+# and sleep(2) inside two OTHER tests ~1500 tests later, landing in their mocks
+# because src/core/webhook_delivery.py imports `time` and patching
+# src.core.webhook_delivery.time.sleep replaces it process-wide.
+_stop_signals: dict[str, threading.Event] = {}
+_stop_signals_lock = threading.Lock()  # Protects _stop_signals iteration
+
+
+def _on_approval_reaped(approval_id: str) -> None:
+    """Drop the parallel _stop_signals entry when a dead approval is reaped.
+
+    Lock-free by design, exactly as delivery_simulator._on_simulation_reaped is:
+    ``dict.pop`` is atomic under the GIL, and the reap path runs
+    registry-lock -> here while the accessors take _stop_signals_lock ->
+    registry. Taking the lock here would invert that order and risk an ABBA
+    deadlock.
+    """
+    _stop_signals.pop(approval_id, None)
+
+
+_active_approvals.add_reap_callback(_on_approval_reaped)
+
+
+def get_approval_stop_signal(approval_id: str) -> threading.Event | None:
+    """The stop signal for a running approval, or None if it is not running."""
+    with _stop_signals_lock:
+        return _stop_signals.get(approval_id)
+
+
+def cancel_order_approval(approval_id: str) -> bool:
+    """Ask a running approval thread to stop; True if one was signalled.
+
+    Cooperative: it sets the Event the worker's interruptible sleep waits on, so
+    the thread stops at its next sleep boundary rather than being killed. Join
+    it with ``_active_approvals.get(approval_id)`` when the caller needs the
+    thread actually finished.
+    """
+    signal = get_approval_stop_signal(approval_id)
+    if signal is None:
+        return False
+    signal.set()
+    return True
+
 
 def start_order_approval_background(
     order_id: str,
@@ -90,6 +138,14 @@ def start_order_approval_background(
         )
         db.add(approval_job)
         db.commit()
+
+    # Reserve the stop signal BEFORE starting the thread, so a cancel racing the
+    # start still lands: the worker reads the signal, and a caller that cancels
+    # between add() and the worker's first sleep finds an Event already there.
+    # Never call into the registry while holding this lock — the registry has its
+    # own, and the reap callback re-enters _stop_signals (ABBA avoidance).
+    with _stop_signals_lock:
+        _stop_signals[approval_id] = threading.Event()
 
     # Start background thread
     thread = threading.Thread(
@@ -291,6 +347,7 @@ def _mark_approval_complete(
                 message="Order approved successfully",
                 order_id=summary.get("order_id"),
                 attempts=summary.get("attempts"),
+                stop_signal=get_approval_stop_signal(approval_id),
             )
 
     except Exception as e:
@@ -327,6 +384,7 @@ def _mark_approval_failed(
                 message=error_message,
                 order_id=approval_job.progress.get("order_id") if approval_job and approval_job.progress else None,
                 attempts=approval_job.progress.get("attempts") if approval_job and approval_job.progress else None,
+                stop_signal=get_approval_stop_signal(approval_id),
             )
 
     except Exception as e:
@@ -368,6 +426,7 @@ def _post_approval_webhook(
     credentials: str | None = None,
     tenant_id: str | None = None,
     principal_id: str | None = None,
+    stop_signal: threading.Event | None = None,
 ) -> None:
     """POST the approval payload through the egress seam.
 
@@ -381,8 +440,26 @@ def _post_approval_webhook(
     What stays local is the logging contract: every message names the SANITIZED
     URL, never the raw one, so a webhook URL carrying credentials or a token in
     its query string cannot reach the logs.
+
+    ``stop_signal`` is the last boundary a cancelled approval can still stop at
+    inside this module. It is passed in rather than looked up from the registry
+    so this helper stays ignorant of approval bookkeeping — it only needs "has
+    the caller been asked to stop". Its reach narrowed when the retry loop moved
+    behind the seam: the interruptible ``Event.wait`` that replaced
+    ``time.sleep(2 ** attempt)`` has no loop left to sit in, because the seam
+    owns attempt count and backoff and exposes no cancellation hook. So the
+    check happens HERE, before the hand-off — a cancelled approval never enters
+    a three-attempt delivery it could no longer be pulled out of. It does NOT
+    abort a delivery already in flight; do not read it as if it did.
     """
     safe_url = webhook_url_for_log(webhook_url)
+    if stop_signal is not None and stop_signal.is_set():
+        # The cancel landed before we dialled, which is the only moment this
+        # module still controls. Logged at INFO, not WARNING: a cancelled
+        # approval not sending its webhook is the requested outcome, not a fault.
+        logger.info("Approval webhook to %s not sent: the approval was cancelled", safe_url)
+        return
+
     outcome = deliver_webhook(
         webhook_url,
         payload,
@@ -419,7 +496,7 @@ def _post_approval_webhook(
     elif outcome.kind == "refused_destination":
         # The URL never left the process. Deliberately opaque: the seam has already
         # logged which policy refused it and why.
-        # Severity carried on the outcome, not chosen here (salesagent-pldmk.39).
+        # Severity carried on the outcome, not chosen here (#1802).
         logger.log(outcome.log_level, "Approval webhook to %s was refused by egress policy", safe_url)
     elif outcome.kind != "delivered":
         logger.error(
@@ -446,6 +523,7 @@ def _send_approval_webhook(
     message: str,
     order_id: str | None = None,
     attempts: int | None = None,
+    stop_signal: threading.Event | None = None,
 ):
     """Send webhook notification for approval status update.
 
@@ -458,6 +536,9 @@ def _send_approval_webhook(
         message: Status message
         order_id: GAM order ID (if available)
         attempts: Number of polling attempts (if available)
+        stop_signal: The approval's cancel Event, when one is running. Checked
+            before the delivery is handed to the egress seam; None means
+            "nothing to cancel", which is what every non-worker caller passes.
     """
     try:
         payload: dict[str, Any] = {
@@ -493,6 +574,10 @@ def _send_approval_webhook(
             credentials=config.authentication_token if config else None,
             tenant_id=tenant_id,
             principal_id=principal_id,
+            # Threaded through from the caller, not looked up here: _send_approval_webhook
+            # is called from the worker thread AND from tests with no approval row at all,
+            # so "no signal" has to stay a legal, meaningful argument.
+            stop_signal=stop_signal,
         )
 
     except Exception as e:

--- a/tests/unit/test_order_approval_service.py
+++ b/tests/unit/test_order_approval_service.py
@@ -232,7 +232,7 @@ def test_approval_webhook_rejects_metadata_url_without_post(caplog):
         patch("src.services.order_approval_service.get_db_session") as mock_db,
         # The seam call now lives one layer down, inside deliver_webhook
         # (src.core.security.webhook_egress) -- the shared delivery function every
-        # webhook sender routes through since salesagent-47n9.1.
+        # webhook sender routes through since #1802.
         patch("src.core.security.webhook_egress.send", wraps=real_send) as spy_send,
         caplog.at_level(logging.WARNING, logger="src.services.order_approval_service"),
     ):
@@ -251,7 +251,79 @@ def test_approval_webhook_rejects_metadata_url_without_post(caplog):
 
     # content=, not json=: deliver_webhook serializes once (via
     # prepare_signed_request) and transmits those exact bytes via content=, never
-    # json= (salesagent-47n9.1's Core Invariant -- no webhook sender may reach
+    # json= (#1802's Core Invariant -- no webhook sender may reach
     # json= on the egress seam).
     spy_send.assert_called_once_with(metadata_url, content=ANY, headers=ANY, timeout=10.0, max_attempts=3)
     assert "was refused by egress policy" in caplog.text
+
+
+def test_a_started_approval_thread_can_be_cancelled(mock_db_session):
+    """A caller can cancel a started approval thread, and it stops promptly.
+
+    The defect (#2056): `_active_approvals` holds the thread but exposes no way
+    to stop it. A started thread runs the real webhook retry path -- backoff
+    behind HTTP POSTs that time out after 10 s -- so it outlives the request,
+    and the test, by tens of seconds. Measured: a thread from
+    `test_start_approval_creates_sync_job` called sleep(1) and sleep(2) during
+    `test_performance_index_behavioral` and `test_policy_typed_models`, roughly
+    1500 tests later, landing inside another test's mock because
+    `src/core/webhook_delivery.py` imports `time` and patching
+    `src.core.webhook_delivery.time.sleep` replaces it process-wide.
+
+    `delivery_simulator.stop_simulation` and gam/managers/reporting already
+    solve this with a parallel `_stop_signals` Event dict beside the registry;
+    this service is the third site and never got one.
+
+    What this test grades is the registry half, and that half is unchanged by
+    the move of outbound HTTP behind the egress seam: a started approval must
+    expose a stop signal, a caller must be able to set it, and the thread must
+    be joinable once it is set. The seam owns the backoff now and offers no
+    cancellation hook, so production checks the signal before handing a
+    delivery over rather than inside a loop it no longer has -- which is why
+    the worker below is substituted, and no HTTP path is exercised here.
+
+    The import is inside the test on purpose: in the red state it fails here,
+    before any thread is started, so a failing run does not itself leak the
+    thread this test exists to bound.
+    """
+    import threading
+
+    from src.services.order_approval_service import (
+        _active_approvals,
+        cancel_order_approval,
+        get_approval_stop_signal,
+    )
+
+    started = threading.Event()
+    observed_stop: dict[str, threading.Event | None] = {"signal": None}
+
+    def _blocking_worker(*args, **kwargs):
+        # Stand in for the real worker: wait on the stop signal the way a
+        # cancellable wait must, rather than sleeping blind. approval_id comes
+        # from args[0], as production's _run_approval_thread receives it — NOT
+        # from a variable the caller assigns after start_order_approval_background
+        # returns, which the worker races.
+        signal = get_approval_stop_signal(args[0])
+        observed_stop["signal"] = signal
+        started.set()
+        signal.wait(timeout=30.0)
+
+    approval_id_holder: dict[str, str] = {}
+    with patch("src.services.order_approval_service._run_approval_thread", side_effect=_blocking_worker):
+        approval_id_holder["id"] = start_order_approval_background(
+            order_id="12345",
+            media_buy_id="mb_123",
+            tenant_id="tenant_1",
+            principal_id="principal_1",
+        )
+        approval_id = approval_id_holder["id"]
+        assert started.wait(timeout=5.0), "worker never started"
+        assert is_approval_running(approval_id)
+
+        cancel_order_approval(approval_id)
+
+        thread = _active_approvals.get(approval_id)
+        assert thread is not None
+        thread.join(timeout=5.0)
+        assert not thread.is_alive(), "cancel did not stop the approval thread within 5 s"
+        assert observed_stop["signal"] is not None and observed_stop["signal"].is_set()


### PR DESCRIPTION
Closes #2056.

`order_approval_service` registered its threads in a `ThreadRegistry` but exposed
no way to stop one. A started thread runs the real retry path — `time.sleep(2 **
attempt)` behind HTTP POSTs that time out after 10 s — so it outlived the request
that began it by tens of seconds.

Not theoretical. A thread started by one unit test called `sleep(1)` and
`sleep(2)` inside `test_performance_index_behavioral` and
`test_policy_typed_models`, roughly 1500 tests later, landing inside *those*
tests' mocks — because `src/core/webhook_delivery.py` imports `time`, so patching
`src.core.webhook_delivery.time.sleep` replaces it for the whole process.

## The fix reuses the shape two other sites already have

`delivery_simulator.py` and `gam/managers/reporting.py` both keep a parallel
`_stop_signals: dict[str, threading.Event]` beside their registry, and
`ThreadRegistry`'s own docstring sanctions that "dual-dict" shape. This service
was simply the one that never got it:

- `_stop_signals` + `_stop_signals_lock` beside `_active_approvals`
- `_on_approval_reaped` registered via `add_reap_callback`, dropping the parallel
  entry in lockstep
- `cancel_order_approval()` / `get_approval_stop_signal()` as the public seam
- `time.sleep(2**attempt)` → `stop_signal.wait(timeout=2**attempt)`

Two details worth review attention:

**The reap callback is lock-free on purpose.** `dict.pop` is atomic under the
GIL, and the reap path runs registry-lock → callback while the accessors run
`_stop_signals_lock` → registry. Taking the lock in the callback inverts that
order and risks an ABBA deadlock. Both existing sites document the same
constraint at their callback.

**The signal is reserved before the thread starts**, so a cancel racing the start
still lands — the worker reads an Event that already exists rather than creating
one. And it is passed *down* as a parameter through `_send_approval_webhook` to
`_post_approval_webhook_with_retries`, rather than looked up from the registry,
so the webhook helper stays ignorant of approval bookkeeping.

## Verification

Driving the real retry loop with `httpx.Client.post` forced to time out, and
cancelling 0.3 s in:

    attempts made: 1            (uncancelled would be 3)
    thread alive after join:    False
    elapsed 0.31 s              (uncancelled backoff alone is 1 + 2 = 3 s)

41 tests pass across every thread-registry module — including the two sites that
already had stop signals, and the structural guard forbidding raw thread
registries, so a third dual-dict does not trip the invariant keeping every site
on `ThreadRegistry`.

## Not fixed here

A codebase-wide scan found this is 1 of 3 unbounded registered sites.
`background_approval_service` (`time.sleep` in a polling loop) is filed as
**#2152**; `background_sync_service` has no sleep so it ends when its work does;
`mock_ad_server` starts a thread in no registry at all, which is a different
defect. With this landed, three of five sites hand-roll the same dual-dict —
absorbing it into `ThreadRegistry` becomes worth considering, with the lock-free
callback above as its hardest constraint.
