### PR TITLE
fix: resolve the tenant's own AI configuration once, and say when ranking is skipped

### DIFF
--- a/.duplication-baseline
+++ b/.duplication-baseline
@@ -1,5 +1,5 @@
 {
   "src": 31,
-  "tests": 71,
+  "tests": 69,
   "scripts": 0
 }

--- a/src/a2a_server/adcp_a2a_server.py
+++ b/src/a2a_server/adcp_a2a_server.py
@@ -251,6 +251,44 @@ def _internal_error_for(operation: str, exc: Exception) -> InternalError:
     )
 
 
+def _response_failed(response_data: dict[str, Any]) -> bool:
+    """Did this task FAIL, as opposed to completing with something to say about it?
+
+    The A2A ``success`` marker (see ``_stamp_a2a_protocol_fields``) answers this
+    question, and until now it answered a different one: "is ``errors[]`` non-empty".
+    Pinned ``core/protocol-envelope.json`` is explicit that those are not the same
+    question — on ``adcp_error``: "a fatal task failure SHOULD populate both this
+    envelope-level field AND the payload's ``errors[]`` array ... Non-fatal warnings
+    populate ONLY ``payload.errors[]`` with ``severity: warning`` — the envelope MUST
+    NOT carry ``adcp_error`` for non-failures." The envelope's own two examples carry
+    exactly that contrast: ``severity: "warning"`` on a completed response, and
+    ``severity: "error"`` on ``status: "failed"``.
+
+    So an entry marked ``severity: "warning"`` is, by the schema's own definition, not a
+    failure and must not flip the marker. Anything else is: an entry with no severity
+    (every fatal ``errors[]`` this codebase emits — ``UpdateMediaBuyError``,
+    ``get_media_buys``' AUTH_REQUIRED degradation) keeps reporting ``success=False``, so
+    the marker only moves for entries that have explicitly declared themselves advisory.
+
+    Deliberately not keyed on the tool or the code. ``get_products``' unranked-ranking
+    advisory is the entry that surfaced this, and a per-tool branch here would leave
+    every sibling to be found separately: ``get_media_buys``'
+    ``_omitted_row_advisory``, and the ``property_list_unsupported_advisories`` that
+    ``create_media_buy`` / ``update_media_buy`` attach, are all non-fatal notices riding
+    a completed response, and all of them still report ``success=False`` today because
+    none of them carries the ``severity`` marker. That is their defect to fix, in one
+    keyword each, and this predicate is what makes fixing it work — the alternative
+    (inferring "advisory" from the code, or from which tool answered) would have to be
+    re-litigated for every new advisory.
+    """
+    if response_data.get("adcp_error"):
+        return True
+    errors = response_data.get("errors") or []
+    # A non-dict entry cannot be shown to be advisory, so it counts as a failure —
+    # unrecognised shapes must not silently upgrade a response to success.
+    return any(not isinstance(entry, dict) or entry.get("severity") != "warning" for entry in errors)
+
+
 class AdCPRequestHandler(RequestHandler):
     """Request handler for AdCP A2A operations supporting JSON-RPC 2.0."""
 
@@ -1418,9 +1456,9 @@ class AdCPRequestHandler(RequestHandler):
         ``task_id``/``adcp_version``; see
         ``tests/integration/test_harness_wire_response.py::ENVELOPE_MARKERS``),
         a deliberate A2A-binding deviation (#1868 review).
-        ``success`` is derived from ``errors`` so a response carrying
-        per-item errors reports ``success=False`` uniformly, regardless of
-        which caller stamped it.
+        ``success`` reports whether the task FAILED, so a response carrying
+        errors reports ``success=False`` uniformly, regardless of which
+        caller stamped it.
 
         Single point for this derivation — three sites used to duplicate it
         inline, and two of the three (the get_products explicit-skill and
@@ -1437,9 +1475,8 @@ class AdCPRequestHandler(RequestHandler):
         response_data = response.model_dump(mode="json")
         response_data["message"] = str(response)
 
-        # Derive success from errors field if present, default True otherwise
-        if "errors" in response_data:
-            response_data["success"] = not bool(response_data["errors"])
+        if "errors" in response_data or "adcp_error" in response_data:
+            response_data["success"] = not _response_failed(response_data)
         else:
             response_data.setdefault("success", True)
 

--- a/src/admin/blueprints/creatives.py
+++ b/src/admin/blueprints/creatives.py
@@ -121,7 +121,7 @@ async def _deliver_sync_creatives_webhook(
         # in scope all along -- the caller raises without tenant_id, and the
         # creative row carries principal_id -- but neither reached the dict, so
         # records_delivery_log was False and every admin-originated delivery wrote
-        # no webhook_delivery_log row and said nothing about it (salesagent-pldmk.39).
+        # no webhook_delivery_log row and said nothing about it (#1802).
         await service.notify(
             push_notification_config,
             task=WebhookTaskContext(
@@ -277,7 +277,7 @@ async def _call_webhook_for_creative_status(
             # Read INSIDE the UoW, like every other attribute here: the row is
             # detached once the session closes. This is the identifier that never
             # reached the delivery, which is why admin-originated sends wrote no
-            # webhook_delivery_log row (salesagent-pldmk.39).
+            # webhook_delivery_log row (#1802).
             step_principal_id = next((c.principal_id for c in all_creatives if c.principal_id), None)
 
         # --- Session closed here; webhook delivery is outside the transaction ---
@@ -298,6 +298,24 @@ async def _call_webhook_for_creative_status(
     except Exception as e:
         logger.error(f"Error sending protocol webhook for creative {creative_id}: {e}", exc_info=True)
         return False
+
+
+def _tenant_ai_enabled(tenant: Any) -> bool:
+    """Can an AI call actually run for this tenant? One owner for that question.
+
+    ``TenantAIConfig.from_tenant`` resolves the tenant's own configuration (``ai_config``
+    first, the legacy ``gemini_api_key`` column second) and ``is_ai_enabled`` adds the
+    platform fallback, so this answers the same question the AI review impl acts on.
+
+    Reading ``tenant.gemini_api_key`` directly answered a DIFFERENT question, and the two
+    disagreed inside this one file: ``review_creatives`` told a tenant that had configured
+    Anthropic (or a Gemini key) through the Admin UI's ``ai_config`` column that AI review
+    was unavailable, while ``_perform_ai_review`` — one page's button away — would happily
+    run one for that same tenant.
+    """
+    from src.services.ai import AIServiceFactory, TenantAIConfig
+
+    return AIServiceFactory().is_ai_enabled(TenantAIConfig.from_tenant(tenant))
 
 
 @creatives_bp.route("/", methods=["GET"])
@@ -385,7 +403,8 @@ def review_creatives(tenant_id, **kwargs):
 
         # Extract tenant attributes before UoW closes (avoid DetachedInstanceError)
         tenant_name = tenant.name
-        has_ai_review = bool(tenant.gemini_api_key and tenant.creative_review_criteria)
+        # The same two conditions `_perform_ai_review` gates on, in the same order.
+        has_ai_review = bool(_tenant_ai_enabled(tenant) and tenant.creative_review_criteria)
         approval_mode = tenant.approval_mode
 
     return render_template(
@@ -1082,7 +1101,7 @@ def _ai_review_creative_impl_inner(
     from src.core.database.repositories.product import ProductRepository
     from src.core.database.repositories.tenant_config import TenantConfigRepository
     from src.core.metrics import ai_review_confidence, record_ai_review
-    from src.services.ai import AIServiceFactory
+    from src.services.ai import AIServiceFactory, TenantAIConfig
     from src.services.ai.agents.review_agent import (
         create_review_agent,
         parse_confidence_score,
@@ -1110,20 +1129,10 @@ def _ai_review_creative_impl_inner(
         if not tenant:
             return {"status": "pending_review", "error": "Tenant not found", "reason": "Configuration error"}
 
-        # Check AI availability - use factory to check tenant + platform config
-        factory = AIServiceFactory()
-
-        # Build effective config from tenant settings
-        tenant_ai_config = tenant.ai_config if hasattr(tenant, "ai_config") else None
-
-        # Backward compatibility: use gemini_api_key if no ai_config
-        if not tenant_ai_config and tenant.gemini_api_key:
-            tenant_ai_config = {
-                "provider": "gemini",
-                "api_key": tenant.gemini_api_key,
-            }
-
-        if not factory.is_ai_enabled(tenant_ai_config):
+        # Check AI availability through `_tenant_ai_enabled` — the same call the
+        # creative-management page makes for its `has_ai_review` flag, so the page and
+        # this impl cannot disagree about whether a review can run.
+        if not _tenant_ai_enabled(tenant):
             return {
                 "status": "pending_review",
                 "error": "AI not configured",
@@ -1157,7 +1166,7 @@ def _ai_review_creative_impl_inner(
                                 promoted_offering = product.name
 
         # Create Pydantic AI agent and run review
-        model_string = factory.create_model(tenant_ai_config)
+        model_string = AIServiceFactory().create_model(TenantAIConfig.from_tenant(tenant))
         agent = create_review_agent(model_string)
 
         # Run async agent in a separate thread to avoid event loop conflicts with Flask

--- a/src/core/tenant_context.py
+++ b/src/core/tenant_context.py
@@ -56,6 +56,7 @@ class TenantContext(BaseModel):
     approval_mode: str = "require-human"  # BR-RULE-037: creative approval mode
     account_approval_mode: str | None = None  # BR-RULE-060: account approval mode (auto|credit_review|legal_review)
     gemini_api_key: str | None = None
+    ai_config: dict[str, Any] | None = None  # provider/model/api_key; supersedes gemini_api_key
     creative_review_criteria: str | None = None
     brand_manifest_policy: str = "require_auth"
     advertising_policy: dict[str, Any] | None = None
@@ -117,6 +118,7 @@ class TenantContext(BaseModel):
             approval_mode=tenant.approval_mode or "require-human",
             account_approval_mode=tenant.account_approval_mode,
             gemini_api_key=tenant.gemini_api_key,
+            ai_config=tenant.ai_config,
             creative_review_criteria=tenant.creative_review_criteria,
             brand_manifest_policy=tenant.brand_manifest_policy or "require_auth",
             advertising_policy=safe_json_loads(tenant.advertising_policy, None),

--- a/src/core/tools/products.py
+++ b/src/core/tools/products.py
@@ -663,8 +663,17 @@ async def _get_products_impl(
             from src.services.ai.factory import get_factory
 
             factory = get_factory()
-            if factory.is_ai_enabled():
-                model = factory.create_model()
+            # Pass the tenant's own AI configuration. Without it the factory falls
+            # back to an empty TenantAIConfig and sees only the platform-level key
+            # from the environment, so a tenant that configured its key in the Admin
+            # UI got no ranking at all — and the miss is logged at debug level, so it
+            # fails silently. Mirrors the fallback in src/core/utils/naming.py.
+            tenant_ai_config = tenant.get("ai_config")
+            if not tenant_ai_config and tenant.get("gemini_api_key"):
+                tenant_ai_config = {"provider": "gemini", "api_key": tenant.get("gemini_api_key")}
+
+            if factory.is_ai_enabled(tenant_ai_config):
+                model = factory.create_model(tenant_ai_config=tenant_ai_config)
                 agent = create_ranking_agent(model)
 
                 # Convert products to dicts for ranking

--- a/src/core/tools/products.py
+++ b/src/core/tools/products.py
@@ -13,7 +13,7 @@ from typing import Annotated, Any, cast
 from adcp import FormatId, ProductFilters
 from adcp import GetProductsRequest as GetProductsRequestGenerated
 from adcp import Product as LibraryProduct
-from adcp.types import BrandReference, ContextObject, PropertyListReference
+from adcp.types import BrandReference, ContextObject, Error, PropertyListReference
 from fastmcp.server.context import Context
 from pydantic import Field
 
@@ -24,6 +24,7 @@ from src.core.exceptions import (
     AdCPAdapterError,
     AdCPAuthenticationError,
     AdCPAuthorizationError,
+    AdCPConfigurationError,
     AdCPError,
     AdCPPolicyViolationError,
     AdCPValidationError,
@@ -39,6 +40,7 @@ from src.core.testing_hooks import AdCPTestContext
 from src.core.tool_context import ToolContext
 from src.core.transport_helpers import resolve_identity_from_context
 from src.core.validation_helpers import adcp_validation_boundary, safe_parse_json_field
+from src.services.ai.config import TenantAIConfig
 from src.services.policy_check_service import PolicyCheckService, PolicyStatus
 
 logger = logging.getLogger(__name__)
@@ -150,6 +152,193 @@ def filter_products_by_property_list(
     return [p for p in products if should_include_product_for_property_list(p, allowed_properties)]
 
 
+# The recovery classification each advisory code carries on the wire, mirroring the
+# `enumMetadata` block of the pinned `enums/error-code.json`. Derived from the code
+# rather than passed alongside it: recovery is a PROPERTY of the code, and a call site
+# free to pair them itself is a call site free to tell a buyer to retry a missing API
+# key (or to give up on a rate limit).
+#
+# * CONFIGURATION_ERROR -> "terminal" / "surface to a human at the seller — the buyer
+#   cannot resolve a seller-side deployment misconfiguration and MUST NOT auto-retry".
+# * SERVICE_UNAVAILABLE -> "transient" / "retry with exponential backoff".
+#
+# recovery is stated on the wire rather than left to be inferred from the enum because
+# pinned `core/error.json` makes the code vocabulary OPEN ("senders MAY emit codes
+# outside that set ... read `error.recovery` for the recovery classification"): a client
+# that does not consult the enum still classifies these correctly.
+_ADVISORY_RECOVERY: dict[str, str] = {
+    "CONFIGURATION_ERROR": "terminal",
+    "SERVICE_UNAVAILABLE": "transient",
+}
+
+
+def _unranked_products_advisory(tenant_id: str, *, code: str, cause: str) -> Error:
+    """The advisory that stands in for AI ranking a tenant asked for but did not get.
+
+    Ranking is configured (``product_ranking_prompt`` is set) but did not happen, so
+    ``products[]`` comes back in catalog order. Silence here is the bug: the buyer sees
+    a plausible-looking list and has no way to tell it was never ranked. One builder,
+    two callers — the shape, the field pointer and the ``PRODUCT_RANKING_UNAVAILABLE``
+    marker are identical; only the CODE and the ``cause`` clause differ, because the two
+    conditions need opposite advice:
+
+    * **Nothing resolved / nothing usable resolved** — CONFIGURATION_ERROR. The fault is
+      entirely on the seller's side of the wire (the buyer's request was valid) and no
+      retry, at any backoff, supplies a missing API key. This mirrors the ruling at
+      ``src/core/tools/media_buy_list.py::_omitted_row_advisory``.
+    * **The ranking call itself did not complete** — SERVICE_UNAVAILABLE. A provider
+      429, a 5xx, a timeout, an unexpected model response: pydantic-ai raises
+      ``ModelHTTPError`` / ``UnexpectedModelBehavior`` / ``UsageLimitExceeded`` /
+      ``UserError``, all of which subclass ``RuntimeError``. Telling the buyer
+      "terminal — MUST NOT auto-retry" for a rate limit is wrong advice; the pinned
+      enumDescription for SERVICE_UNAVAILABLE is "Seller service is temporarily
+      unavailable. Retry with exponential backoff. Recovery: transient."
+
+    The ``cause`` clause never interpolates ``str(exc)``. This message is wire-visible to
+    an anonymous buyer (``get_products`` is auth-optional discovery), and a provider
+    exception's text can carry request URLs, response bodies and key fragments; the
+    pinned enumDescription for CONFIGURATION_ERROR states sellers "MUST NOT include
+    credentials, connection strings, or stack traces — the message is wire-visible to
+    the buyer". The exception class name is enough to classify; the full text goes to
+    the seller's log.
+
+    It rides on ``payload.errors[]`` inside a SUCCESS envelope, never as an envelope
+    ``adcp_error``: pinned ``core/protocol-envelope.json`` states that non-fatal warnings
+    populate ONLY ``payload.errors[]`` with ``severity: warning`` and that the envelope
+    MUST NOT carry ``adcp_error`` for non-failures, and pinned
+    ``get-products-response.json`` requires ``errors[]`` only when ``status == "failed"``
+    while describing it as "Task-specific errors and warnings", so a completed response
+    may carry it. Ungraded: no phase in the pinned storyboards grades a get_products
+    ranking advisory.
+    """
+    return Error(  # structural-guard: advisory unranked-catalog notice in GetProductsResponse.errors[]
+        code=code,
+        recovery=_ADVISORY_RECOVERY[code],
+        # severity is not a field of the pinned core/error.json, whose
+        # additionalProperties is true; it is the marker the envelope schema names for a
+        # non-fatal payload error, and the envelope's own examples carry it exactly here.
+        # It is also what keeps the A2A envelope reporting success=True for an advisory
+        # (see AdCPRequestHandler._stamp_a2a_protocol_fields).
+        severity="warning",
+        message=(
+            f"PRODUCT_RANKING_UNAVAILABLE: seller {tenant_id!r} has AI product ranking "
+            f"configured but {cause}, so these products are returned unranked (catalog "
+            f"order), not ordered by relevance to the brief."
+        ),
+        field="products[]",
+    )
+
+
+async def _rank_products_with_ai(
+    products: list[Product],
+    tenant: Any,
+    ranking_prompt: str,
+    brief_text: str,
+    advisories: list[Error],
+) -> list[Product]:
+    """Order products by AI-scored relevance to the brief, dropping the irrelevant ones.
+
+    Returns the products unchanged when ranking cannot run, appending EXACTLY ONE
+    advisory to ``advisories`` on every such path — the unusable-configuration one and
+    the call-did-not-complete one alike. Owning the failure paths here, rather than in a
+    ``try`` at the call site, is what makes that "every" true: the caller's handler
+    logged a warning and dropped through with ``advisories`` untouched, so a provider
+    401/429/5xx returned a plausible-looking catalog-order list with ``errors=None`` —
+    precisely the silent failure the advisory exists to end, on the paths most likely to
+    happen in production.
+
+    Extracted from ``_get_products_impl`` so the ranking decision reads in one place —
+    and so this addition does not deepen a function already over every complexity
+    threshold.
+    """
+    from src.services.ai.agents.ranking_agent import create_ranking_agent, rank_products_async
+    from src.services.ai.factory import get_factory
+
+    tenant_id = tenant["tenant_id"]
+    factory = get_factory()
+    # TenantAIConfig.from_tenant owns "given a tenant, what is its AI configuration?" —
+    # ai_config first, the legacy gemini_api_key column second, None when neither is set.
+    # Reading only the platform environment key here meant a tenant that configured its
+    # key in the Admin UI got no ranking at all.
+    tenant_ai_config = TenantAIConfig.from_tenant(tenant)
+
+    # is_ai_enabled(), not `tenant_ai_config is not None`: the platform-key fallback is
+    # existing, relied-upon behaviour for ranking — a deployment-wide GEMINI_API_KEY
+    # ranks for every tenant that set a ranking prompt.
+    if not factory.is_ai_enabled(tenant_ai_config):
+        logger.warning(
+            "[GET_PRODUCTS] AI ranking is configured for tenant %s but no usable AI configuration "
+            "resolved (tenant ai_config/gemini_api_key: %s; platform environment key: absent). "
+            "Returning products unranked.",
+            tenant_id,
+            "present but unusable" if tenant_ai_config is not None else "absent",
+        )
+        advisories.append(
+            _unranked_products_advisory(
+                tenant_id,
+                code="CONFIGURATION_ERROR",
+                cause="no usable AI configuration resolved for it",
+            )
+        )
+        return products
+
+    try:
+        model = factory.create_model(tenant_ai_config=tenant_ai_config)
+        ranking_result = await rank_products_async(
+            agent=create_ranking_agent(model),
+            custom_prompt=ranking_prompt,
+            brief=brief_text,
+            products=products,
+        )
+    except (AdCPConfigurationError, ImportError, RuntimeError, OSError) as e:
+        # Two conditions, opposite advice, one handler so neither can be added without
+        # its advisory:
+        #
+        # * AdCPConfigurationError is the factory REFUSING this seller's configuration.
+        #   `is_ai_enabled` can report a coherent provider/model/key and `create_model`
+        #   still decline the combination (a provider with no explicit-API-key
+        #   integration, where the string form would authenticate with whatever ELSE is
+        #   in the environment). It extends Exception, not RuntimeError, so nothing here
+        #   caught it: a seller-side misconfiguration 500'd an auth-OPTIONAL discovery
+        #   call for every anonymous buyer. Same fault as the branch above, same code.
+        # * Everything else is the call not completing. pydantic-ai's ModelHTTPError,
+        #   UnexpectedModelBehavior, UsageLimitExceeded and UserError all subclass
+        #   RuntimeError, so every provider auth failure, 429, timeout and malformed
+        #   response lands here. That is transient, not a deployment misconfiguration.
+        #
+        # `str(e)` is logged for the seller and deliberately kept OFF the wire (see
+        # `_unranked_products_advisory`).
+        code, cause = (
+            ("CONFIGURATION_ERROR", "its AI configuration cannot build a model")
+            if isinstance(e, AdCPConfigurationError)
+            else ("SERVICE_UNAVAILABLE", "the ranking call did not complete")
+        )
+        logger.warning(
+            "[GET_PRODUCTS] AI ranking did not run for tenant %s (%s). Returning products unranked. Cause: %s",
+            tenant_id,
+            cause,
+            e,
+        )
+        advisories.append(_unranked_products_advisory(tenant_id, code=code, cause=f"{cause} ({type(e).__name__})"))
+        return products
+
+    # Build a map of product_id -> (score, reason); products the agent did not score sort last.
+    ranking_map = {r.product_id: (r.relevance_score, r.reason) for r in ranking_result.rankings}
+    ranked = sorted(products, key=lambda p: ranking_map.get(p.product_id, (0.0, ""))[0], reverse=True)
+    # Drop very low relevance. Deliberately NOT reported on errors[]: the pinned schema
+    # assigns score-threshold reporting to filter_diagnostics and calls it observability,
+    # not error reporting.
+    ranked = [p for p in ranked if ranking_map.get(p.product_id, (0.0, ""))[0] >= 0.1]
+
+    for r in ranking_result.rankings:
+        logger.info(f"[AI_RANKING] {r.product_id}: score={r.relevance_score:.2f}, reason={r.reason}")
+    logger.info(
+        f"[GET_PRODUCTS] AI ranking applied: {len(ranking_result.rankings)} products ranked, "
+        f"{len(ranked)} products above threshold"
+    )
+    return ranked
+
+
 async def _get_products_impl(
     req: GetProductsRequestGenerated, identity: ResolvedIdentity | None
 ) -> GetProductsResponse:
@@ -229,15 +418,41 @@ async def _get_products_impl(
         policy_disabled_reason = "disabled_by_tenant"
         logger.info(f"Policy checks disabled for tenant {tenant['tenant_id']}")
     else:
-        # Get tenant's Gemini API key for policy checks
-        tenant_gemini_key = tenant.get("gemini_api_key")
-        if not tenant_gemini_key:
-            # No API key - cannot run policy checks
+        # Resolve the tenant's own AI configuration. `TenantAIConfig.from_tenant` returns
+        # a config only when the tenant has its OWN usable credential — ai_config with a
+        # non-empty api_key first, the legacy gemini_api_key column second, None
+        # otherwise — so `is not None` here reads as "this seller has a credential of its
+        # own". That is the same question the pre-PR gate asked as
+        # `tenant.get("gemini_api_key")`, generalised to the column the Admin UI actually
+        # writes: reading only gemini_api_key meant a tenant that configured AI in the UI
+        # had its policy checks silently skipped even with "enabled" ticked.
+        #
+        # Usability is load-bearing, not incidental. src/admin/blueprints/settings.py
+        # stores {"provider": ..., "model": ...} with NO api_key when the seller leaves
+        # the key blank, and tells them "AI features will be disabled" as it does. If
+        # that row came back as a configuration, this gate would open and
+        # check_brief_compliance would make a live LLM call on the OPERATOR's platform
+        # credential — and a BLOCKED verdict raises AdCPPolicyViolationError below, a new
+        # buyer-visible rejection for a tenant the UI said was switched off.
+        #
+        # The gate is NOT factory.is_ai_enabled(): is_ai_enabled counts the platform
+        # GEMINI_API_KEY from the environment, so gating on it would silently switch
+        # policy checks on for every tenant on any deployment that sets that variable.
+        # Gating on the tenant's own configuration widens the gate exactly as far as the
+        # bug requires and no further.
+        tenant_ai_config = TenantAIConfig.from_tenant(tenant)
+        if tenant_ai_config is None:
+            # No AI configuration - cannot run policy checks
             policy_result = None
-            policy_disabled_reason = "no_gemini_api_key"
-            logger.warning(f"Policy checks enabled but no Gemini API key configured for tenant {tenant['tenant_id']}")
+            policy_disabled_reason = "no_ai_configuration"
+            logger.warning(f"Policy checks enabled but no AI configuration for tenant {tenant['tenant_id']}")
         else:
-            policy_service = PolicyCheckService(gemini_api_key=tenant_gemini_key)
+            # tenant_ai_config=, not the deprecated gemini_api_key=: that parameter pins
+            # provider/model instead of honouring the tenant's own, and its _UNSET
+            # sentinel treats an explicit None as "hard-disable AI". Leaving it unset
+            # keeps the intended branch — configuration honoured, platform defaults
+            # filling any field the tenant did not set.
+            policy_service = PolicyCheckService(tenant_ai_config=tenant_ai_config)
 
             # Use advertising_policy settings for tenant-specific rules
             tenant_policies = advertising_policy if advertising_policy else {}
@@ -653,63 +868,20 @@ async def _get_products_impl(
         eligible_products = filtered_products
 
     # AI-powered product ranking (when tenant has product_ranking_prompt configured)
+    advisories: list[Error] = []
     product_ranking_prompt = tenant.get("product_ranking_prompt")
     if product_ranking_prompt and brief_text and eligible_products:
-        try:
-            from src.services.ai.agents.ranking_agent import (
-                create_ranking_agent,
-                rank_products_async,
-            )
-            from src.services.ai.factory import get_factory
-
-            factory = get_factory()
-            # Pass the tenant's own AI configuration. Without it the factory falls
-            # back to an empty TenantAIConfig and sees only the platform-level key
-            # from the environment, so a tenant that configured its key in the Admin
-            # UI got no ranking at all — and the miss is logged at debug level, so it
-            # fails silently. Mirrors the fallback in src/core/utils/naming.py.
-            tenant_ai_config = tenant.get("ai_config")
-            if not tenant_ai_config and tenant.get("gemini_api_key"):
-                tenant_ai_config = {"provider": "gemini", "api_key": tenant.get("gemini_api_key")}
-
-            if factory.is_ai_enabled(tenant_ai_config):
-                model = factory.create_model(tenant_ai_config=tenant_ai_config)
-                agent = create_ranking_agent(model)
-
-                # Convert products to dicts for ranking
-                # Run AI ranking
-                ranking_result = await rank_products_async(
-                    agent=agent,
-                    custom_prompt=product_ranking_prompt,
-                    brief=brief_text,
-                    products=eligible_products,
-                )
-
-                # Build a map of product_id -> (score, reason)
-                ranking_map = {r.product_id: (r.relevance_score, r.reason) for r in ranking_result.rankings}
-
-                # Sort products by relevance score (highest first)
-                # Products not in ranking_map get score 0
-                eligible_products.sort(
-                    key=lambda p: ranking_map.get(p.product_id, (0.0, ""))[0],
-                    reverse=True,
-                )
-
-                # Filter out products with very low relevance (score < 0.1)
-                eligible_products = [p for p in eligible_products if ranking_map.get(p.product_id, (0.0, ""))[0] >= 0.1]
-
-                # Log the ranking results
-                for r in ranking_result.rankings:
-                    logger.info(f"[AI_RANKING] {r.product_id}: score={r.relevance_score:.2f}, reason={r.reason}")
-
-                logger.info(
-                    f"[GET_PRODUCTS] AI ranking applied: {len(ranking_result.rankings)} products ranked, "
-                    f"{len(eligible_products)} products above threshold"
-                )
-            else:
-                logger.debug("[GET_PRODUCTS] AI ranking configured but AI not enabled (no API key)")
-        except (ImportError, RuntimeError, OSError) as e:
-            logger.warning(f"Failed to apply AI product ranking: {e}. Returning unranked products.")
+        # No handler here on purpose: `_rank_products_with_ai` owns every failure path so
+        # that each one emits its advisory. A `try` here could only log and drop through
+        # with `advisories` empty — which is how a provider 429 returned an unranked list
+        # with `errors=None`.
+        eligible_products = await _rank_products_with_ai(
+            products=eligible_products,
+            tenant=tenant,
+            ranking_prompt=product_ranking_prompt,
+            brief_text=brief_text,
+            advisories=advisories,
+        )
 
     # Annotate pricing options with adapter support (AdCP PR #88)
     # Do this BEFORE serialization to avoid reconstruction issues
@@ -759,7 +931,7 @@ async def _get_products_impl(
     # but mypy still needs cast() due to list invariance in static typing
     resp = GetProductsResponse(
         products=cast(list[LibraryProduct], eligible_products),
-        errors=None,
+        errors=advisories or None,
         context=req.context,
     )
 

--- a/src/core/utils/naming.py
+++ b/src/core/utils/naming.py
@@ -91,19 +91,19 @@ def generate_auto_name(
         "Nike Air Max Campaign - Q4 Holiday Push"
         "Acme Corp Brand Awareness - Premium Video"
     """
-    from src.services.ai import AIServiceFactory
+    from src.services.ai import AIServiceFactory, TenantAIConfig
 
     factory = AIServiceFactory()
 
-    # Handle backward compatibility: convert gemini_api_key to ai_config
-    effective_config = tenant_ai_config
-    if effective_config is None and tenant_gemini_key:
-        effective_config = {
-            "provider": "gemini",
-            "api_key": tenant_gemini_key,
-        }
+    # One owner for "ai_config first, legacy gemini_api_key second, else nothing":
+    # TenantAIConfig.from_tenant reads those two field names off whatever it is given,
+    # so the two deprecated-parameter shapes this function accepts resolve through the
+    # same rule as every other consumer. This site used to test `is None` where the
+    # others tested falsiness, which made an empty ai_config dict shadow the legacy key
+    # here and fall through to it everywhere else.
+    effective_config = TenantAIConfig.from_tenant({"ai_config": tenant_ai_config, "gemini_api_key": tenant_gemini_key})
 
-    # Check if AI is enabled
+    # Check if AI is enabled (None still falls back to the platform environment key)
     if not factory.is_ai_enabled(effective_config):
         logger.debug("No AI configuration available, falling back to brand_name")
         return _get_fallback_name(request)

--- a/src/core/utils/tenant_utils.py
+++ b/src/core/utils/tenant_utils.py
@@ -53,6 +53,7 @@ def serialize_tenant_to_dict(tenant: Tenant) -> dict[str, Any]:
         "account_approval_mode": tenant.account_approval_mode,
         "supported_billing": safe_json_loads(tenant.supported_billing, None),
         "gemini_api_key": tenant.gemini_api_key,
+        "ai_config": tenant.ai_config,
         "creative_review_criteria": tenant.creative_review_criteria,
         "brand_manifest_policy": tenant.brand_manifest_policy,
         "advertising_policy": safe_json_loads(tenant.advertising_policy, None),

--- a/src/services/ai/config.py
+++ b/src/services/ai/config.py
@@ -1,8 +1,13 @@
 """Configuration models for Pydantic AI service."""
 
+import logging
 import os
+from collections.abc import Mapping
+from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ValidationError
+
+logger = logging.getLogger(__name__)
 
 
 class ModelSettings(BaseModel):
@@ -15,6 +20,13 @@ class ModelSettings(BaseModel):
 
 GOOGLE_PROVIDER_ALIASES: frozenset[str] = frozenset({"gemini", "google", "google-gla"})
 CANONICAL_GOOGLE_PROVIDER = "google"
+
+# The model that pairs with the Google provider. Named here because a provider and a
+# model must travel together: a model name is only meaningful to the vendor it belongs
+# to, so a Google client handed a "claude-*" name 404s on every call. This is the pin
+# src/services/policy_check_service.py hard-coded at its own call site.
+DEFAULT_GOOGLE_MODEL = "gemini-2.0-flash"
+DEFAULT_PLATFORM_PROVIDER = "gemini"
 
 
 def canonicalize_google_provider(provider: str) -> str:
@@ -52,6 +64,138 @@ class TenantAIConfig(BaseModel):
     # Model behavior settings
     settings: ModelSettings = Field(default_factory=ModelSettings)
 
+    @classmethod
+    def coerce(cls, value: Any, *, source: str = "tenant ai_config") -> "TenantAIConfig":
+        """Tolerant parse of a STORED AI configuration value; caller mistakes still raise.
+
+        Two failure modes arrive here and they need opposite answers:
+
+        * **Malformed stored data** - a dict or list that came out of the JSONB column
+          but does not satisfy this model (a settings block outside ModelSettings'
+          bounds, a list where an object belongs). The seller's row is broken; the
+          buyer's request is not. That degrades to a bare TenantAIConfig() with one
+          WARNING. Strict parsing here raised pydantic's ValidationError, which
+          subclasses ValueError and so was normalised by every transport into a
+          VALIDATION_ERROR/correctable envelope naming a field (e.g.
+          "settings.temperature") that does not exist in the buyer's request schema.
+        * **A caller passing the wrong Python type** - a str, an int, an arbitrary
+          object. `src/core/database/json_type.py` raises TypeError itself for anything
+          that is not a dict or list, so these shapes CANNOT come from the column; they
+          only come from a caller that passed the wrong argument (the reason this exists
+          is `build_order_name_context(..., gemini_key)` landing a key string in the
+          `tenant_ai_config` parameter). That raises TypeError naming the parameter and
+          the offending type. Degrading it instead hid the mistake behind a log line and
+          silently ran the AI feature on some other configuration.
+
+        `source` names the value being parsed; it appears in both messages so the log
+        or traceback identifies which tenant and which parameter is at fault.
+        """
+        if isinstance(value, cls):
+            return value
+        if value is None:
+            return cls()
+        if not isinstance(value, Mapping | list):
+            raise TypeError(
+                f"{source} must be a JSON object (dict) or None, got {type(value).__name__}. "
+                "PostgreSQL JSONB only ever yields dict, list or None, so this value comes "
+                "from a caller passing the wrong argument - pass it by keyword."
+            )
+        try:
+            return cls.model_validate(value)
+        except ValidationError as exc:
+            logger.warning(
+                "Ignoring malformed %s (%s); the AI feature degrades instead of failing the request: %s",
+                source,
+                type(value).__name__,
+                exc,
+            )
+            return cls()
+
+    @classmethod
+    def from_tenant(cls, tenant: Any) -> "TenantAIConfig | None":
+        """Resolve 'given a tenant, what is its AI configuration?' - the one owner of that rule.
+
+        Accepts every shape a tenant travels as: the ORM Tenant row, TenantContext /
+        LazyTenantContext, and the plain tenant dict. The field names `ai_config` and
+        `gemini_api_key` are identical across all three; only the ACCESS MECHANISM
+        differs (the ORM row has no `.get()`, the plain dict has no attribute access),
+        which is why the read goes through `_read_tenant_field`.
+
+        USABILITY IS THE CONTRACT. A config comes back only when the tenant has its OWN
+        usable credential, because that is what every consumer asks this question for.
+        Resolution order:
+
+        1. `ai_config` parses AND carries a non-empty `api_key` -> that config.
+        2. Otherwise the legacy `gemini_api_key` column -> the canonical Google config,
+           provider and model pinned together.
+        3. Otherwise None.
+
+        A row carrying provider/model but NO api_key is not a tenant configuration.
+        `src/admin/blueprints/settings.py` writes exactly that shape when the seller
+        leaves the key field blank, and tells them "AI features will be disabled" as it
+        does. Returning it as a real config opened the policy gate in
+        `src/core/tools/products.py` for those tenants and ran `check_brief_compliance`
+        on the OPERATOR's platform credential - a live LLM call, and a BLOCKED verdict
+        there is a new buyer-visible rejection. None makes that gate skip, and lets
+        ranking fall back to the platform's own coherent provider+model+key instead.
+
+        A MALFORMED row resolves to nothing, never to a different vendor. `coerce`
+        degrades it to a bare config, which carries no api_key, so it falls through to
+        step 2 and then to None - it is never returned as if it were the tenant's
+        configuration. Returning the bare config let the factory fill in the PLATFORM's
+        provider and key, so a seller who had deliberately configured Anthropic had the
+        buyer's brief and product catalog sent to Google, unranked-advisory-free.
+
+        The absent-test is FALSY, not `is None`: an empty `ai_config` dict (`{}`)
+        carries no provider and no key, so it must fall through to the legacy field
+        rather than shadow it. This resolves the divergence with
+        `src/core/utils/naming.py`, which tested `is None` while every other site
+        tested falsiness.
+
+        It NEVER falls back to the platform environment key - that decision belongs to
+        the caller, because the two consumers (ranking, policy) want different answers
+        to it.
+        """
+        if tenant is None:
+            return None
+
+        tenant_id = _read_tenant_field(tenant, "tenant_id")
+        source = f"tenant ai_config for tenant {tenant_id!r}" if tenant_id else "tenant ai_config"
+
+        ai_config = _read_tenant_field(tenant, "ai_config")
+        if ai_config:
+            config = cls.coerce(ai_config, source=source)
+            if config.api_key:
+                return config
+
+        legacy_key = _read_tenant_field(tenant, "gemini_api_key")
+        if legacy_key:
+            # CANONICAL_GOOGLE_PROVIDER, not the literal "gemini": every consumer of
+            # the provider string canonicalizes before comparing or using it
+            # (canonicalize_google_provider at config.py _get_provider_api_key /
+            # build_model_string, factory.create_model, and uses_legacy_gemini_api_key),
+            # so the two spellings are interchangeable downstream.
+            #
+            # The MODEL is pinned with the provider. Left unset, the factory filled it
+            # from the platform's PYDANTIC_AI_MODEL - so a deployment configured for
+            # Anthropic handed "claude-sonnet-4-…" to a Google client built on this
+            # tenant's Gemini key, and every call 404'd.
+            return cls(provider=CANONICAL_GOOGLE_PROVIDER, model=DEFAULT_GOOGLE_MODEL, api_key=legacy_key)
+
+        return None
+
+
+def _read_tenant_field(tenant: Any, field: str) -> Any:
+    """Read one field from a tenant in whichever shape it arrived.
+
+    Plain dicts answer to `.get()`; ORM rows and TenantContext answer to attribute
+    access. Missing fields read as None rather than raising, so a partial projection
+    degrades to "not configured" instead of failing the request.
+    """
+    if isinstance(tenant, Mapping):
+        return tenant.get(field)
+    return getattr(tenant, field, None)
+
 
 def get_platform_defaults() -> dict:
     """Get platform-level AI configuration from environment variables.
@@ -59,12 +203,27 @@ def get_platform_defaults() -> dict:
     Returns:
         dict with platform default settings
     """
+    provider = os.getenv("PYDANTIC_AI_PROVIDER", DEFAULT_PLATFORM_PROVIDER)
     return {
-        "provider": os.getenv("PYDANTIC_AI_PROVIDER", "gemini"),
-        "model": os.getenv("PYDANTIC_AI_MODEL", "gemini-2.0-flash"),
-        "api_key": _get_provider_api_key(os.getenv("PYDANTIC_AI_PROVIDER", "gemini")),
+        "provider": provider,
+        "model": os.getenv("PYDANTIC_AI_MODEL") or default_model_for(provider),
+        "api_key": _get_provider_api_key(provider),
         "logfire_token": os.getenv("LOGFIRE_TOKEN"),
     }
+
+
+def default_model_for(provider: str) -> str | None:
+    """The model this codebase can name for `provider` without being told.
+
+    Only Google: "gemini-2.0-flash" is what the deployment default has always meant, and
+    it is the pin `policy_check_service` carried at its own call site. For any other
+    provider we do not know a model, and None is the honest answer - guessing carries a
+    model name across vendors, which is how a Google client ended up asking for
+    "claude-sonnet-4-…" (404 on every call).
+    """
+    if canonicalize_google_provider(provider) == CANONICAL_GOOGLE_PROVIDER:
+        return DEFAULT_GOOGLE_MODEL
+    return None
 
 
 def _get_provider_api_key(provider: str) -> str | None:

--- a/src/services/ai/factory.py
+++ b/src/services/ai/factory.py
@@ -2,7 +2,7 @@
 
 import logging
 from functools import lru_cache
-from typing import Any
+from typing import Any, NamedTuple
 
 from src.core.exceptions import AdCPConfigurationError
 from src.services.ai.config import (
@@ -14,6 +14,25 @@ from src.services.ai.config import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+class ResolvedAIConfig(NamedTuple):
+    """What one AI call would actually run on, after platform defaults are applied.
+
+    The three fields are resolved TOGETHER by `AIServiceFactory._resolve` because they
+    are not independent: a model name and an API key both belong to a specific vendor.
+    Resolving them from independent expressions is what sent the platform's Google
+    credential to api.anthropic.com and paired a "claude-*" model name with a Google
+    client.
+
+    `model` and `api_key` are None when nothing coherent resolves for `provider` - that
+    is "AI is not available for this request", not "use whatever the platform has".
+    """
+
+    provider: str
+    model: str | None
+    api_key: str | None
+
 
 # Track if logfire has been configured
 _logfire_configured = False
@@ -75,9 +94,48 @@ class AIServiceFactory:
     def __init__(self):
         """Initialize the factory with platform defaults."""
         self._platform_defaults = get_platform_defaults()
+        self._platform_provider = canonicalize_google_provider(self._platform_defaults["provider"])
 
         # Try to configure logfire on factory creation
         configure_logfire(self._platform_defaults.get("logfire_token"))
+
+    def _resolve(
+        self,
+        tenant_ai_config: dict | TenantAIConfig | None,
+        provider_override: str | None = None,
+        model_override: str | None = None,
+    ) -> tuple[TenantAIConfig, ResolvedAIConfig]:
+        """Resolve provider, model and key together - the one place platform defaults apply.
+
+        The platform's model and API key belong to the PLATFORM's provider
+        (PYDANTIC_AI_PROVIDER, whose key `get_platform_defaults` reads from that
+        provider's own environment variable). They may therefore only fill in for a
+        request that resolves to that same provider. Filling them in regardless sent the
+        operator's Google secret to another vendor: a tenant naming "anthropic" got an
+        AnthropicModel whose client carried the platform's GEMINI_API_KEY, and
+        get_products is auth-OPTIONAL discovery, so an anonymous buyer's brief was
+        enough to trigger it.
+
+        When the providers differ and the tenant named no model/key of its own, the
+        fields stay None: `is_ai_enabled` then reports False and callers skip AI,
+        rather than building a model that cannot work or carries the wrong secret.
+
+        Returns the parsed tenant config alongside the resolution, because callers need
+        both (logfire token, settings, and "did the tenant name a provider at all").
+        """
+        config = TenantAIConfig.coerce(tenant_ai_config)
+
+        # Display form, not canonicalized: get_effective_config reports this string to
+        # the admin UI, and _create_provider_model canonicalizes for itself.
+        provider = provider_override or config.provider or self._platform_defaults["provider"]
+        platform_is_same_vendor = canonicalize_google_provider(provider) == self._platform_provider
+
+        model = (
+            model_override or config.model or (self._platform_defaults["model"] if platform_is_same_vendor else None)
+        )
+        api_key = config.api_key or (self._platform_defaults.get("api_key") if platform_is_same_vendor else None)
+
+        return config, ResolvedAIConfig(provider=provider, model=model, api_key=api_key)
 
     def create_model(
         self,
@@ -102,32 +160,31 @@ class AIServiceFactory:
             This can be passed directly to Agent(model=...).
 
         Raises:
-            AdCPConfigurationError: If no API key is available for the configured provider
+            AdCPConfigurationError: If no API key, or no model, resolves for the
+                configured provider. Gate on `is_ai_enabled()` first to skip AI
+                cleanly instead of raising into a request.
         """
-        # Parse tenant config if provided as dict
-        if isinstance(tenant_ai_config, dict):
-            config = TenantAIConfig.model_validate(tenant_ai_config)
-        elif tenant_ai_config:
-            config = tenant_ai_config
-        else:
-            config = TenantAIConfig()
-
-        # Resolve configuration with priority
-        provider = provider_override or config.provider or self._platform_defaults["provider"]
-        model_name = model_override or config.model or self._platform_defaults["model"]
-        api_key = config.api_key or self._platform_defaults.get("api_key")
+        config, resolved = self._resolve(tenant_ai_config, provider_override, model_override)
 
         # Configure logfire with tenant token if provided
         if config.logfire_token:
             configure_logfire(config.logfire_token)
 
-        provider = canonicalize_google_provider(provider)
+        if resolved.model is None:
+            raise AdCPConfigurationError(
+                f"No model configured for AI provider {resolved.provider!r}. The platform default model "
+                f"belongs to provider {self._platform_defaults['provider']!r}, so pairing it with this one "
+                "would send a model name to a vendor that does not have it. Set 'model' on the tenant's "
+                "AI configuration."
+            )
 
-        logger.debug(f"Creating Pydantic AI model: {provider}:{model_name}")
+        provider = canonicalize_google_provider(resolved.provider)
+
+        logger.debug(f"Creating Pydantic AI model: {provider}:{resolved.model}")
 
         # Create model with Provider that has API key directly configured
         # This avoids setting global environment variables
-        return self._create_provider_model(provider, model_name, api_key)
+        return self._create_provider_model(provider, resolved.model, resolved.api_key)
 
     def _create_provider_model(self, provider: str, model_name: str, api_key: str | None) -> Any:
         """Create a Pydantic AI model with explicit API key via Provider.
@@ -200,6 +257,17 @@ class AIServiceFactory:
             # Fallback: use model string and let Pydantic AI resolve it
             # This handles gateway providers and any new providers
             model_string = build_model_string(provider, model_name)
+            if api_key:
+                # No quiet failures: this branch has nowhere to put an explicit key, so
+                # returning the string would drop the configured credential on the floor
+                # and let pydantic-ai authenticate with whatever ELSE is in the
+                # environment - a different key than the one the seller configured.
+                raise AdCPConfigurationError(
+                    f"Provider '{provider}' has no explicit-API-key integration here, so the configured "
+                    f"API key cannot be used for it; '{model_string}' would authenticate with whatever "
+                    "credential pydantic-ai finds in the environment instead. Configure a supported "
+                    "provider, or add an explicit branch for this one."
+                )
             logger.warning(
                 f"Provider '{provider}' not explicitly supported, "
                 f"using model string '{model_string}' (API key must be in env var)"
@@ -210,9 +278,13 @@ class AIServiceFactory:
         self,
         tenant_ai_config: dict | TenantAIConfig | None = None,
     ) -> bool:
-        """Check if AI is enabled for the given configuration.
+        """Check whether a COHERENT AI configuration resolves - can this call actually run?
 
-        AI is enabled if there's an API key available (from tenant or platform).
+        Enabled means a provider with both a model and an API key that belong to it.
+        A key alone is not enough: the platform's key belongs to the platform's
+        provider, so "there is a key somewhere" answered True for a tenant whose named
+        provider had no credential at all, and the call it green-lit either carried the
+        wrong vendor's secret or 404'd on a model name from another vendor.
 
         Args:
             tenant_ai_config: Tenant's AI configuration
@@ -220,15 +292,8 @@ class AIServiceFactory:
         Returns:
             True if AI calls can be made, False otherwise
         """
-        if isinstance(tenant_ai_config, dict):
-            config = TenantAIConfig.model_validate(tenant_ai_config)
-        elif tenant_ai_config:
-            config = tenant_ai_config
-        else:
-            config = TenantAIConfig()
-
-        # AI is enabled if we have an API key from either source
-        return bool(config.api_key or self._platform_defaults.get("api_key"))
+        _, resolved = self._resolve(tenant_ai_config)
+        return bool(resolved.api_key and resolved.model)
 
     def get_effective_config(
         self,
@@ -242,25 +307,20 @@ class AIServiceFactory:
             tenant_ai_config: Tenant's AI configuration
 
         Returns:
-            dict with effective provider, model, and whether API key is set
+            dict with effective provider, model, and whether API key is set.
+            `has_api_key` is provider-scoped: it reports whether a key is available
+            FOR THE RESOLVED PROVIDER, not whether any key exists anywhere. Reporting
+            the platform's Google key as this tenant's key is what told
+            `PolicyCheckService` that AI was configured for a tenant that had no
+            credential of its own.
         """
-        if isinstance(tenant_ai_config, dict):
-            config = TenantAIConfig.model_validate(tenant_ai_config)
-        elif tenant_ai_config:
-            config = tenant_ai_config
-        else:
-            config = TenantAIConfig()
-
-        provider = config.provider or self._platform_defaults["provider"]
-        model = config.model or self._platform_defaults["model"]
-        has_api_key = bool(config.api_key or self._platform_defaults.get("api_key"))
-        has_logfire = bool(config.logfire_token or self._platform_defaults.get("logfire_token"))
+        config, resolved = self._resolve(tenant_ai_config)
 
         return {
-            "provider": provider,
-            "model": model,
-            "has_api_key": has_api_key,
-            "has_logfire": has_logfire,
+            "provider": resolved.provider,
+            "model": resolved.model,
+            "has_api_key": bool(resolved.api_key),
+            "has_logfire": bool(config.logfire_token or self._platform_defaults.get("logfire_token")),
             "settings": config.settings,
             "source": "tenant" if config.provider else "platform",
         }

--- a/tests/bdd/conftest.py
+++ b/tests/bdd/conftest.py
@@ -78,6 +78,7 @@ pytest_plugins = [
     "tests.bdd.steps.domain.uc011_accounts",
     "tests.bdd.steps.domain.admin_accounts",
     "tests.bdd.steps.domain.uc_get_products_inventory",
+    "tests.bdd.steps.domain.uc001_ai_ranking",
     "tests.bdd.steps.domain.egress_ssrf",
     "tests.bdd.steps.domain.uc_brand_shorthand",
     "tests.bdd.steps.domain.compat_normalization",
@@ -3808,14 +3809,24 @@ _UC_BUCKET_ROUTES: dict[str, EnvRoute] = {
         env_builder=_build_uc003_storyboard_generic_client_env,
         seed=_seed_uc003_storyboard_generic_client,
     ),
-    # The five rows below are keyed by the coarse `uc` bucket (from
+    # The six rows below are keyed by the coarse `uc` bucket (from
     # _detect_uc), not a per-scenario tag: they are what a scenario in these
     # UCs falls back to when no predicate row above claims it. ADMIN, COMPAT,
-    # UC-GET-PRODUCTS and UC-005 have no predicate rows at all — one env + one
-    # seed serves every scenario. UC-019 does have one (@post-create-poll needs
-    # create + list in a single scenario), so its bucket row is the remainder.
+    # UC-001, UC-GET-PRODUCTS and UC-005 have no predicate rows at all — one env
+    # + one seed serves every scenario. UC-019 does have one (@post-create-poll
+    # needs create + list in a single scenario), so its bucket row is the
+    # remainder.
     "ADMIN": EnvRoute(tag="ADMIN", env_builder=_build_admin_env),
     "COMPAT": EnvRoute(tag="COMPAT", env_builder=_build_product_env),
+    # UC-001 is get_products discovery, so it takes the SAME env as
+    # UC-GET-PRODUCTS. It had no row at all until now, which meant a
+    # `@T-UC-001-*` scenario xfailed with "No harness wired for UC-001" — the
+    # catch-all that exists for UCs whose harness does not exist yet, standing in
+    # for a harness that has existed all along. Adding the row binds nothing on
+    # its own: the generated BR-UC-001 feature carries 121 scenarios and NO
+    # `scenarios()` call anywhere binds it, so the only collected UC-001
+    # scenarios are the ones test_uc001_ai_ranking_tenant_config.py binds.
+    "UC-001": EnvRoute(tag="UC-001", env_builder=_build_product_env),
     "UC-GET-PRODUCTS": EnvRoute(tag="UC-GET-PRODUCTS", env_builder=_build_product_env),
     "UC-005": EnvRoute(tag="UC-005", env_builder=_build_creative_formats_env, seed=_seed_uc005),
     "UC-019": EnvRoute(tag="UC-019", env_builder=_build_media_buy_list_env, seed=_seed_uc019),
@@ -4093,8 +4104,8 @@ def _harness_env(request: pytest.FixtureRequest, ctx: dict) -> Generator[None, N
     """Provide the appropriate harness for each BDD scenario.
 
     - A ``uc`` bucket with no marker_names-based sub-branching (ADMIN, COMPAT,
-      UC-GET-PRODUCTS, UC-005, UC-019) is a row in ``ENV_ROUTES`` and goes
-      through the one generic ``_run_env_route`` consumer.
+      UC-001, UC-GET-PRODUCTS, UC-005, UC-019) is a row in ``ENV_ROUTES`` and
+      goes through the one generic ``_run_env_route`` consumer.
     - UC-004 @polling → DeliveryPollEnv
     - UC-004 @webhook → WebhookEnv (unit variant, no DB needed)
     - UC-004 @webhook-reliability → CircuitBreakerEnv (unit variant)

--- a/tests/bdd/features/BR-UC-001-ai-ranking-tenant-config.feature
+++ b/tests/bdd/features/BR-UC-001-ai-ranking-tenant-config.feature
@@ -1,0 +1,82 @@
+# Local feature (not generated): AI product ranking and the SELLER's own AI configuration.
+#
+# BR-RULE-005 is the ranking rule: when the buyer supplies a brief and the seller
+# has configured a product_ranking_prompt, products[] comes back ordered by
+# relevance_score descending, and anything scoring below 0.1 is dropped.
+#
+# What is graded here is where the ranking's AI configuration comes FROM. It used
+# to come from the platform environment key alone, so a seller who configured AI
+# through the Admin UI — which writes the tenant's ai_config column — silently got
+# catalog order back with no way to tell. Both scenarios therefore REMOVE the
+# platform key in their Given step (tests/conftest.py sets it for every test in the
+# suite, and is_ai_enabled returns true on that key by itself), so the tenant's own
+# configuration is the only AI configuration in play and neither expected outcome
+# below is reachable without reading it.
+#
+# Deliberately NOT added to BR-UC-GET-PRODUCTS-inventory-profile.feature, which is
+# scoped to selection_type inference, and deliberately not bound to the generated
+# BR-UC-001-discover-available-inventory.feature, whose 121 scenarios have no
+# step definitions.
+#
+# The last Then line of the second scenario grades the ENVELOPE, not the payload. The
+# A2A handler stamps a `success` marker on every get_products response and derived it
+# from "is errors[] non-empty", so the moment this advisory existed an advisory-carrying
+# seller reported success=false on every discovery call over A2A. Pinned
+# core/protocol-envelope.json: "Non-fatal warnings populate ONLY payload.errors[] with
+# severity: warning - the envelope MUST NOT carry adcp_error for non-failures." Without
+# that line the two payload assertions above pass with the marker inverted.
+#
+# The scoring step says "called with that prompt and the buyer's brief" because that
+# is graded, not decoration. rank_products_async takes the seller's ranking prompt as
+# custom_prompt and the buyer's brief as brief, the prompt builder concatenates both,
+# and swapping them changes only the wording sent to the model — so no wire assertion
+# can see it. The stub behind that step checks which text arrived as which argument;
+# with the two exchanged in production, these scenarios and the whole of
+# tests/unit/test_get_products_impl_coverage.py were green (39 passed).
+
+Feature: AI product ranking honours the seller's own AI configuration
+  As a Buyer Agent
+  I want products[] ordered by the seller's configured relevance model
+  So that the order reflects my brief instead of the seller's catalog order
+
+  Background:
+    Given a tenant is configured for product discovery
+
+  @T-UC-001-ranking-tenant-ai-config @BR-RULE-005 @requires_db
+  Scenario: The tenant's own ai_config drives ranking when no platform key exists
+    Given the seller's catalog contains, in catalog order:
+      | product_id        | name            |
+      | prod_a_banner     | Homepage Banner |
+      | prod_b_video      | Preroll Video   |
+      | prod_c_newsletter | Newsletter Slot |
+    And the seller configured AI ranking in ai_config with the prompt "Prefer video inventory"
+    And the ranking model, called with that prompt and the buyer's brief, scores:
+      | product_id        | relevance_score |
+      | prod_b_video      | 0.90            |
+      | prod_a_banner     | 0.20            |
+      | prod_c_newsletter | 0.05            |
+    When the buyer requests products with the brief "video campaign for a sports launch"
+    Then the response products are exactly, in order:
+      | product_id    |
+      | prod_b_video  |
+      | prod_a_banner |
+    And the response does not contain the product "prod_c_newsletter"
+    And the response carries no advisory errors
+
+  @T-UC-001-ranking-unavailable-advisory @BR-RULE-005 @requires_db
+  Scenario: Ranking configured with no AI configuration returns catalog order and says so
+    Given the seller's catalog contains, in catalog order:
+      | product_id        | name            |
+      | prod_a_banner     | Homepage Banner |
+      | prod_b_video      | Preroll Video   |
+      | prod_c_newsletter | Newsletter Slot |
+    And the seller configured AI ranking with no ai_config and the prompt "Prefer video inventory"
+    When the buyer requests products with the brief "video campaign for a sports launch"
+    Then the response products are exactly, in order:
+      | product_id        |
+      | prod_a_banner     |
+      | prod_b_video      |
+      | prod_c_newsletter |
+    And the response carries one advisory error with code "CONFIGURATION_ERROR"
+    And the advisory error is a non-fatal warning about field "products[]"
+    And the response envelope still reports the task as successful

--- a/tests/bdd/steps/domain/uc001_ai_ranking.py
+++ b/tests/bdd/steps/domain/uc001_ai_ranking.py
@@ -1,0 +1,207 @@
+"""Domain step definitions for BR-RULE-005 AI product ranking (UC-001).
+
+Grades where ranking's AI configuration comes from: the SELLER's own ``ai_config``
+column, not the platform environment key. The tenant setup Given
+("a tenant is configured for product discovery") is reused from
+``uc_get_products_inventory`` — same env (``ProductEnv``), same tenant/principal
+contract — so only the ranking-specific steps live here.
+
+Every Then reads the WIRE (``wire_dict``/``wire_field``), never ``env.mock`` call
+args: mock arguments are an in-process-only fact, and asserting on them would make
+the e2e parameterization of these scenarios structurally impossible. The one fact
+with no wire surface — which of ``rank_products_async``'s two text arguments received
+the seller's prompt and which received the buyer's brief — is graded inside the
+scripted-ranking stub in ``tests/harness/product.py``, where the call actually lands,
+so it needs no Then step reading harness state.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+from pytest_bdd import given, parsers, then, when
+
+from tests.bdd.steps._outcome_helpers import wire_dict, wire_field
+from tests.bdd.steps.generic._dispatch import dispatch_request
+from tests.factories import PricingOptionFactory, ProductFactory
+
+# The ai_config a seller writes through the Admin UI. "gemini" rather than the
+# canonical "google" on purpose: it is the legacy spelling the UI stores, and
+# production canonicalizes it (``canonicalize_google_provider``) before use, so
+# the scenario exercises the shape sellers actually have in their database.
+_TENANT_AI_CONFIG: dict[str, Any] = {
+    "provider": "gemini",
+    "model": "gemini-2.0-flash",
+    "api_key": "tenant-owned-ranking-key",
+}
+
+
+def _rows(datatable: Sequence[Sequence[object]]) -> list[dict[str, str]]:
+    """Gherkin table -> list of {header: cell} dicts, header row consumed."""
+    headers = [str(cell) for cell in datatable[0]]
+    return [{headers[i]: str(cell) for i, cell in enumerate(row)} for row in datatable[1:]]
+
+
+def _wire_product_ids(ctx: dict) -> list[str]:
+    """The product_ids of ``products[]`` in the order the buyer receives them."""
+    products = wire_field(ctx, "products")
+    return [product["product_id"] for product in products]
+
+
+def _advisories(ctx: dict) -> list[dict[str, Any]]:
+    """``errors[]`` as it appears on the wire — absent and empty are the same thing.
+
+    A completed get_products response may carry advisory errors[] (pinned
+    ``media-buy/get-products-response.json`` requires the field only when
+    ``status == "failed"``), and a response with nothing to advise about omits it
+    entirely. Both mean "no advisory", so both normalize to [].
+    """
+    return wire_dict(ctx).get("errors") or []
+
+
+# ── Given steps ─────────────────────────────────────────────────────
+
+
+@given("the seller's catalog contains, in catalog order:")
+def given_catalog_in_order(ctx: dict, datatable: Sequence[Sequence[object]]) -> None:
+    """Create the table's products, each with pricing so it survives conversion.
+
+    "in catalog order" is a claim about production, not about this table:
+    ``ProductRepository.list_all`` orders by ``product_id``. The assertion below
+    keeps the Gherkin honest — write the rows out of order and the scenario fails
+    here rather than silently grading a different baseline order.
+    """
+    tenant = ctx["tenant"]
+    rows = _rows(datatable)
+    product_ids = [row["product_id"] for row in rows]
+    assert product_ids == sorted(product_ids), (
+        f"the table claims catalog order but product_ids {product_ids} are not sorted; "
+        "ProductRepository.list_all orders by product_id, so the table must too"
+    )
+    for row in rows:
+        product = ProductFactory(tenant=tenant, product_id=row["product_id"], name=row["name"])
+        PricingOptionFactory(product=product)
+    ctx["catalog_product_ids"] = product_ids
+
+
+@given(parsers.parse('the seller configured AI ranking in ai_config with the prompt "{prompt}"'))
+def given_ranking_via_ai_config(ctx: dict, prompt: str) -> None:
+    """The seller has both a ranking prompt and their own AI configuration."""
+    ctx["env"].set_tenant_ai_ranking(_TENANT_AI_CONFIG, prompt)
+
+
+@given(parsers.parse('the seller configured AI ranking with no ai_config and the prompt "{prompt}"'))
+def given_ranking_without_ai_config(ctx: dict, prompt: str) -> None:
+    """The seller asked for ranking but configured no AI at all — the advisory case."""
+    ctx["env"].set_tenant_ai_ranking(None, prompt)
+
+
+@given("the ranking model, called with that prompt and the buyer's brief, scores:")
+def given_ranking_scores(ctx: dict, datatable: Sequence[Sequence[object]]) -> None:
+    """Score every product deterministically instead of calling a real model.
+
+    The step name states two obligations and the stub behind it grades both: the scores
+    (which decide the expected order) and the ROLES of the model's two text arguments —
+    the seller's ``product_ranking_prompt`` arrives as ``custom_prompt``, the buyer's
+    brief as ``brief``. The second is graded inside ``ProductEnv.set_ranking_scores``
+    rather than in a Then step, because a Then would have to read in-process call
+    arguments; see that method for why the swap is otherwise invisible.
+    """
+    scores = {row["product_id"]: float(row["relevance_score"]) for row in _rows(datatable)}
+    ctx["env"].set_ranking_scores(scores)
+
+
+# ── When steps ──────────────────────────────────────────────────────
+
+
+@when(parsers.parse('the buyer requests products with the brief "{brief}"'))
+def when_request_products_with_brief(ctx: dict, brief: str) -> None:
+    """Dispatch get_products with the buyer's brief through the current transport."""
+    dispatch_request(ctx, brief=brief)
+
+
+# ── Then steps ──────────────────────────────────────────────────────
+
+
+@then("the response products are exactly, in order:")
+def then_products_exactly_in_order(ctx: dict, datatable: Sequence[Sequence[object]]) -> None:
+    """Assert products[] is exactly the listed ids, in the listed order."""
+    expected = [row["product_id"] for row in _rows(datatable)]
+    actual = _wire_product_ids(ctx)
+    assert actual == expected, f"Expected products[] {expected}, got {actual}"
+
+
+@then(parsers.parse('the response does not contain the product "{product_id}"'))
+def then_product_absent(ctx: dict, product_id: str) -> None:
+    """Assert a below-threshold product was dropped rather than merely sorted last."""
+    actual = _wire_product_ids(ctx)
+    assert product_id not in actual, f"Expected {product_id!r} to be dropped, but products[] is {actual}"
+
+
+@then("the response carries no advisory errors")
+def then_no_advisory(ctx: dict) -> None:
+    """Assert a successfully ranked response says nothing on errors[]."""
+    advisories = _advisories(ctx)
+    assert advisories == [], f"Expected no advisory errors, got {advisories}"
+
+
+@then(parsers.parse('the response carries one advisory error with code "{code}"'))
+def then_one_advisory_with_code(ctx: dict, code: str) -> None:
+    """Assert exactly one advisory rides on the SUCCESS envelope, with the given code."""
+    advisories = _advisories(ctx)
+    assert len(advisories) == 1, f"Expected exactly 1 advisory error, got {advisories}"
+    assert advisories[0]["code"] == code, f"Expected advisory code {code!r}, got {advisories[0]}"
+    ctx["advisory"] = advisories[0]
+
+
+@then(parsers.parse('the advisory error is a non-fatal warning about field "{field}"'))
+def then_advisory_is_warning(ctx: dict, field: str) -> None:
+    """Assert the advisory's severity/recovery/field, and that it did NOT fail the task.
+
+    ``severity: warning`` plus the absence of an envelope-level error is the pinned
+    ``core/protocol-envelope.json`` contract for a non-fatal advisory; ``terminal``
+    tells the buyer no retry supplies the seller's missing API key; ``field`` points
+    at what the advisory is about.
+    """
+    advisory = _advisories(ctx)[0]
+    assert advisory["severity"] == "warning", f"Expected severity 'warning', got {advisory}"
+    assert advisory["recovery"] == "terminal", f"Expected recovery 'terminal', got {advisory}"
+    assert advisory["field"] == field, f"Expected field {field!r}, got {advisory}"
+    assert "PRODUCT_RANKING_UNAVAILABLE" in advisory["message"], (
+        f"Expected the advisory message to name PRODUCT_RANKING_UNAVAILABLE, got {advisory['message']!r}"
+    )
+
+
+@then("the response envelope still reports the task as successful")
+def then_envelope_reports_success(ctx: dict) -> None:
+    """An advisory rides a COMPLETED task — it does not turn the response into a failure.
+
+    This grades the ENVELOPE, where the two assertions above grade the payload. Pinned
+    ``core/protocol-envelope.json`` on ``adcp_error``: "a fatal task failure SHOULD
+    populate both this envelope-level field AND the payload's ``errors[]`` array ...
+    Non-fatal warnings populate ONLY ``payload.errors[]`` with ``severity: warning`` —
+    the envelope MUST NOT carry ``adcp_error`` for non-failures."
+
+    A2A is the transport this bites on. ``AdCPRequestHandler._stamp_a2a_protocol_fields``
+    stamps a ``success`` marker on every ``get_products`` response and derived it from
+    "is ``errors[]`` non-empty", so the moment this advisory existed a seller carrying it
+    reported ``success=false`` on EVERY discovery call. Reverting that derivation left
+    this whole feature green (6 passed) before this step existed.
+
+    ``success`` is asserted only where the envelope actually carries it: REST and MCP
+    stamp no such marker, so requiring the key everywhere would fail those two for a
+    reason that has nothing to do with the advisory. The two assertions that DO run on
+    every transport come first, so no transport reaches the end of this step having
+    graded nothing.
+    """
+    wire = wire_dict(ctx)
+    assert wire.get("status") == "completed", f"Expected a completed task, got status {wire.get('status')!r}"
+    assert wire.get("adcp_error") is None, (
+        f"A non-fatal advisory must leave the envelope's adcp_error unset, got {wire.get('adcp_error')!r}"
+    )
+    if "success" in wire:
+        assert wire["success"] is True, (
+            f"Expected success=True on a completed response whose only errors[] entry is a "
+            f"severity 'warning' advisory, got {wire['success']!r} (advisory: {_advisories(ctx)})"
+        )

--- a/tests/bdd/test_uc001_ai_ranking_tenant_config.py
+++ b/tests/bdd/test_uc001_ai_ranking_tenant_config.py
@@ -1,0 +1,13 @@
+"""BDD scenario binding for BR-RULE-005 AI ranking and the seller's own AI config.
+
+Binds only the local ranking feature. The generated
+``features/BR-UC-001-discover-available-inventory.feature`` (121 scenarios, no step
+definitions) stays unbound — binding it here would collect 121 scenarios that all
+xfail as "step definition not found", which reads as coverage and is not.
+"""
+
+from __future__ import annotations
+
+from pytest_bdd import scenarios
+
+scenarios("features/BR-UC-001-ai-ranking-tenant-config.feature")

--- a/tests/harness/_base.py
+++ b/tests/harness/_base.py
@@ -1517,6 +1517,30 @@ class IntegrationEnv(BaseTestEnv):
             principal = PrincipalFactory(tenant=tenant, principal_id=self._principal_id)
         return tenant, principal
 
+    def _require_tenant_row(self, setter_name: str) -> Any:
+        """Return the env's Tenant row, raising if it does not exist yet.
+
+        No-Quiet-Failures: writing tenant config to a missing row silently drops
+        it, and over the real auth chain (MCP resolves the tenant from the DB, not
+        from the injected identity) the tool then never sees the setting. Direct
+        the caller to create the tenant first instead of skipping the write.
+
+        Lives here rather than on one env because every fluent setter that
+        DUAL-WRITES tenant config needs the identical lookup and the identical
+        failure message — ``AccountSyncEnv``'s billing/approval-mode setters and
+        ``ProductEnv``'s AI-ranking setter today. One rule, one copy.
+        """
+        from src.core.database.models import Tenant
+
+        tenant = self._session.get(Tenant, self._tenant_id) if self._session else None
+        if tenant is None:
+            raise RuntimeError(
+                f"{setter_name}() requires the tenant row '{self._tenant_id}' to exist. "
+                "Call env.setup_default_data() (or create the tenant via a Given step) "
+                "before configuring tenant policy."
+            )
+        return tenant
+
     # -- Public query API (step functions must use these, not env._session) ----
 
     def get_session(self) -> Session:

--- a/tests/harness/account_sync.py
+++ b/tests/harness/account_sync.py
@@ -88,24 +88,6 @@ class AccountSyncEnv(IntegrationEnv):
             self.set_approval_mode(self._account_approval_mode)
         return tenant, principal
 
-    def _require_tenant_row(self, setter_name: str) -> Any:
-        """Return the env's Tenant row, raising if it does not exist yet.
-
-        No-Quiet-Failures: writing tenant config to a missing row silently drops
-        it, and over e2e the live server then never sees the policy. Direct the
-        step to create the tenant first instead of skipping the write.
-        """
-        from src.core.database.models import Tenant
-
-        tenant = self._session.get(Tenant, self._tenant_id) if self._session else None
-        if tenant is None:
-            raise RuntimeError(
-                f"{setter_name}() requires the tenant row '{self._tenant_id}' to exist. "
-                "Call env.setup_default_data() (or create the tenant via a Given step) "
-                "before configuring billing policy / approval mode."
-            )
-        return tenant
-
     def set_billing_policy(self, supported: list[str]) -> None:
         """Configure which billing models this seller accepts (BR-RULE-059).
 

--- a/tests/harness/product.py
+++ b/tests/harness/product.py
@@ -42,13 +42,23 @@ Transport support:
 from __future__ import annotations
 
 import asyncio
+import os
+from collections.abc import Mapping
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from src.core.schemas import GetProductsResponse
 from tests.harness._base import IntegrationEnv
 from tests.harness._mixins import ProductMixin
+from tests.harness._realize import e2e_unsupported, realize_e2e
 from tests.harness.egress import EgressHatchMixin
+
+# The environment variable the platform AI key is read from. Production spells it
+# once, in ``src.services.ai.config._get_provider_api_key``'s provider map, and
+# that spelling is not importable as a constant — so the name is repeated here and
+# the REMOVAL is verified through production's own ``is_ai_enabled`` rather than
+# trusted (see ``ProductEnv.set_tenant_ai_ranking``).
+_PLATFORM_AI_KEY_ENV = "GEMINI_API_KEY"
 
 
 class ProductEnv(ProductMixin, IntegrationEnv):
@@ -69,6 +79,11 @@ class ProductEnv(ProductMixin, IntegrationEnv):
         set_property_list(ids)           -- configure property list resolver
         set_ranking_disabled()           -- disable AI ranking
         call_impl(brief, **kw)           -- call _get_products_impl
+
+    Plus the two AI-ranking setters defined below:
+        set_tenant_ai_ranking(cfg, prompt) -- the tenant's own AI config and ranking
+                                             prompt, with the platform key removed
+        set_ranking_scores(scores)         -- deterministic relevance scores
     """
 
     # Dispatch declaration: the base owns call_mcp/call_a2a.
@@ -89,9 +104,171 @@ class ProductEnv(ProductMixin, IntegrationEnv):
 
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
+        # The two texts ``rank_products_async`` takes, recorded where each one is
+        # actually decided, so ``set_ranking_scores``'s stub can grade WHICH argument
+        # got which. See ``set_ranking_scores`` for why that needs grading at all.
+        self._tenant_ranking_prompt: str | None = None
+        self._dispatched_brief: str | None = None
 
     def _configure_mocks(self) -> None:
         self._configure_product_mocks()
+
+    def call_via(self, transport: Any, **kwargs: Any) -> Any:
+        """Record the buyer's brief on the way through, then dispatch normally.
+
+        Every transport — impl, mcp, a2a, rest — reaches production through this one
+        frame, so it is the only place that sees the brief for all four. Recording it
+        in ``call_impl`` instead would cover the impl leg alone and leave the three
+        wire transports grading nothing.
+        """
+        if "brief" in kwargs:
+            self._dispatched_brief = kwargs["brief"]
+        return super().call_via(transport, **kwargs)
+
+    @realize_e2e(
+        e2e_unsupported(
+            "the platform GEMINI_API_KEY is read from the LIVE SERVER's own process environment "
+            "(and cached there by get_factory's lru_cache), so the harness cannot remove it; "
+            "'the tenant's own ai_config is the only AI configuration present' has no server surface"
+        )
+    )
+    def set_tenant_ai_ranking(self, ai_config: dict[str, Any] | None, ranking_prompt: str) -> None:
+        """Configure AI product ranking as the TENANT configured it, and only as the tenant did.
+
+        Dual-write, for the same reason ``AccountSyncEnv.set_billing_policy`` is one:
+        the REST/A2A in-process transports read the tenant off the injected identity
+        (``_tenant_overrides``), while the MCP transport runs the real auth chain and
+        reads it back out of the database. A setter that wrote only one of the two
+        would grade a different tenant on different transports.
+
+        The platform key is REMOVED here, and that is the load-bearing half.
+        ``tests/conftest.py`` sets ``GEMINI_API_KEY`` for every test in the suite, and
+        ``AIServiceFactory.is_ai_enabled`` returns True on the platform key ALONE — so
+        with it left in place, ranking runs whatever the tenant has configured and a
+        scenario asserting "ranking happened" passes with the production fix reverted.
+        The removal is then VERIFIED through production's own predicate rather than
+        assumed: if any other provider/key combination still enables AI (say
+        ``PYDANTIC_AI_PROVIDER=openai`` with an ``OPENAI_API_KEY`` in the environment),
+        this raises instead of handing back a vacuous scenario.
+
+        ``get_factory`` stays patched, but its return value becomes a REAL
+        ``AIServiceFactory`` built against the key-free environment: the whole point is
+        to grade production's "is this tenant's AI usable?" rule, and a MagicMock
+        answering ``is_ai_enabled`` would be the test grading its own stub.
+
+        Args:
+            ai_config: The tenant's ``ai_config`` column value, or None for a tenant
+                that configured a ranking prompt but no AI at all.
+            ranking_prompt: The tenant's ``product_ranking_prompt`` column value.
+        """
+        from src.services.ai.factory import AIServiceFactory
+
+        self._tenant_overrides["ai_config"] = ai_config
+        self._tenant_overrides["product_ranking_prompt"] = ranking_prompt
+        self._tenant_ranking_prompt = ranking_prompt
+        self._identity_cache.clear()
+
+        tenant = self._require_tenant_row("set_tenant_ai_ranking")
+        tenant.ai_config = ai_config
+        tenant.product_ranking_prompt = ranking_prompt
+        self._commit_factory_data()
+
+        original = os.environ.pop(_PLATFORM_AI_KEY_ENV, None)
+        if original is not None:
+            self._guard(f"env:{_PLATFORM_AI_KEY_ENV}", lambda: os.environ.__setitem__(_PLATFORM_AI_KEY_ENV, original))
+
+        factory = AIServiceFactory()
+        if factory.is_ai_enabled(None):
+            raise RuntimeError(
+                f"set_tenant_ai_ranking() removed {_PLATFORM_AI_KEY_ENV} but production still reports "
+                "AI enabled with no tenant configuration, so the tenant's own config would not be what "
+                "makes ranking run and the scenario would pass with the fix reverted. Check "
+                "PYDANTIC_AI_PROVIDER and the other provider key environment variables."
+            )
+        self.mock["ranking_factory"].return_value = factory
+
+    @realize_e2e(
+        e2e_unsupported(
+            "the ranking factory has no live-server injection surface: over e2e the server builds a "
+            "real model and calls the provider, so scripted relevance scores cannot be realized"
+        )
+    )
+    def set_ranking_scores(self, scores: Mapping[str, float]) -> None:
+        """Score each product deterministically, by product_id, instead of calling a model.
+
+        Replaces ``rank_products_async`` with a plain async function rather than a mock:
+        the scenario's obligation is the ORDER on the wire, and a mock would additionally
+        invite Then steps to assert on call args — an in-process-only fact that the e2e
+        parameterization could never reproduce.
+
+        THE STUB GRADES ITS OWN ARGUMENTS, because nothing downstream can.
+        ``rank_products_async`` takes two free-text arguments — ``custom_prompt`` (the
+        SELLER's ``product_ranking_prompt``) and ``brief`` (the BUYER's brief) — and the
+        prompt builder concatenates both into one string, so passing them in the wrong
+        roles produces a differently-worded prompt and an identical response shape. A
+        stub that accepted both and ignored both made that swap invisible: exchanging the
+        two keyword arguments in ``_rank_products_with_ai`` left every scenario here and
+        every test in ``tests/unit/test_get_products_impl_coverage.py`` green (39 passed).
+        Asserting inside the stub keeps the check where the call actually lands, so no
+        Then step has to read in-process mock arguments to see it.
+
+        The two expected values are not passed in — they are read from where each one is
+        really decided, so they cannot drift from the scenario: the prompt from
+        ``set_tenant_ai_ranking`` (which writes ``tenant.product_ranking_prompt``), the
+        brief from ``call_via`` (which sees the buyer's request on every transport).
+
+        A product the scenario did not score is a scenario bug, not a zero: the sort
+        would silently bury it and the expected order would still "pass" for the wrong
+        reason, so it raises.
+
+        Args:
+            scores: product_id -> relevance_score (0.0-1.0), covering every product the
+                request will return.
+        """
+        from src.services.ai.agents.ranking_agent import ProductRanking, ProductRankingResult
+
+        if self._tenant_ranking_prompt is None:
+            raise RuntimeError(
+                "set_ranking_scores() requires set_tenant_ai_ranking() to have run first: the "
+                "seller's product_ranking_prompt is what the stub grades `custom_prompt` against, "
+                "and without it the scenario would score products while grading nothing about "
+                "which text production sent as which argument."
+            )
+        expected_prompt = self._tenant_ranking_prompt
+
+        async def _scripted_ranking(agent: Any, custom_prompt: str, brief: str, products: list) -> Any:
+            expected_brief = self._dispatched_brief
+            if expected_brief is None:
+                raise AssertionError(
+                    "set_ranking_scores() was reached without a recorded brief. Dispatch through "
+                    "env.call_via (dispatch_request does), which is where the buyer's brief is "
+                    "recorded; a direct call_impl() bypasses it and would grade nothing."
+                )
+            if (custom_prompt, brief) != (expected_prompt, expected_brief):
+                raise AssertionError(
+                    "rank_products_async got the seller's prompt and the buyer's brief in the "
+                    f"wrong roles.\n"
+                    f"  custom_prompt: got {custom_prompt!r}, expected {expected_prompt!r} "
+                    "(tenant.product_ranking_prompt)\n"
+                    f"  brief:         got {brief!r}, expected {expected_brief!r} "
+                    "(the buyer's request brief)"
+                )
+            unscored = sorted(p.product_id for p in products if p.product_id not in scores)
+            if unscored:
+                raise AssertionError(
+                    f"set_ranking_scores() has no score for {unscored}; every product the request "
+                    "returns must be scored, or the expected order grades an unstated default."
+                )
+            return ProductRankingResult(
+                rankings=[
+                    ProductRanking(product_id=pid, relevance_score=score, reason="scripted by set_ranking_scores")
+                    for pid, score in scores.items()
+                ]
+            )
+
+        patcher = patch("src.services.ai.agents.ranking_agent.rank_products_async", new=_scripted_ranking)
+        patcher.start()
+        self._guard("patch:rank_products_async", patcher.stop)
 
     def call_impl(self, **kwargs: Any) -> Any:  # type: ignore[override]
         """Call _get_products_impl — async-aware sync bridge.

--- a/tests/integration/test_a2a_response_compliance.py
+++ b/tests/integration/test_a2a_response_compliance.py
@@ -426,27 +426,37 @@ class TestA2AResponseRegressionPrevention:
 
 
 @pytest.mark.integration
-class TestA2ASuccessDerivedFromErrorsOnRealWire:
-    """``_stamp_a2a_protocol_fields`` derives ``success`` from ``errors`` so a
-    response carrying per-item errors reports ``success=False`` uniformly
-    (single derivation point after three call sites used to duplicate it
-    inline — PR #1868, one of the three previously omitted the derivation
-    entirely and always forced ``success=True``).
+class TestA2ASuccessReportsFailureOnRealWire:
+    """The A2A ``success`` marker reports whether the task FAILED — not whether
+    ``errors[]`` is non-empty.
+
+    Two obligations, one predicate in ``_stamp_a2a_protocol_fields``:
+
+    * ONE derivation (PR #1868). Three call sites used to stamp ``success``
+      inline and two of them omitted the derivation entirely, always forcing
+      ``success=True``.
+    * The RIGHT derivation (PR #2167). ``not bool(errors)`` answered a
+      different question from the one the marker names. Pinned
+      ``core/protocol-envelope.json``: "Non-fatal warnings populate ONLY
+      ``payload.errors[]`` with ``severity: warning`` — the envelope MUST NOT
+      carry ``adcp_error`` for non-failures." So a seller whose AI ranking is
+      configured but unavailable — which attaches an advisory to EVERY
+      ``get_products`` response — reported ``success=false`` on every discovery
+      call while returning a complete, usable product list.
 
     Dispatched through the real ``AdCPRequestHandler`` (not by calling
     ``_stamp_a2a_protocol_fields`` directly) so a regression in the
     derivation — or in any call site that stopped routing through it — shows
     up on the real A2A wire, the same bytes a buyer actually receives.
-    Deleting the derivation in ``_stamp_a2a_protocol_fields`` must make this
-    test fail.
+
+    Both tests are sync on purpose: ``call_a2a``/``call_via`` bridge to
+    ``asyncio.run()`` internally (see ``ProductEnv.call_impl``'s docstring on the
+    same bridge) — an ``async def`` test would nest event loops and silently
+    swallow the resulting RuntimeError.
     """
 
-    def test_get_products_populated_errors_derive_wire_success_false(self, integration_db):
-        """Sync on purpose: ``call_a2a``/``call_via`` bridge to ``asyncio.run()``
-        internally (see ``ProductEnv.call_impl``'s docstring on the same bridge) —
-        an ``async def`` test would nest event loops and silently swallow the
-        resulting RuntimeError.
-        """
+    def test_get_products_unmarked_errors_derive_wire_success_false(self, integration_db):
+        """An entry that has NOT declared itself advisory is still a failure."""
         from unittest.mock import AsyncMock, patch
 
         from src.core.schemas import Error, GetProductsResponse
@@ -460,13 +470,11 @@ class TestA2ASuccessDerivedFromErrorsOnRealWire:
             tenant = TenantFactory(tenant_id="a2a-success-errors-test")
             PrincipalFactory(tenant=tenant, principal_id="test_principal")
 
-            # get_products has no production code path that populates
-            # non-fatal errors[] today (unlike CreateMediaBuySuccess's
-            # property_list_filtering advisory) — stub the tool boundary
-            # _handle_get_products_skill calls, the same seam the transport
-            # wrapper is contractually bound to (Pattern #5), to grade the
-            # stamping/derivation logic the wrapper owns independent of
-            # whether any business path currently exercises it.
+            # No production get_products path emits an UNMARKED errors[] entry —
+            # stub the tool boundary _handle_get_products_skill calls, the same
+            # seam the transport wrapper is contractually bound to (Pattern #5),
+            # to grade the stamping logic the wrapper owns independent of whether
+            # a business path currently produces this shape.
             errored_response = GetProductsResponse(
                 products=[],
                 errors=[Error(code="UNSUPPORTED_FEATURE", message="property_list_filtering unavailable")],
@@ -480,3 +488,44 @@ class TestA2ASuccessDerivedFromErrorsOnRealWire:
                 dispatch_request(ctx, brief="display ads")
 
             assert wire_field(ctx, "success") is False
+
+    def test_get_products_ranking_advisory_keeps_wire_success_true(self, integration_db):
+        """The live case, end to end: no stub for the response, no stub for the marker.
+
+        The seller sets a ``product_ranking_prompt`` and no AI configuration, and the
+        harness removes the platform key (verifying through production's own
+        ``is_ai_enabled`` that it is really gone), so ``_get_products_impl`` builds its
+        real ``PRODUCT_RANKING_UNAVAILABLE`` advisory and A2A serializes the real
+        response. That makes this one test grade both halves of the contract: the
+        advisory reaches the buyer as a ``severity: warning`` entry, AND the envelope
+        still reports the task as successful, because a complete product list returned
+        in catalog order is not a failed task.
+        """
+        from tests.bdd.steps._outcome_helpers import wire_dict, wire_field
+        from tests.bdd.steps.generic._dispatch import dispatch_request
+        from tests.factories import PricingOptionFactory, PrincipalFactory, ProductFactory, TenantFactory
+        from tests.harness.product import ProductEnv
+        from tests.harness.transport import Transport
+
+        with ProductEnv(tenant_id="a2a-advisory-success-test", principal_id="test_principal") as env:
+            tenant = TenantFactory(tenant_id="a2a-advisory-success-test")
+            PrincipalFactory(tenant=tenant, principal_id="test_principal")
+            product = ProductFactory(tenant=tenant, product_id="prod-a")
+            PricingOptionFactory(product=product)
+
+            env.set_tenant_ai_ranking(None, "rank by relevance to the brief")
+
+            ctx: dict = {"env": env, "transport": Transport.A2A}
+            dispatch_request(ctx, brief="display ads")
+
+        advisories = wire_dict(ctx).get("errors") or []
+        assert len(advisories) == 1, advisories
+        assert advisories[0]["severity"] == "warning", advisories[0]
+        assert "PRODUCT_RANKING_UNAVAILABLE" in advisories[0]["message"], advisories[0]
+
+        assert [p["product_id"] for p in wire_field(ctx, "products")] == ["prod-a"]
+        assert wire_field(ctx, "success") is True, (
+            "a complete product list plus a non-fatal advisory is a successful task; "
+            "reporting success=false here told every buyer of an advisory-carrying "
+            "seller that discovery had failed"
+        )

--- a/tests/integration/test_get_products_behavioral.py
+++ b/tests/integration/test_get_products_behavioral.py
@@ -242,7 +242,13 @@ class TestRankingFailureFailopen:
 
     @pytest.mark.asyncio
     async def test_ranking_failure_returns_products_unranked(self, integration_db):
-        """When AI ranking service raises Exception, products returned in catalog order."""
+        """When AI ranking service raises Exception, products returned in catalog order — and said so.
+
+        Fail-open is only half the contract. This test used to assert the order alone,
+        which a response with ``errors=None`` satisfies — and that is exactly what the
+        buyer got: a plausible-looking list with no way to tell it was never ranked. The
+        advisory assertion below is the other half.
+        """
         with ProductEnv(tenant_id="rank-fail", principal_id="p1") as env:
             tenant = TenantFactory(
                 tenant_id="rank-fail",
@@ -270,6 +276,16 @@ class TestRankingFailureFailopen:
         assert len(response.products) == 2
         assert response.products[0].product_id == "p_first"
         assert response.products[1].product_id == "p_second"
+
+        # SERVICE_UNAVAILABLE / transient, not CONFIGURATION_ERROR / terminal: a
+        # RuntimeError out of the AI path is the call not completing, and telling the
+        # buyer "MUST NOT auto-retry" would be wrong advice for a 429 or a 503.
+        assert response.errors is not None and len(response.errors) == 1
+        advisory = response.errors[0]
+        assert advisory.code == "SERVICE_UNAVAILABLE"
+        assert advisory.recovery == "transient"
+        assert advisory.severity == "warning"
+        assert "PRODUCT_RANKING_UNAVAILABLE" in advisory.message
 
 
 # ---- Policy: tests 3, 4, 5 (S9, S8, S10) ----

--- a/tests/integration/test_tenant_utils.py
+++ b/tests/integration/test_tenant_utils.py
@@ -140,3 +140,86 @@ def test_account_approval_mode_defaults_to_none_when_unset(integration_db):
         assert ctx.account_approval_mode is None
         # Creative approval_mode keeps its own default, unaffected
         assert ctx.approval_mode == "require-human"
+
+
+@pytest.mark.requires_db
+def test_ai_config_round_trips_through_both_tenant_projections(integration_db):
+    """ai_config and product_ranking_prompt survive every tenant projection.
+
+    _get_products_impl resolves the tenant's AI configuration out of whatever shape the
+    tenant arrived in, so a field that the ORM model stores but a projection drops makes
+    ranking and policy checks silently fall back to the platform key. There are two
+    projections and they are maintained independently — serialize_tenant_to_dict (the
+    plain dict) and TenantContext — so both are graded here.
+    """
+    from src.core.tenant_context import TenantContext
+    from tests.factories import TenantFactory
+    from tests.harness._base import IntegrationEnv
+
+    ai_config = {"provider": "anthropic", "model": "claude-x", "api_key": "tenant-key"}
+
+    with IntegrationEnv(tenant_id="test_aicfg"):
+        tenant = TenantFactory(
+            tenant_id="test_aicfg",
+            ai_config=ai_config,
+            product_ranking_prompt="rank by relevance to the brief",
+        )
+
+        # 1. serialize_tenant_to_dict exposes both keys
+        d = serialize_tenant_to_dict(tenant)
+        assert d["ai_config"] == ai_config
+        assert d["product_ranking_prompt"] == "rank by relevance to the brief"
+
+        # 2. TenantContext.from_orm_model populates the fields
+        ctx = TenantContext.from_orm_model(tenant)
+        assert ctx.ai_config == ai_config
+        assert ctx.product_ranking_prompt == "rank by relevance to the brief"
+
+        # 3. Round-trip via from_dict preserves the values
+        ctx2 = TenantContext.from_dict(d)
+        assert ctx2.ai_config == ai_config
+        assert ctx2.product_ranking_prompt == "rank by relevance to the brief"
+
+        # 4. The dict-style read products.py performs works via TenantContext.get()
+        assert ctx.get("ai_config") == ai_config
+
+
+@pytest.mark.requires_db
+def test_ai_config_survives_the_lazy_tenant_chain(integration_db):
+    """LazyTenantContext resolves ai_config through the chain products.py walks.
+
+    The transports that inject an identity directly hand _get_products_impl a flat dict
+    that never passes through serialize_tenant_to_dict or TenantContext.from_dict, so
+    they cannot observe a projection that dropped the field. LazyTenantContext is the one
+    path that composes the whole chain — get_tenant_by_id -> serialize_tenant_to_dict ->
+    TenantContext.from_dict — so this is the assertion that dies if EITHER projection
+    stops carrying ai_config.
+
+    A missing tenant row would also make _resolve() fall back to a bare
+    TenantContext(tenant_id=...), whose ai_config is None; the equality assertion below
+    fails on that fallback too rather than passing vacuously.
+    """
+    from src.core.tenant_context import LazyTenantContext
+    from src.services.ai.config import TenantAIConfig
+    from tests.factories import TenantFactory
+    from tests.harness._base import IntegrationEnv
+
+    ai_config = {"provider": "anthropic", "model": "claude-x", "api_key": "tenant-key"}
+
+    with IntegrationEnv(tenant_id="test_aicfg_lazy"):
+        TenantFactory(
+            tenant_id="test_aicfg_lazy",
+            ai_config=ai_config,
+            product_ranking_prompt="rank by relevance to the brief",
+        )
+
+        lazy = LazyTenantContext("test_aicfg_lazy")
+
+        assert lazy.get("ai_config") == ai_config
+        assert lazy.get("product_ranking_prompt") == "rank by relevance to the brief"
+
+        # And the resolution rule reads it off the lazy proxy unchanged — the shape
+        # _rank_products_with_ai and the policy gate both consume.
+        assert TenantAIConfig.from_tenant(lazy) == TenantAIConfig(
+            provider="anthropic", model="claude-x", api_key="tenant-key"
+        )

--- a/tests/unit/test_a2a_success_field_consolidation.py
+++ b/tests/unit/test_a2a_success_field_consolidation.py
@@ -1,17 +1,30 @@
-"""A2A 'success' field: single derivation, not 3 duplicated inline copies (#1868 review).
+"""A2A 'success' field: one derivation, and it reports FAILURE (#1868 review, then #2167).
 
-Three sites independently stamped response_data["success"] onto the A2A wire:
-_serialize_for_a2a (the declared "single serialization point", which correctly
-derives success from the presence of `errors`), _handle_get_products_skill, and
-_get_products (the natural-language handler) -- the latter two duplicated the
-stamp inline WITHOUT the errors-derivation, unconditionally forcing
-success=True even when the response carried populated `errors`.
+Two obligations meet in one predicate here.
 
-This is a DRY violation (CLAUDE.md non-negotiable invariant) that hid a real
-behavioral divergence: a get_products response with per-item errors reported
-success=True on the A2A wire via the explicit-skill and NL paths, but
-success=False via any other path that returns a raw Pydantic model through
-_serialize_for_a2a.
+DRY (#1868). Three sites independently stamped response_data["success"] onto the
+A2A wire: _serialize_for_a2a (the declared "single serialization point"),
+_handle_get_products_skill, and _get_products (the natural-language handler) --
+the latter two duplicated the stamp inline WITHOUT any derivation, unconditionally
+forcing success=True even when the response carried populated `errors`. That is a
+DRY violation (CLAUDE.md non-negotiable invariant) that hid a real behavioral
+divergence between the paths. All three now route through
+_stamp_a2a_protocol_fields, so every test below is repeated on all three.
+
+WHAT THE MARKER MEANS (#2167). The single derivation then answered the wrong
+question: `success = not bool(errors)`, i.e. "is errors[] non-empty". The pinned
+core/protocol-envelope.json says those are different questions -- on `adcp_error`:
+"a fatal task failure SHOULD populate both this envelope-level field AND the
+payload's `errors[]` array ... Non-fatal warnings populate ONLY `payload.errors[]`
+with `severity: warning` -- the envelope MUST NOT carry `adcp_error` for
+non-failures." Its two examples carry exactly that contrast: severity "warning" on
+a completed response, severity "error" on status "failed".
+
+So a tenant with an advisory -- get_products' unranked-ranking notice is the live
+one -- reported success=false on EVERY call over A2A while returning a complete,
+usable product list. An entry that has declared itself `severity: "warning"` no
+longer flips the marker; an entry that has NOT is still a failure, which is why
+every unmarked-error case below keeps its original expectation.
 """
 
 from __future__ import annotations
@@ -19,6 +32,7 @@ from __future__ import annotations
 from unittest.mock import patch
 
 import pytest
+from adcp.types import Error
 
 from src.a2a_server.adcp_a2a_server import AdCPRequestHandler
 from src.core.schemas import GetProductsResponse
@@ -28,8 +42,23 @@ _MOCK_IDENTITY = PrincipalFactory.make_identity(
     principal_id="test_principal", tenant_id="test_tenant", tenant={"tenant_id": "test_tenant"}, protocol="a2a"
 )
 
+# The shape production emits: src.core.tools.products._unranked_products_advisory.
+# Built here as a real adcp Error so `severity` travels as the extra field it is,
+# through the same model_dump the stamper reads.
+_ADVISORY = Error(
+    code="CONFIGURATION_ERROR",
+    message="PRODUCT_RANKING_UNAVAILABLE: products returned unranked",
+    recovery="terminal",
+    severity="warning",
+    field="products[]",
+)
 
-def _make_get_products_response(errors=None) -> GetProductsResponse:
+# An errors[] entry with no severity marker -- every fatal errors[] this codebase
+# emits (UpdateMediaBuyError, get_media_buys' AUTH_REQUIRED degradation).
+_UNMARKED_ERROR = {"code": "X", "message": "y"}
+
+
+def _make_get_products_response(errors=None, adcp_error=None) -> GetProductsResponse:
     """A real GetProductsResponse -- no MagicMock standing in for the response object.
 
     A MagicMock's canned .model_dump()/__str__ return values round-trip regardless of
@@ -40,6 +69,8 @@ def _make_get_products_response(errors=None) -> GetProductsResponse:
     kwargs = {"products": []}
     if errors is not None:
         kwargs["errors"] = errors
+    if adcp_error is not None:
+        kwargs["adcp_error"] = adcp_error
     return GetProductsResponse(**kwargs)
 
 
@@ -53,8 +84,39 @@ class TestSerializeForA2ADerivesSuccessFromErrors:
 
     def test_success_false_when_errors_present(self):
         handler = AdCPRequestHandler()
-        result = handler._serialize_for_a2a(_make_get_products_response(errors=[{"code": "X", "message": "y"}]))
+        result = handler._serialize_for_a2a(_make_get_products_response(errors=[_UNMARKED_ERROR]))
         assert result["success"] is False
+
+    def test_success_true_when_the_only_entry_is_an_advisory_warning(self):
+        """A complete product list plus a non-fatal notice is not a failed task."""
+        handler = AdCPRequestHandler()
+        result = handler._serialize_for_a2a(_make_get_products_response(errors=[_ADVISORY]))
+        assert result["success"] is True, (
+            "an errors[] entry marked severity='warning' is by the pinned envelope's own "
+            "definition non-fatal and must not flip the A2A success marker"
+        )
+        # The advisory still reaches the buyer -- success is corrected, not the payload.
+        assert result["errors"][0]["code"] == "CONFIGURATION_ERROR"
+        assert result["errors"][0]["severity"] == "warning"
+
+    def test_success_false_when_a_warning_rides_alongside_an_unmarked_error(self):
+        """One real error is enough; a warning next to it does not launder it."""
+        handler = AdCPRequestHandler()
+        result = handler._serialize_for_a2a(_make_get_products_response(errors=[_ADVISORY, _UNMARKED_ERROR]))
+        assert result["success"] is False
+
+    def test_success_false_when_the_envelope_carries_adcp_error(self):
+        """`adcp_error` is the envelope's own fatal-failure signal, warnings or not.
+
+        Pinned core/protocol-envelope.json: it is the "transport-envelope error signal
+        for fatal task failures", and the envelope "MUST NOT carry `adcp_error` for
+        non-failures" -- so its presence settles the question by itself.
+        """
+        handler = AdCPRequestHandler()
+        response = _make_get_products_response(
+            errors=[_ADVISORY], adcp_error=Error(code="INVALID_REQUEST", message="bad brief")
+        )
+        assert handler._serialize_for_a2a(response)["success"] is False
 
 
 class TestHandleGetProductsSkillDerivesSuccessFromErrors:
@@ -64,7 +126,7 @@ class TestHandleGetProductsSkillDerivesSuccessFromErrors:
     async def test_success_false_when_errors_present(self):
         handler = AdCPRequestHandler()
         with patch("src.a2a_server.adcp_a2a_server.core_get_products_tool") as mock_core_tool:
-            mock_core_tool.return_value = _make_get_products_response(errors=[{"code": "X", "message": "y"}])
+            mock_core_tool.return_value = _make_get_products_response(errors=[_UNMARKED_ERROR])
             result = await handler._handle_get_products_skill({"brief": "test"}, _MOCK_IDENTITY)
 
         assert result["success"] is False, (
@@ -81,6 +143,22 @@ class TestHandleGetProductsSkillDerivesSuccessFromErrors:
 
         assert result["success"] is True
 
+    @pytest.mark.asyncio
+    async def test_success_true_when_the_only_entry_is_an_advisory_warning(self):
+        """The live case: a seller with AI ranking configured but unavailable.
+
+        Every get_products call from that seller carries the advisory, so before this
+        was corrected every one of them reported success=false over A2A while returning
+        a complete product list.
+        """
+        handler = AdCPRequestHandler()
+        with patch("src.a2a_server.adcp_a2a_server.core_get_products_tool") as mock_core_tool:
+            mock_core_tool.return_value = _make_get_products_response(errors=[_ADVISORY])
+            result = await handler._handle_get_products_skill({"brief": "test"}, _MOCK_IDENTITY)
+
+        assert result["success"] is True
+        assert result["errors"][0]["severity"] == "warning"
+
 
 class TestNaturalLanguageGetProductsDerivesSuccessFromErrors:
     """_get_products (NL handler) duplicated the stamp without errors-derivation."""
@@ -89,7 +167,7 @@ class TestNaturalLanguageGetProductsDerivesSuccessFromErrors:
     async def test_success_false_when_errors_present(self):
         handler = AdCPRequestHandler()
         with patch("src.a2a_server.adcp_a2a_server.core_get_products_tool") as mock_core_tool:
-            mock_core_tool.return_value = _make_get_products_response(errors=[{"code": "X", "message": "y"}])
+            mock_core_tool.return_value = _make_get_products_response(errors=[_UNMARKED_ERROR])
             result = await handler._get_products("test query", _MOCK_IDENTITY)
 
         assert result["success"] is False, (
@@ -105,3 +183,13 @@ class TestNaturalLanguageGetProductsDerivesSuccessFromErrors:
             result = await handler._get_products("test query", _MOCK_IDENTITY)
 
         assert result["success"] is True
+
+    @pytest.mark.asyncio
+    async def test_success_true_when_the_only_entry_is_an_advisory_warning(self):
+        handler = AdCPRequestHandler()
+        with patch("src.a2a_server.adcp_a2a_server.core_get_products_tool") as mock_core_tool:
+            mock_core_tool.return_value = _make_get_products_response(errors=[_ADVISORY])
+            result = await handler._get_products("test query", _MOCK_IDENTITY)
+
+        assert result["success"] is True
+        assert result["errors"][0]["severity"] == "warning"

--- a/tests/unit/test_admin_creative_ai_review_availability.py
+++ b/tests/unit/test_admin_creative_ai_review_availability.py
@@ -1,0 +1,111 @@
+"""The creative-management page and the AI review impl must answer the same question.
+
+``review_creatives`` renders a ``has_ai_review`` flag that decides whether the page even
+offers AI review, and ``_perform_ai_review`` decides whether one runs. They read the same
+tenant one click apart, so they cannot be allowed to disagree — and they did: the page
+tested ``tenant.gemini_api_key`` (the legacy column) while the impl resolved through
+``TenantAIConfig.from_tenant`` (``ai_config`` first, the legacy column second). A seller
+who configured AI in the Admin UI — which writes ``ai_config``, not that column — was
+shown "AI review unavailable" by a page whose impl would happily have run one.
+
+Both now go through ``_tenant_ai_enabled``, the single owner of "can an AI call actually
+run for this tenant".
+
+``TenantFactory.build()`` makes a real ORM ``Tenant`` without touching the database, so
+``ai_config`` / ``gemini_api_key`` / ``creative_review_criteria`` are read through the
+same attributes production reads.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.admin.blueprints.creatives import _tenant_ai_enabled, review_creatives
+from tests.factories import TenantFactory
+
+# A tenant configured the way the Admin UI writes it: provider, model and key on
+# `ai_config`, nothing in the legacy `gemini_api_key` column.
+_ADMIN_UI_AI_CONFIG = {"provider": "anthropic", "model": "claude-sonnet-4-20250514", "api_key": "sk-ant-tenant"}
+
+# What `src/admin/blueprints/settings.py` stores when the seller leaves the key field
+# blank — and tells them "AI features will be disabled" as it does.
+_KEYLESS_AI_CONFIG = {"provider": "google", "model": "gemini-2.0-flash"}
+
+
+@pytest.fixture(autouse=True)
+def _tenant_credentials_only(monkeypatch):
+    """Remove the platform credentials, and supply the key the tenant column needs.
+
+    ``is_ai_enabled`` counts the platform key, so with ``GEMINI_API_KEY`` left in place —
+    ``tests/conftest.py`` sets it for every test — every tenant looks AI-enabled and the
+    keyless-row case below would pass no matter what production resolved.
+
+    ``Tenant.gemini_api_key`` encrypts on write and decrypts on read, so the legacy-column
+    case needs an ``ENCRYPTION_KEY``. A per-run Fernet key round-trips through the real
+    encrypt/decrypt path rather than stubbing it out.
+    """
+    from cryptography.fernet import Fernet
+
+    for var in ("GEMINI_API_KEY", "ANTHROPIC_API_KEY", "PYDANTIC_AI_PROVIDER", "PYDANTIC_AI_MODEL"):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("ENCRYPTION_KEY", Fernet.generate_key().decode())
+
+
+def _render_page(tenant):
+    """Call ``review_creatives`` with its access decorator off and capture the template kwargs.
+
+    ``__wrapped__`` is the undecorated view — ``require_tenant_access`` needs a Flask
+    request context and grades nothing this test is about. The UoW is a stub with no
+    creatives, so the only thing the page computes is the tenant flag set.
+    """
+    uow = MagicMock()
+    uow.__enter__.return_value = uow
+    uow.tenant_config.get_tenant.return_value = tenant
+    uow.creatives.admin_list_all.return_value = []
+
+    with (
+        patch("src.admin.blueprints.creatives.AdminCreativeUoW", return_value=uow),
+        patch("src.admin.blueprints.creatives.render_template") as render,
+    ):
+        review_creatives.__wrapped__(tenant_id=tenant.tenant_id)
+
+    return render.call_args.kwargs
+
+
+class TestPageOffersAIReviewExactlyWhenTheImplWouldRunOne:
+    def test_ai_config_only_tenant_is_offered_ai_review(self):
+        """The regression: configured through the Admin UI, told it was unavailable."""
+        tenant = TenantFactory.build(
+            tenant_id="t-ai-config", ai_config=_ADMIN_UI_AI_CONFIG, creative_review_criteria="no nudity"
+        )
+
+        assert _render_page(tenant)["has_ai_review"] is True
+        # ...and the impl agrees, which is the whole point of sharing the owner.
+        assert _tenant_ai_enabled(tenant) is True
+
+    def test_legacy_gemini_key_tenant_is_still_offered_ai_review(self):
+        """The pre-existing behaviour the page had, preserved through the new owner."""
+        tenant = TenantFactory.build(
+            tenant_id="t-legacy", gemini_api_key="AIza-legacy-key", creative_review_criteria="no nudity"
+        )
+
+        assert _render_page(tenant)["has_ai_review"] is True
+
+    def test_key_left_blank_in_settings_is_not_offered_ai_review(self):
+        """A provider/model row with no key is not a configuration, so the page says so."""
+        tenant = TenantFactory.build(
+            tenant_id="t-keyless", ai_config=_KEYLESS_AI_CONFIG, creative_review_criteria="no nudity"
+        )
+
+        assert _render_page(tenant)["has_ai_review"] is False
+        assert _tenant_ai_enabled(tenant) is False
+
+    def test_configured_ai_without_review_criteria_is_not_offered_ai_review(self):
+        """The second condition still stands: the impl refuses without criteria."""
+        tenant = TenantFactory.build(
+            tenant_id="t-no-criteria", ai_config=_ADMIN_UI_AI_CONFIG, creative_review_criteria=None
+        )
+
+        assert _render_page(tenant)["has_ai_review"] is False

--- a/tests/unit/test_ai_review.py
+++ b/tests/unit/test_ai_review.py
@@ -273,6 +273,43 @@ class TestAIReviewCreative:
         assert result["error"] == "AI not configured"
         assert "AI review unavailable" in result["reason"]
 
+    # Configuration resolution: the tenant's own ai_config wins over the legacy column
+    @patch("src.services.ai.agents.review_agent.review_creative_async")
+    @patch("src.services.ai.agents.review_agent.create_review_agent")
+    @patch("src.services.ai.AIServiceFactory")
+    def test_tenant_ai_config_reaches_the_factory(
+        self, mock_factory_class, mock_create_agent, mock_review_async, mock_db_session, mock_tenant
+    ):
+        """The resolved tenant configuration is what the factory is asked about.
+
+        Graded explicitly because no other test here can catch a regression in it: the
+        rest leave the resolution unasserted and mock is_ai_enabled truthy, so a site
+        that resolved nothing at all still reviews creatives and still passes.
+        """
+        from src.admin.blueprints.creatives import _ai_review_creative_impl
+        from src.services.ai.config import TenantAIConfig
+
+        mock_tenant.ai_config = {"provider": "anthropic", "model": "claude-x", "api_key": "tenant-key"}
+        mock_tenant.gemini_api_key = "legacy-key-that-must-lose"
+
+        mock_factory = MagicMock()
+        mock_factory.is_ai_enabled.return_value = True
+        mock_factory.create_model.return_value = "anthropic:claude-x"
+        mock_factory_class.return_value = mock_factory
+
+        mock_review_async.return_value = self._create_mock_review_result(
+            decision="APPROVE",
+            reason="Creative is brand-safe",
+            confidence="high",
+        )
+
+        result = _ai_review_creative_impl("test_tenant", "test_creative_123", db_session=mock_db_session)
+
+        expected = TenantAIConfig(provider="anthropic", model="claude-x", api_key="tenant-key")
+        mock_factory.is_ai_enabled.assert_called_once_with(expected)
+        mock_factory.create_model.assert_called_once_with(expected)
+        assert result["status"] == "approved"
+
     # Edge Case: Missing review criteria
     @patch("src.services.ai.AIServiceFactory")
     def test_missing_review_criteria(self, mock_factory_class, mock_db_session, mock_tenant):

--- a/tests/unit/test_ai_service_factory.py
+++ b/tests/unit/test_ai_service_factory.py
@@ -1,5 +1,6 @@
 """Tests for AI service factory and configuration."""
 
+import logging
 import os
 from unittest.mock import patch
 
@@ -12,7 +13,26 @@ from src.services.ai import (
     build_model_string,
     get_platform_defaults,
 )
-from src.services.ai.config import GOOGLE_PROVIDER_ALIASES, uses_legacy_gemini_api_key
+from src.services.ai.config import (
+    CANONICAL_GOOGLE_PROVIDER,
+    DEFAULT_GOOGLE_MODEL,
+    GOOGLE_PROVIDER_ALIASES,
+    uses_legacy_gemini_api_key,
+)
+
+
+def credential_of(model) -> str | None:
+    """The API key the built model will actually authenticate with.
+
+    Reaches through the pydantic-ai model to the vendor client because that is the only
+    place the answer exists: `create_model` returns a Model, and which SECRET it carries
+    is exactly the property under test. Anthropic/OpenAI/Groq clients expose `api_key`
+    directly; the Google client keeps it on its inner `_api_client`.
+    """
+    client = model.client
+    if hasattr(client, "api_key"):
+        return client.api_key
+    return getattr(getattr(client, "_api_client", None), "api_key", None)
 
 
 class TestTenantAIConfig:
@@ -47,6 +67,310 @@ class TestTenantAIConfig:
         )
         assert config.provider == "gemini"
         assert not hasattr(config, "future_field")
+
+
+class TestTenantAIConfigCoerce:
+    """TenantAIConfig.coerce is the one tolerant parse of a stored ai_config value."""
+
+    def test_dict_is_parsed(self):
+        """A well-formed dict parses into a real config."""
+        config = TenantAIConfig.coerce({"provider": "anthropic", "model": "claude-sonnet-4-20250514"})
+        assert config.provider == "anthropic"
+        assert config.model == "claude-sonnet-4-20250514"
+
+    def test_existing_instance_passes_through_unchanged(self):
+        """An already-parsed TenantAIConfig is returned as the same object, not re-validated."""
+        original = TenantAIConfig(provider="openai", api_key="k")
+        assert TenantAIConfig.coerce(original) is original
+
+    def test_none_yields_platform_defaults(self):
+        """None means 'nothing configured' — a bare config, so the factory uses platform defaults."""
+        config = TenantAIConfig.coerce(None)
+        assert config.provider is None
+        assert config.api_key is None
+
+    def test_malformed_settings_degrade_to_defaults_with_one_warning(self, caplog):
+        """A settings block that violates ModelSettings bounds must NOT raise.
+
+        Regression guard: TenantAIConfig.model_validate raises pydantic's
+        ValidationError, which subclasses ValueError, so a malformed seller-side
+        ai_config row reached the buyer as a VALIDATION_ERROR/correctable envelope
+        naming 'settings.temperature' — a field that does not exist in the request
+        schema. A broken config row must degrade the AI feature, not fail the request.
+        """
+        with caplog.at_level(logging.WARNING, logger="src.services.ai.config"):
+            config = TenantAIConfig.coerce({"provider": "gemini", "settings": {"temperature": 9}})
+
+        assert config.provider is None, "malformed config must fall back to platform defaults entirely"
+        assert config.settings.temperature == 0.3
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warnings) == 1, f"expected exactly one WARNING, got {[r.message for r in warnings]}"
+
+    def test_list_from_the_jsonb_column_degrades_instead_of_raising(self, caplog):
+        """A list is a shape the JSONB column can hold, so it is malformed DATA: degrade.
+
+        Before coerce, the factory's `elif tenant_ai_config:` branch bound such a value
+        straight to `config`, and the next line (`config.api_key`) died with AttributeError.
+        """
+        with caplog.at_level(logging.WARNING, logger="src.services.ai.config"):
+            config = TenantAIConfig.coerce(["provider", "gemini"])
+
+        assert config == TenantAIConfig()
+        assert len([r for r in caplog.records if r.levelno == logging.WARNING]) == 1
+
+    @pytest.mark.parametrize("value", ["gemini", 42, object()])
+    def test_caller_type_mistake_raises_type_error(self, value, caplog):
+        """A str/int/object can only come from a caller bug, so it must RAISE.
+
+        `src/core/database/json_type.py` raises TypeError itself for anything that is
+        not a dict or list, so these shapes never come out of the ai_config column. They
+        come from a caller passing the wrong argument — the live example being
+        `build_order_name_context(..., gemini_key)`, which lands an API-key string in
+        the `tenant_ai_config` parameter. Degrading that to platform defaults hid the
+        mistake behind a log line and quietly ran the AI feature on somebody else's
+        configuration; `code-patterns.md` names exactly that shape as wrong.
+
+        The message must name both the offending type and the parameter, because the
+        caller's only clue is this exception.
+        """
+        with caplog.at_level(logging.WARNING, logger="src.services.ai.config"):
+            with pytest.raises(TypeError) as excinfo:
+                TenantAIConfig.coerce(value)
+
+        assert type(value).__name__ in str(excinfo.value)
+        assert "ai_config" in str(excinfo.value)
+        assert [r.message for r in caplog.records if r.levelno == logging.WARNING] == [], (
+            "a caller mistake is raised, not logged-and-swallowed"
+        )
+
+    def test_source_label_names_the_offending_parameter(self):
+        """`source` identifies which value was wrong — the caller's only clue."""
+        with pytest.raises(TypeError, match="naming.tenant_ai_config"):
+            TenantAIConfig.coerce("AIzaSy...", source="naming.tenant_ai_config")
+
+    def test_empty_dict_yields_platform_defaults(self):
+        """An empty ai_config is valid and simply carries nothing."""
+        assert TenantAIConfig.coerce({}) == TenantAIConfig()
+
+
+class TestTenantAIConfigFromTenant:
+    """TenantAIConfig.from_tenant owns 'given a tenant, what is its AI configuration?'."""
+
+    def test_ai_config_wins_over_legacy_key(self):
+        """A tenant's own ai_config supersedes the legacy gemini_api_key column."""
+        tenant = {"ai_config": {"provider": "anthropic", "api_key": "tenant-key"}, "gemini_api_key": "legacy-key"}
+
+        config = TenantAIConfig.from_tenant(tenant)
+
+        assert config is not None
+        assert config.provider == "anthropic"
+        assert config.api_key == "tenant-key"
+
+    def test_legacy_key_alone_becomes_canonical_google_config(self):
+        """With no ai_config, the legacy key is surfaced as a Google-provider config.
+
+        The provider is CANONICAL_GOOGLE_PROVIDER rather than the literal "gemini":
+        every consumer canonicalizes the string before comparing or using it, so the
+        two spellings are interchangeable downstream.
+
+        The MODEL travels with the provider. Left None, the factory filled it from the
+        platform's PYDANTIC_AI_MODEL, which names whatever vendor the DEPLOYMENT runs —
+        so a deployment set to Anthropic produced a Google client asking for
+        "claude-sonnet-4-…" on this tenant's Gemini key, and every call 404'd.
+        `policy_check_service` pinned "gemini-2.0-flash" at its own call site for
+        exactly this reason; the pin belongs here, with the provider it goes with.
+        """
+        config = TenantAIConfig.from_tenant({"ai_config": None, "gemini_api_key": "legacy-key"})
+
+        assert config is not None
+        assert config.provider == CANONICAL_GOOGLE_PROVIDER
+        assert config.api_key == "legacy-key"
+        assert config.model == DEFAULT_GOOGLE_MODEL
+
+    def test_provider_and_model_without_a_key_is_not_a_tenant_config(self):
+        """A row with provider/model but no api_key resolves to None, not to a config.
+
+        `src/admin/blueprints/settings.py` writes exactly {"provider": …, "model": …}
+        when the seller submits the AI form with the key field blank, and flashes "no
+        API key configured. AI features will be disabled." Returning that row as a real
+        configuration opened the policy gate in `_get_products_impl` for those tenants,
+        which then ran `check_brief_compliance` — a live LLM call — on the OPERATOR's
+        platform credential, and a BLOCKED verdict there is a buyer-visible rejection
+        the seller never asked for.
+
+        The platform key is set here on purpose: the answer must be None because the
+        TENANT has no usable credential, not because no key exists anywhere.
+        """
+        with patch.dict(os.environ, {"GEMINI_API_KEY": "platform-key"}, clear=False):
+            assert TenantAIConfig.from_tenant({"ai_config": {"provider": "anthropic", "model": "claude-x"}}) is None
+
+    def test_keyless_ai_config_falls_through_to_the_legacy_key(self):
+        """An unusable ai_config does not shadow a legacy key that IS usable."""
+        config = TenantAIConfig.from_tenant(
+            {"ai_config": {"provider": "google", "model": "gemini-2.0-flash"}, "gemini_api_key": "legacy-key"}
+        )
+
+        assert config is not None
+        assert config.api_key == "legacy-key"
+        assert config.provider == CANONICAL_GOOGLE_PROVIDER
+
+    def test_both_absent_returns_none(self):
+        """Nothing configured means None — from_tenant NEVER reaches for the platform key."""
+        with patch.dict(os.environ, {"GEMINI_API_KEY": "platform-key"}, clear=False):
+            assert TenantAIConfig.from_tenant({"ai_config": None, "gemini_api_key": None}) is None
+
+    def test_empty_ai_config_falls_through_to_legacy_key(self):
+        """The absent-test is falsy, not `is None`.
+
+        An empty ai_config dict carries no provider and no key, so it must not shadow
+        the legacy column. src/core/utils/naming.py tested `is None` and so returned an
+        empty config here, disabling AI for a tenant that had a working legacy key.
+        """
+        config = TenantAIConfig.from_tenant({"ai_config": {}, "gemini_api_key": "legacy-key"})
+
+        assert config is not None
+        assert config.api_key == "legacy-key"
+
+    def test_malformed_ai_config_resolves_to_nothing_not_a_bare_config(self, caplog):
+        """A malformed row degrades to None — never to a config the factory refills.
+
+        This test previously asserted `config == TenantAIConfig()`, which pinned the
+        defect: a bare config is falsy in no way the caller can see, so the ranking path
+        treated it as "the tenant is configured", the factory filled in the PLATFORM's
+        provider and key, and the seller who had deliberately chosen Anthropic had the
+        buyer's brief and product catalog sent to Google — with no advisory, because
+        `is_ai_enabled` said True on the platform key.
+
+        The api_key in the row is REAL and valid; only `settings.temperature` is out of
+        bounds. Returning None anyway is the point: a row we cannot parse is a row we
+        cannot act on, and one WARNING naming the tenant is how the seller finds out.
+        """
+        malformed = {
+            "tenant_id": "t1",
+            "ai_config": {"provider": "anthropic", "api_key": "sk-ant-real", "settings": {"temperature": 9}},
+        }
+
+        with patch.dict(os.environ, {"GEMINI_API_KEY": "platform-key"}, clear=False):
+            with caplog.at_level(logging.WARNING, logger="src.services.ai.config"):
+                config = TenantAIConfig.from_tenant(malformed)
+
+        assert config is None
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warnings) == 1, f"expected exactly one WARNING, got {[r.getMessage() for r in warnings]}"
+        assert "t1" in warnings[0].getMessage(), "the WARNING must name the tenant whose row is broken"
+
+    def test_malformed_ai_config_still_falls_through_to_the_legacy_key(self):
+        """A broken ai_config does not cost the tenant a legacy key that still works."""
+        config = TenantAIConfig.from_tenant(
+            {"ai_config": {"settings": {"temperature": 9}}, "gemini_api_key": "legacy-key"}
+        )
+
+        assert config is not None
+        assert config.api_key == "legacy-key"
+
+    def test_wrong_typed_ai_config_raises(self):
+        """A str in the ai_config position is a caller mistake, and still raises here."""
+        with pytest.raises(TypeError, match="str"):
+            TenantAIConfig.from_tenant({"ai_config": "AIzaSy...", "gemini_api_key": None})
+
+    def test_missing_fields_read_as_not_configured(self):
+        """A partial projection that omits both fields degrades to None, not KeyError."""
+        assert TenantAIConfig.from_tenant({"tenant_id": "t1"}) is None
+
+    def test_none_tenant_returns_none(self):
+        assert TenantAIConfig.from_tenant(None) is None
+
+    def test_orm_tenant_row_shape(self):
+        """The ORM Tenant row has no .get() — from_tenant must read it by attribute."""
+        from src.core.database.models import Tenant
+
+        tenant = Tenant(
+            tenant_id="t1",
+            name="T",
+            subdomain="t1",
+            ai_config={"provider": "openai", "api_key": "orm-key"},
+        )
+        assert not hasattr(tenant, "get"), "the ORM row's access mechanism is attributes, not .get()"
+
+        config = TenantAIConfig.from_tenant(tenant)
+
+        assert config is not None
+        assert config.provider == "openai"
+        assert config.api_key == "orm-key"
+
+    def test_orm_tenant_row_legacy_key_is_decrypted(self):
+        """The legacy path reads the ORM property, so it gets the decrypted key."""
+        from cryptography.fernet import Fernet
+
+        from src.core.database.models import Tenant
+
+        with patch.dict(os.environ, {"ENCRYPTION_KEY": Fernet.generate_key().decode()}, clear=False):
+            tenant = Tenant(tenant_id="t1", name="T", subdomain="t1")
+            tenant.gemini_api_key = "legacy-secret"
+
+            config = TenantAIConfig.from_tenant(tenant)
+
+            assert config is not None
+            assert config.api_key == "legacy-secret", "must read the decrypting property, not the raw column"
+            assert config.provider == CANONICAL_GOOGLE_PROVIDER
+
+    def test_tenant_context_shape(self):
+        """TenantContext is the projection the real production chain produces."""
+        from src.core.tenant_context import TenantContext
+
+        tenant = TenantContext(tenant_id="t1", ai_config={"provider": "groq", "api_key": "ctx-key"})
+
+        config = TenantAIConfig.from_tenant(tenant)
+
+        assert config is not None
+        assert config.provider == "groq"
+        assert config.api_key == "ctx-key"
+
+    def test_tenant_context_legacy_key_only(self):
+        """TenantContext carrying only the legacy key resolves through the fallback."""
+        from src.core.tenant_context import TenantContext
+
+        config = TenantAIConfig.from_tenant(TenantContext(tenant_id="t1", gemini_api_key="legacy-key"))
+
+        assert config is not None
+        assert config.provider == CANONICAL_GOOGLE_PROVIDER
+        assert config.api_key == "legacy-key"
+
+    def test_result_drives_the_factory(self):
+        """The returned config is what the factory consumes — no dict round-trip needed."""
+        config = TenantAIConfig.from_tenant({"gemini_api_key": "legacy-key"})
+
+        with patch.dict(os.environ, {}, clear=True):
+            factory = AIServiceFactory()
+            assert factory.is_ai_enabled(config) is True
+            assert factory.get_effective_config(config)["provider"] == CANONICAL_GOOGLE_PROVIDER
+
+    def test_tenant_config_wins_while_a_platform_key_is_present(self):
+        """Anti-vacuity guard: the tenant's config must win over a set platform key.
+
+        A platform GEMINI_API_KEY makes is_ai_enabled() return True on its own, so a
+        test that only asserts "AI was enabled" passes even when the tenant's own
+        configuration was dropped on the floor. Pinning the factory's reported source
+        to "tenant" is what actually fails if from_tenant returns None here.
+        """
+        tenant = {"ai_config": {"provider": "anthropic", "model": "claude-sonnet-4-20250514", "api_key": "tenant-key"}}
+        config = TenantAIConfig.from_tenant(tenant)
+
+        with patch.dict(os.environ, {"GEMINI_API_KEY": "platform-key"}, clear=True):
+            effective = AIServiceFactory().get_effective_config(config)
+
+        assert effective["source"] == "tenant"
+        assert effective["provider"] == "anthropic"
+        assert effective["model"] == "claude-sonnet-4-20250514"
+
+    def test_legacy_key_wins_while_a_platform_key_is_present(self):
+        """Same guard for the legacy column — the tenant's own key must not be shadowed."""
+        config = TenantAIConfig.from_tenant({"gemini_api_key": "legacy-key"})
+
+        assert config is not None
+        with patch.dict(os.environ, {"GEMINI_API_KEY": "platform-key"}, clear=True):
+            assert AIServiceFactory().get_effective_config(config)["source"] == "tenant"
+        assert config.api_key == "legacy-key", "the tenant's own key, not the platform key"
 
 
 class TestModelSettings:
@@ -156,6 +480,21 @@ class TestGetPlatformDefaults:
                 "provider='google' must map to GEMINI_API_KEY; api_key=None would make is_ai_enabled() return False"
             )
 
+    def test_model_default_is_not_borrowed_across_vendors(self):
+        """PYDANTIC_AI_PROVIDER without PYDANTIC_AI_MODEL must not default to Google's model.
+
+        "gemini-2.0-flash" was the unconditional default, so an operator who set only
+        PYDANTIC_AI_PROVIDER=anthropic got a platform default pair that cannot work.
+        None is the honest answer: we do not know a model for that vendor.
+        """
+        with patch.dict(os.environ, {"PYDANTIC_AI_PROVIDER": "anthropic"}, clear=True):
+            defaults = get_platform_defaults()
+            assert defaults["provider"] == "anthropic"
+            assert defaults["model"] is None
+
+        with patch.dict(os.environ, {"PYDANTIC_AI_PROVIDER": "google-gla"}, clear=True):
+            assert get_platform_defaults()["model"] == DEFAULT_GOOGLE_MODEL
+
     def test_google_gla_provider_resolves_gemini_api_key(self):
         """PYDANTIC_AI_PROVIDER=google-gla (legacy DB value) also resolves GEMINI_API_KEY."""
         with patch.dict(
@@ -259,15 +598,23 @@ class TestAIServiceFactory:
             assert isinstance(model, AnthropicModel)
 
     def test_create_model_with_override(self):
-        """Explicit overrides take highest priority."""
+        """Explicit overrides take highest priority — and do not import the platform key.
+
+        OPENAI_API_KEY is set here because the platform (gemini) key is no longer lent
+        to the overridden provider; the assertion on the credential is what makes that
+        visible instead of leaving the model's authentication unexamined.
+        """
         from pydantic_ai.models.openai import OpenAIChatModel
 
         with patch.dict(
             os.environ,
             {
-                "GEMINI_API_KEY": "test-key",
+                "PYDANTIC_AI_PROVIDER": "gemini",
+                "PYDANTIC_AI_MODEL": "gemini-2.0-flash",
+                "GEMINI_API_KEY": "platform-gemini-secret",
+                "OPENAI_API_KEY": "platform-openai-key",
             },
-            clear=False,
+            clear=True,
         ):
             factory = AIServiceFactory()
             tenant_config = {"provider": "anthropic", "model": "claude-sonnet-4-20250514"}
@@ -278,6 +625,8 @@ class TestAIServiceFactory:
             )
             # Override to openai returns OpenAIChatModel
             assert isinstance(model, OpenAIChatModel)
+            assert model.model_name == "gpt-4o"
+            assert credential_of(model) != "platform-gemini-secret"
 
     def test_get_effective_config_platform(self):
         """Effective config shows platform source when no tenant config."""
@@ -312,6 +661,192 @@ class TestAIServiceFactory:
             assert effective["provider"] == "anthropic"
             assert effective["model"] == "claude-sonnet-4-20250514"
             assert effective["source"] == "tenant"
+
+    def test_malformed_tenant_config_does_not_raise_out_of_is_ai_enabled(self):
+        """A malformed ai_config row must not surface as an exception to the caller.
+
+        Regression guard for the get_products ranking path: is_ai_enabled() raised
+        pydantic ValidationError (a ValueError) from inside the ranking try-block,
+        which the `except (ImportError, RuntimeError, OSError)` tuple there does not
+        catch, so every transport reported VALIDATION_ERROR/correctable to the buyer.
+        """
+        with patch.dict(os.environ, {"GEMINI_API_KEY": "platform-key"}, clear=False):
+            factory = AIServiceFactory()
+            assert factory.is_ai_enabled({"settings": {"temperature": 9}}) is True
+
+    def test_non_dict_tenant_config_does_not_raise_out_of_is_ai_enabled(self):
+        """A list where a dict was expected used to die with AttributeError."""
+        with patch.dict(os.environ, {"GEMINI_API_KEY": "platform-key"}, clear=False):
+            factory = AIServiceFactory()
+            assert factory.is_ai_enabled(["provider", "gemini"]) is True
+
+    def test_malformed_tenant_config_degrades_to_a_COHERENT_platform_configuration(self):
+        """A malformed row degrades to the platform's own provider+model+key, as one set.
+
+        This test used to assert only `isinstance(model, GoogleModel)` for a row naming
+        provider "openai", which read as "the tenant's vendor may be swapped" and said
+        nothing about which secret went with it. The contract is narrower: an unparseable
+        row contributes NOTHING, so all three fields come from the platform and they
+        match each other. The buyer-facing paths never reach this state at all —
+        `TenantAIConfig.from_tenant` returns None for a malformed row (asserted in
+        TestTenantAIConfigFromTenant), so this is the direct-caller fallback only.
+        """
+        from pydantic_ai.models.google import GoogleModel
+
+        with patch.dict(
+            os.environ,
+            {
+                "PYDANTIC_AI_PROVIDER": "gemini",
+                "PYDANTIC_AI_MODEL": "gemini-2.0-flash",
+                "GEMINI_API_KEY": "platform-key",
+            },
+            clear=True,
+        ):
+            factory = AIServiceFactory()
+            model = factory.create_model(tenant_ai_config={"provider": "openai", "settings": {"timeout": -1}})
+
+            assert isinstance(model, GoogleModel)
+            assert model.model_name == "gemini-2.0-flash"
+            assert credential_of(model) == "platform-key"
+
+    def test_platform_key_is_never_lent_to_another_vendor(self):
+        """The platform's Google secret must not travel to api.anthropic.com.
+
+        `create_model` resolved provider and api_key from independent expressions, so a
+        tenant row naming "anthropic" produced an AnthropicModel whose client carried
+        the platform's GEMINI_API_KEY. `get_products` is auth-OPTIONAL discovery, so an
+        anonymous buyer's brief was enough to trigger it.
+
+        ANTHROPIC_API_KEY is present so the model still builds: the assertion is about
+        WHICH credential it carries, and a test where no model can be built could pass
+        for the wrong reason.
+        """
+        from pydantic_ai.models.anthropic import AnthropicModel
+
+        with patch.dict(
+            os.environ,
+            {
+                "PYDANTIC_AI_PROVIDER": "gemini",
+                "PYDANTIC_AI_MODEL": "gemini-2.0-flash",
+                "GEMINI_API_KEY": "PLATFORM-GEMINI-SECRET",
+                "ANTHROPIC_API_KEY": "PLATFORM-ANTHROPIC-KEY",
+            },
+            clear=True,
+        ):
+            factory = AIServiceFactory()
+            model = factory.create_model(
+                tenant_ai_config={"provider": "anthropic", "model": "claude-sonnet-4-20250514"}
+            )
+
+            assert isinstance(model, AnthropicModel)
+            assert credential_of(model) != "PLATFORM-GEMINI-SECRET", "the platform's Google key reached Anthropic"
+
+    def test_ai_is_disabled_when_the_platform_key_belongs_to_another_vendor(self):
+        """A tenant provider with no credential of its own is NOT AI-enabled.
+
+        `is_ai_enabled` counted any key from any source, so it green-lit a request that
+        could only run by borrowing the wrong vendor's secret. Consumers gate on this,
+        so False here is what makes them skip AI (and, in get_products, emit the
+        unranked advisory) instead of making the call.
+        """
+        with patch.dict(
+            os.environ,
+            {
+                "PYDANTIC_AI_PROVIDER": "gemini",
+                "PYDANTIC_AI_MODEL": "gemini-2.0-flash",
+                "GEMINI_API_KEY": "PLATFORM-GEMINI-SECRET",
+            },
+            clear=True,
+        ):
+            factory = AIServiceFactory()
+
+            assert factory.is_ai_enabled({"provider": "anthropic", "model": "claude-sonnet-4-20250514"}) is False
+            # …and the same answer is reported to the admin UI and to PolicyCheckService,
+            # which gates on has_api_key.
+            effective = factory.get_effective_config({"provider": "anthropic", "model": "claude-sonnet-4-20250514"})
+            assert effective["has_api_key"] is False
+            # The tenant's own key is still enough on its own.
+            assert factory.is_ai_enabled({"provider": "anthropic", "model": "claude-x", "api_key": "sk-ant"}) is True
+
+    def test_missing_model_for_a_foreign_provider_disables_ai_and_raises_if_forced(self):
+        """A model name from another vendor is not a model for this one.
+
+        The Admin UI writes model="" when the seller leaves the field blank, so
+        {"provider": "anthropic", "api_key": …} with no model is a real stored shape.
+        Filling it from PYDANTIC_AI_MODEL handed "gemini-2.0-flash" to an Anthropic
+        client — every call 404s, and in the ranking path that 404 is a RuntimeError
+        that comes back to the buyer as a silently unranked list.
+        """
+        with patch.dict(
+            os.environ,
+            {
+                "PYDANTIC_AI_PROVIDER": "gemini",
+                "PYDANTIC_AI_MODEL": "gemini-2.0-flash",
+                "GEMINI_API_KEY": "PLATFORM-GEMINI-SECRET",
+            },
+            clear=True,
+        ):
+            factory = AIServiceFactory()
+            keyed_but_modelless = {"provider": "anthropic", "api_key": "sk-ant-tenant"}
+
+            assert factory.is_ai_enabled(keyed_but_modelless) is False
+            assert factory.get_effective_config(keyed_but_modelless)["model"] is None
+
+            from src.core.exceptions import AdCPConfigurationError
+
+            with pytest.raises(AdCPConfigurationError, match="No model configured"):
+                factory.create_model(tenant_ai_config=keyed_but_modelless)
+
+    def test_legacy_google_config_runs_on_google_under_an_anthropic_platform(self):
+        """End to end for the legacy column: provider, model and key are all Google.
+
+        With PYDANTIC_AI_PROVIDER=anthropic the platform model names a Claude release.
+        Before the pin, `from_tenant`'s legacy config carried provider="google" and no
+        model, so the factory paired that Claude name with a Google client built on the
+        tenant's Gemini key: a model that 404s on every request.
+        """
+        from pydantic_ai.models.google import GoogleModel
+
+        with patch.dict(
+            os.environ,
+            {
+                "PYDANTIC_AI_PROVIDER": "anthropic",
+                "PYDANTIC_AI_MODEL": "claude-sonnet-4-20250514",
+                "ANTHROPIC_API_KEY": "PLATFORM-ANTHROPIC-KEY",
+            },
+            clear=True,
+        ):
+            config = TenantAIConfig.from_tenant({"tenant_id": "t1", "gemini_api_key": "AIza-TENANT"})
+            factory = AIServiceFactory()
+
+            assert factory.is_ai_enabled(config) is True
+            model = factory.create_model(config)
+
+            assert isinstance(model, GoogleModel)
+            assert model.model_name == DEFAULT_GOOGLE_MODEL
+            assert credential_of(model) == "AIza-TENANT"
+
+    def test_unsupported_provider_refuses_to_drop_a_configured_key(self):
+        """The string-fallback branch cannot inject a key, so it must not pretend to.
+
+        Returning "gateway/anthropic:model" leaves pydantic-ai to authenticate with
+        whatever it finds in the environment — a different credential than the one the
+        seller configured. No quiet failures: say so.
+        """
+        from src.core.exceptions import AdCPConfigurationError
+
+        with patch.dict(os.environ, {"GEMINI_API_KEY": "platform-key"}, clear=True):
+            factory = AIServiceFactory()
+
+            with pytest.raises(AdCPConfigurationError, match="cannot be used"):
+                factory.create_model(
+                    tenant_ai_config={"provider": "gateway/anthropic", "model": "claude-x", "api_key": "sk-tenant"}
+                )
+
+            # With no key to drop, the string fallback still works.
+            assert factory.create_model(tenant_ai_config={"provider": "gateway/anthropic", "model": "claude-x"}) == (
+                "gateway/anthropic:claude-x"
+            )
 
     def test_model_receives_api_key_via_provider(self):
         """Factory passes API key directly via Provider, not environment variables."""

--- a/tests/unit/test_architecture_e2e_rest_escape_hatches.py
+++ b/tests/unit/test_architecture_e2e_rest_escape_hatches.py
@@ -440,6 +440,25 @@ EXPECTED_UNSUPPORTED_DECLARATIONS: frozenset[tuple[str, str, str]] = frozenset(
             "live stack always serves the agent catalog; an empty catalog cannot be realized over e2e",
         ),
         ("tests/harness/creative_formats.py", "_validate_registry_formats", "<dynamic>"),
+        # PR #2167, the BR-RULE-005 ranking scenarios. Both halves of their setup
+        # are in-process facts about THIS process, which is why neither is a silent
+        # parametrize drop: the platform AI key belongs to the live server's own
+        # environment, and the relevance scores stand in for a model call the live
+        # server would really make. Declared at the env methods so the reason
+        # travels with the setup instead of living in a nodeid ledger.
+        (
+            "tests/harness/product.py",
+            "set_tenant_ai_ranking",
+            "the platform GEMINI_API_KEY is read from the LIVE SERVER's own process environment "
+            "(and cached there by get_factory's lru_cache), so the harness cannot remove it; "
+            "'the tenant's own ai_config is the only AI configuration present' has no server surface",
+        ),
+        (
+            "tests/harness/product.py",
+            "set_ranking_scores",
+            "the ranking factory has no live-server injection surface: over e2e the server builds a "
+            "real model and calls the provider, so scripted relevance scores cannot be realized",
+        ),
     }
 )
 

--- a/tests/unit/test_architecture_measurement_floors.py
+++ b/tests/unit/test_architecture_measurement_floors.py
@@ -33,9 +33,9 @@ sys.path.insert(0, str(REPO_ROOT))
 # node ids by identity rather than by size.
 #
 # The set spans BOTH sources, deliberately. The literal `ENV_ROUTES` block holds
-# 20 wired rows; `ENV_ROUTES +=` appends 5 more from `_UC_BUCKET_ROUTES` at
+# 20 wired rows; `ENV_ROUTES +=` appends 6 more from `_UC_BUCKET_ROUTES` at
 # import time. "How many wired rows are there" therefore has two answers (20 and
-# 25), and a floor that does not say which it means is itself an ambiguous
+# 26), and a floor that does not say which it means is itself an ambiguous
 # counter. This pins the runtime set — what actually routes scenarios.
 #
 # Discipline, matching EXPECTED_LEDGER in test_storyboard_ledger_state.py:
@@ -46,6 +46,10 @@ EXPECTED_WIRED_ROUTES: frozenset[str] = frozenset(
         # bucket rows, appended from _UC_BUCKET_ROUTES
         "ADMIN",
         "COMPAT",
+        # UC-001 joined the wired set in PR #2167: get_products discovery has had a
+        # harness all along (ProductEnv), but no row claimed the bucket, so a
+        # @T-UC-001-* scenario xfailed as "No harness wired for UC-001".
+        "UC-001",
         "UC-005",
         "UC-019",
         "UC-GET-PRODUCTS",

--- a/tests/unit/test_get_products_impl_coverage.py
+++ b/tests/unit/test_get_products_impl_coverage.py
@@ -512,6 +512,72 @@ class TestAIRankingDisabled:
         assert result.products[1].product_id == "prod-b"
 
 
+class TestAIRankingUsesTenantConfig:
+    """The ranking path must consult the tenant's own AI configuration.
+
+    Intent: a tenant that configures its API key in the Admin UI (stored in
+    tenants.ai_config) gets AI ranking. Calling the factory without that config
+    makes it fall back to the platform-level environment key, so such a tenant
+    silently got no ranking — the miss is only logged at debug level.
+    """
+
+    @pytest.mark.asyncio
+    async def test_tenant_ai_config_is_passed_to_factory(self):
+        """The tenant's ai_config reaches both is_ai_enabled and create_model."""
+        ai_config = {"provider": "google", "model": "gemini-flash-lite-latest", "api_key": "tenant-key"}
+        tenant = _make_tenant()
+        tenant["product_ranking_prompt"] = "rank by relevance"
+        tenant["ai_config"] = ai_config
+        identity = _make_identity(principal_id="user-1", tenant_id="test-tenant", tenant=tenant)
+        req = _make_request()
+
+        mock_factory = MagicMock()
+        # Keep AI off so the test stops at the factory calls it is asserting on,
+        # rather than needing a working agent.
+        mock_factory.is_ai_enabled.return_value = False
+
+        mock_uow = _mock_uow_with_products([create_test_product(product_id="prod-a")])
+        patches = _standard_patches(mock_uow)
+
+        with contextlib.ExitStack() as stack:
+            for p in patches:
+                stack.enter_context(p)
+            stack.enter_context(patch("src.services.ai.factory.get_factory", return_value=mock_factory))
+
+            from src.core.tools.products import _get_products_impl
+
+            await _get_products_impl(req, identity)
+
+        mock_factory.is_ai_enabled.assert_called_once_with(ai_config)
+
+    @pytest.mark.asyncio
+    async def test_legacy_gemini_api_key_is_used_when_ai_config_absent(self):
+        """A tenant still on the legacy gemini_api_key field keeps working."""
+        tenant = _make_tenant()
+        tenant["product_ranking_prompt"] = "rank by relevance"
+        tenant["ai_config"] = None
+        tenant["gemini_api_key"] = "legacy-key"
+        identity = _make_identity(principal_id="user-1", tenant_id="test-tenant", tenant=tenant)
+        req = _make_request()
+
+        mock_factory = MagicMock()
+        mock_factory.is_ai_enabled.return_value = False
+
+        mock_uow = _mock_uow_with_products([create_test_product(product_id="prod-a")])
+        patches = _standard_patches(mock_uow)
+
+        with contextlib.ExitStack() as stack:
+            for p in patches:
+                stack.enter_context(p)
+            stack.enter_context(patch("src.services.ai.factory.get_factory", return_value=mock_factory))
+
+            from src.core.tools.products import _get_products_impl
+
+            await _get_products_impl(req, identity)
+
+        mock_factory.is_ai_enabled.assert_called_once_with({"provider": "gemini", "api_key": "legacy-key"})
+
+
 class TestAdapterPricingAnnotation:
     """Adapter annotation fail-open on expected errors.
 

--- a/tests/unit/test_get_products_impl_coverage.py
+++ b/tests/unit/test_get_products_impl_coverage.py
@@ -19,14 +19,107 @@ Tests verify intended behavioral contracts, not just line coverage:
 """
 
 import contextlib
-from unittest.mock import AsyncMock, MagicMock, patch
+import logging
+from unittest.mock import AsyncMock, MagicMock, create_autospec, patch
 
 import pytest
 from adcp.types import FormatId
 
 from src.core.exceptions import AdCPAuthenticationError
 from src.core.resolved_identity import ResolvedIdentity
+from src.services.ai.config import CANONICAL_GOOGLE_PROVIDER, DEFAULT_GOOGLE_MODEL, TenantAIConfig
+from tests.harness.product_unit import ProductEnv
 from tests.helpers.adcp_factories import create_test_cpm_pricing_option, create_test_product
+
+# The two configurations a tenant can carry, and what the single owner of
+# "tenant -> TenantAIConfig" must resolve each of them to. They differ in provider AND
+# in key so that the both-set case can tell which one won.
+_TENANT_AI_CONFIG = {"provider": "anthropic", "model": "claude-x", "api_key": "tenant-key"}
+_RESOLVED_FROM_AI_CONFIG = TenantAIConfig(provider="anthropic", model="claude-x", api_key="tenant-key")
+_LEGACY_KEY = "legacy-key"
+_RESOLVED_FROM_LEGACY_KEY = TenantAIConfig(
+    provider=CANONICAL_GOOGLE_PROVIDER, model=DEFAULT_GOOGLE_MODEL, api_key=_LEGACY_KEY
+)
+
+# The OPERATOR's own credential, present in the environment exactly as it is in a real
+# deployment — and as ``tests/conftest.py`` sets it for every test in this suite. Given a
+# recognisable value so "which vendor received which secret" is an assertion on a literal
+# rather than an inference.
+_PLATFORM_GEMINI_SECRET = "AIzaSy-PLATFORM-GEMINI-SECRET"
+
+
+@contextlib.contextmanager
+def _platform_ai_environment(monkeypatch, *, provider=None, model=None):
+    """Pin the PLATFORM half of the AI environment and watch what gets built on it.
+
+    Yields ``(factory, built)``:
+
+    * ``factory`` is a fresh ``AIServiceFactory`` constructed against the environment
+      this manager just pinned. It is built directly, never through ``get_factory()``,
+      because that lookup is ``lru_cache``d with ``maxsize=1``: the first call anywhere in
+      the process captures ``get_platform_defaults()`` into ``_platform_defaults``, and
+      every later ``monkeypatch.setenv`` / ``delenv`` leaves that cached instance
+      untouched. A test that only edits the environment and then lets production call
+      ``get_factory()`` grades whichever environment happened to warm the cache — in file
+      order that is ``tests/conftest.py``'s ``GEMINI_API_KEY``, so such a test would take
+      the platform-key branch it believes it removed, and would reach a real provider the
+      moment its path built a model.
+    * ``built`` records every ``(provider, model_name, api_key)`` triple that
+      ``AIServiceFactory._create_provider_model`` is asked to construct, with the real
+      implementation still running underneath. That method IS the cross-vendor decision:
+      it is the single place where a provider name and an API key are handed to a client
+      constructor together, so recording its arguments states, as a literal, which vendor
+      would receive which secret. Reading the key back off a built ``GoogleModel``
+      (``model._provider.client._api_client.api_key``) tests the same fact through three
+      layers of pydantic-ai private attributes.
+
+    The platform key is left PRESENT on purpose. Every pre-existing ranking test either
+    supplies a tenant key or deletes ``GEMINI_API_KEY``, so the configuration that
+    actually ships — an operator-wide Google key plus whatever the seller stored — was
+    graded by nothing.
+    """
+    monkeypatch.setenv("GEMINI_API_KEY", _PLATFORM_GEMINI_SECRET)
+    # Every other provider credential removed, so "no key resolved" means exactly that
+    # and cannot be satisfied by a variable that happens to be set on the dev box.
+    for var in ("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GROQ_API_KEY", "PYDANTIC_AI_PROVIDER", "PYDANTIC_AI_MODEL"):
+        monkeypatch.delenv(var, raising=False)
+    if provider is not None:
+        monkeypatch.setenv("PYDANTIC_AI_PROVIDER", provider)
+    if model is not None:
+        monkeypatch.setenv("PYDANTIC_AI_MODEL", model)
+
+    from src.services.ai.factory import AIServiceFactory
+
+    factory = AIServiceFactory()
+    built: list[tuple[str, str, str | None]] = []
+    real_create = AIServiceFactory._create_provider_model
+
+    def _record(self, provider_name, model_name, api_key):
+        built.append((provider_name, model_name, api_key))
+        return real_create(self, provider_name, model_name, api_key)
+
+    with patch.object(AIServiceFactory, "_create_provider_model", _record):
+        yield factory, built
+
+
+def _assert_one_products_warning(caplog, needle: str):
+    """Exactly one WARNING on ``src.core.tools.products`` whose message contains *needle*.
+
+    The logger is named explicitly rather than leaning on caplog's root capture, because
+    these are the SELLER-facing notices — the other half of "tell the seller in the log,
+    keep it off the buyer's wire" — and nothing else in the repo binds that logger.
+    Demoting one of them to ``logger.debug`` silences an operator's only signal that AI
+    stopped working, and before these assertions existed it broke no test in the suite.
+
+    Returns the record, so a caller can assert more about it.
+    """
+    matches = [r for r in caplog.records if r.name == "src.core.tools.products" and needle in r.getMessage()]
+    assert len(matches) == 1, (
+        f"expected exactly one src.core.tools.products WARNING containing {needle!r}, got {len(matches)}; "
+        f"captured: {[(r.name, r.levelname, r.getMessage()) for r in caplog.records]}"
+    )
+    assert matches[0].levelno == logging.WARNING, matches[0].levelname
+    return matches[0]
 
 
 def _make_identity(principal_id=None, tenant=None, tenant_id=None):
@@ -473,6 +566,78 @@ class TestPolicyEligibility:
         assert len(result.products) == 1
         assert result.products[0].product_id == "good-prod"
 
+    @pytest.mark.asyncio
+    async def test_policy_check_runs_for_ai_config_only_tenant(self):
+        """A tenant whose AI config lives in ai_config still gets its policy checks run.
+
+        The Admin UI writes ai_config; only the legacy gemini_api_key column was read
+        here, so ticking "enabled" did nothing for those tenants and the brief was never
+        checked. The service must also be constructed from the tenant's own configuration
+        rather than the deprecated gemini_api_key= parameter, which pins provider/model.
+        """
+        from src.services.ai.config import TenantAIConfig
+
+        tenant = _make_tenant()
+        tenant["advertising_policy"] = '{"enabled": true}'
+        tenant["ai_config"] = {"provider": "anthropic", "model": "claude-x", "api_key": "tenant-key"}
+        identity = _make_identity(principal_id="user-1", tenant_id="test-tenant", tenant=tenant)
+        req = _make_request()
+
+        mock_policy_service = MagicMock()
+        mock_policy_result = MagicMock()
+        mock_policy_result.status = "compliant"
+        mock_policy_service.check_brief_compliance = AsyncMock(return_value=mock_policy_result)
+        mock_policy_service.check_product_eligibility.return_value = (True, None)
+
+        mock_uow = _mock_uow_with_products([create_test_product(product_id="prod-a")])
+        patches = _standard_patches(mock_uow)
+
+        with contextlib.ExitStack() as stack:
+            for p in patches:
+                stack.enter_context(p)
+            policy_cls = stack.enter_context(patch("src.core.tools.products.PolicyCheckService"))
+            policy_cls.return_value = mock_policy_service
+
+            from src.core.tools.products import _get_products_impl
+
+            result = await _get_products_impl(req, identity)
+
+        policy_cls.assert_called_once_with(
+            tenant_ai_config=TenantAIConfig(provider="anthropic", model="claude-x", api_key="tenant-key")
+        )
+        mock_policy_service.check_brief_compliance.assert_awaited_once()
+        assert [p.product_id for p in result.products] == ["prod-a"]
+
+    @pytest.mark.asyncio
+    async def test_policy_check_skipped_when_tenant_configures_no_ai(self):
+        """No tenant AI configuration → the check is skipped, not run on platform credentials.
+
+        The gate is the tenant's own configuration, never factory.is_ai_enabled(): the
+        latter counts the platform GEMINI_API_KEY (which tests/conftest.py sets for every
+        test, as production deployments do), so gating on it would start running policy
+        checks — and raising AdCPPolicyViolationError — for tenants that configured none.
+        """
+        tenant = _make_tenant()
+        tenant["advertising_policy"] = '{"enabled": true}'  # enabled, but nothing configured
+
+        identity = _make_identity(principal_id="user-1", tenant_id="test-tenant", tenant=tenant)
+        req = _make_request()
+
+        mock_uow = _mock_uow_with_products([create_test_product(product_id="prod-a")])
+        patches = _standard_patches(mock_uow)
+
+        with contextlib.ExitStack() as stack:
+            for p in patches:
+                stack.enter_context(p)
+            policy_cls = stack.enter_context(patch("src.core.tools.products.PolicyCheckService"))
+
+            from src.core.tools.products import _get_products_impl
+
+            result = await _get_products_impl(req, identity)
+
+        policy_cls.assert_not_called()
+        assert [p.product_id for p in result.products] == ["prod-a"]
+
 
 class TestAIRankingDisabled:
     """Test AI ranking disabled path.
@@ -511,71 +676,624 @@ class TestAIRankingDisabled:
         assert result.products[0].product_id == "prod-a"
         assert result.products[1].product_id == "prod-b"
 
+    @pytest.mark.asyncio
+    async def test_unresolvable_ai_config_reports_one_advisory(self, monkeypatch, caplog):
+        """Ranking configured but nothing resolves → unranked products AND one advisory.
+
+        The buyer must be able to tell an unranked list from a ranked one; a plausible
+        looking list returned in catalog order with no signal is the silent failure
+        this advisory exists to end.
+
+        The platform environment key is deleted deliberately and the factory rebuilt
+        against that environment: ``is_ai_enabled`` returns True on the platform key
+        alone (``tests/conftest.py`` sets ``GEMINI_API_KEY`` for every test), so a test
+        that left it set would take the ranked branch regardless of what the tenant
+        configured. Only the singleton lookup is patched — the resolution rule under
+        test (``TenantAIConfig.from_tenant`` + the real ``is_ai_enabled``) runs for real.
+        """
+        monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+        monkeypatch.delenv("PYDANTIC_AI_PROVIDER", raising=False)
+
+        from src.services.ai.factory import AIServiceFactory
+
+        keyless_factory = AIServiceFactory()
+
+        tenant = _make_tenant()
+        tenant["product_ranking_prompt"] = "rank by relevance"
+        identity = _make_identity(principal_id="user-1", tenant_id="test-tenant", tenant=tenant)
+        req = _make_request()
+
+        mock_uow = _mock_uow_with_products([create_test_product(product_id="prod-a")])
+        patches = _standard_patches(mock_uow)
+
+        with contextlib.ExitStack() as stack:
+            for p in patches:
+                stack.enter_context(p)
+            stack.enter_context(patch("src.services.ai.factory.get_factory", return_value=keyless_factory))
+            stack.enter_context(caplog.at_level(logging.WARNING, logger="src.core.tools.products"))
+
+            from src.core.tools.products import _get_products_impl
+
+            result = await _get_products_impl(req, identity)
+
+        assert [p.product_id for p in result.products] == ["prod-a"]
+        assert result.errors is not None and len(result.errors) == 1
+        advisory = result.errors[0]
+        assert advisory.code == "CONFIGURATION_ERROR"
+        assert advisory.recovery == "terminal"
+        assert advisory.field == "products[]"
+        assert "unranked" in advisory.message
+
+        # The seller's own log line, at WARNING. The advisory tells the BUYER the list is
+        # unranked; this tells the SELLER that their AI configuration is the reason, and
+        # it is the half an operator greps for.
+        _assert_one_products_warning(caplog, "no usable AI configuration")
+
+        # The advisory has to be legal on the wire, not merely constructible: it rides
+        # in a completed (not failed) response, which the pinned schema permits only
+        # because errors[] is required just for status == "failed".
+        from tests.helpers.pinned_schema import validate_against_pinned_schema
+
+        validate_against_pinned_schema(
+            "media-buy/get-products-response.json", result.model_dump(mode="json", exclude_none=True)
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_ranking_prompt_emits_no_advisory(self, monkeypatch):
+        """A tenant that never asked for ranking is not told ranking is unavailable.
+
+        The singleton lookup is PATCHED, the way the two advisory tests above do it,
+        instead of leaning on ``monkeypatch.delenv("GEMINI_API_KEY")``. Deleting the
+        variable alone grades nothing here: ``get_factory`` is ``lru_cache``d, so the
+        first test in the process to call it builds the factory while
+        ``tests/conftest.py`` still sets the key, and every later deletion leaves that
+        cached instance — with the key baked into ``_platform_defaults`` — in place. A
+        test whose premise is "no platform key" while the live factory still holds one
+        passes for the wrong reason, and would reach a real provider the moment the
+        code path it exercises grew a model call.
+
+        The stronger assertion is that the factory is never CONSULTED at all: a tenant
+        with no ``product_ranking_prompt`` must not reach the ranking decision, so
+        neither the advisory nor an AI call can be produced regardless of what any
+        environment holds.
+        """
+        monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+        monkeypatch.delenv("PYDANTIC_AI_PROVIDER", raising=False)
+
+        from src.services.ai.factory import AIServiceFactory
+
+        keyless_factory = AIServiceFactory()
+
+        tenant = _make_tenant()  # no product_ranking_prompt
+        identity = _make_identity(principal_id="user-1", tenant_id="test-tenant", tenant=tenant)
+        req = _make_request()
+
+        mock_uow = _mock_uow_with_products([create_test_product(product_id="prod-a")])
+        patches = _standard_patches(mock_uow)
+
+        with contextlib.ExitStack() as stack:
+            for p in patches:
+                stack.enter_context(p)
+            get_factory = stack.enter_context(
+                patch("src.services.ai.factory.get_factory", return_value=keyless_factory)
+            )
+
+            from src.core.tools.products import _get_products_impl
+
+            result = await _get_products_impl(req, identity)
+
+        assert result.errors is None
+        get_factory.assert_not_called()
+
 
 class TestAIRankingUsesTenantConfig:
     """The ranking path must consult the tenant's own AI configuration.
 
     Intent: a tenant that configures its API key in the Admin UI (stored in
-    tenants.ai_config) gets AI ranking. Calling the factory without that config
-    makes it fall back to the platform-level environment key, so such a tenant
-    silently got no ranking — the miss is only logged at debug level.
+    tenants.ai_config) gets AI ranking. Reading only the platform-level environment
+    key meant such a tenant silently got no ranking at all.
+
+    BOTH factory calls are graded here. The previous pair of tests set
+    ``is_ai_enabled.return_value = False``, which stops the impl before
+    ``create_model`` is ever reached — so the argument that actually configures the
+    model went ungraded, and reverting the production line left them green.
+    ``create_autospec`` binds each assertion against the real ``AIServiceFactory``
+    signature, so it grades the call rather than this call site's punctuation.
     """
 
     @pytest.mark.asyncio
-    async def test_tenant_ai_config_is_passed_to_factory(self):
-        """The tenant's ai_config reaches both is_ai_enabled and create_model."""
-        ai_config = {"provider": "google", "model": "gemini-flash-lite-latest", "api_key": "tenant-key"}
-        tenant = _make_tenant()
-        tenant["product_ranking_prompt"] = "rank by relevance"
-        tenant["ai_config"] = ai_config
-        identity = _make_identity(principal_id="user-1", tenant_id="test-tenant", tenant=tenant)
-        req = _make_request()
+    @pytest.mark.parametrize(
+        ("tenant_ai_fields", "expected_config"),
+        [
+            pytest.param({"ai_config": _TENANT_AI_CONFIG}, _RESOLVED_FROM_AI_CONFIG, id="ai_config_only"),
+            pytest.param({"gemini_api_key": _LEGACY_KEY}, _RESOLVED_FROM_LEGACY_KEY, id="legacy_key_only"),
+            pytest.param(
+                {"ai_config": _TENANT_AI_CONFIG, "gemini_api_key": _LEGACY_KEY},
+                _RESOLVED_FROM_AI_CONFIG,
+                id="both_set_ai_config_wins",
+            ),
+            pytest.param({}, None, id="neither_set"),
+        ],
+    )
+    async def test_resolved_tenant_config_reaches_both_factory_calls(self, tenant_ai_fields, expected_config):
+        """Every resolution branch reaches is_ai_enabled AND create_model unchanged.
 
-        mock_factory = MagicMock()
-        # Keep AI off so the test stops at the factory calls it is asserting on,
-        # rather than needing a working agent.
-        mock_factory.is_ai_enabled.return_value = False
+        The ``both_set`` case is the one that pins PRECEDENCE: ai_config and the legacy
+        column resolve to different providers and different keys, so swapping the two
+        resolution lines in ``TenantAIConfig.from_tenant`` fails this branch. Without
+        it, the precedence rule is asserted nowhere.
 
-        mock_uow = _mock_uow_with_products([create_test_product(product_id="prod-a")])
-        patches = _standard_patches(mock_uow)
+        The ``neither_set`` case asserts ``None`` rather than skipping the factory:
+        ``is_ai_enabled`` is mocked truthy so the ranked branch is taken regardless, and
+        an autospec mock distinguishes ``is_ai_enabled()`` from ``is_ai_enabled(None)``
+        — dropping the argument entirely does not pass.
+        """
+        from src.services.ai.agents.ranking_agent import ProductRanking, ProductRankingResult
+        from src.services.ai.factory import AIServiceFactory
 
-        with contextlib.ExitStack() as stack:
-            for p in patches:
-                stack.enter_context(p)
-            stack.enter_context(patch("src.services.ai.factory.get_factory", return_value=mock_factory))
+        model = object()
+        factory = create_autospec(AIServiceFactory, instance=True)
+        factory.is_ai_enabled.return_value = True
+        factory.create_model.return_value = model
 
-            from src.core.tools.products import _get_products_impl
+        ranked = ProductRankingResult(
+            rankings=[ProductRanking(product_id="prod-a", relevance_score=0.9, reason="matches the brief")]
+        )
 
-            await _get_products_impl(req, identity)
+        with ProductEnv(product_ranking_prompt="rank by relevance", **tenant_ai_fields) as env:
+            product_a = env.add_product(product_id="prod-a")
+            env.mock["ranking_factory"].return_value = factory
 
-        mock_factory.is_ai_enabled.assert_called_once_with(ai_config)
+            with (
+                patch("src.services.ai.agents.ranking_agent.create_ranking_agent") as make_agent,
+                patch(
+                    "src.services.ai.agents.ranking_agent.rank_products_async",
+                    new_callable=AsyncMock,
+                    return_value=ranked,
+                ) as rank,
+            ):
+                response = await env.call_impl(brief="video inventory")
+
+        factory.is_ai_enabled.assert_called_once_with(expected_config)
+        factory.create_model.assert_called_once_with(tenant_ai_config=expected_config)
+        # The model the factory built is the one the ranking agent runs on: without
+        # this, create_model could receive the right config and have its result dropped.
+        make_agent.assert_called_once_with(model)
+        # WHICH text went in as WHICH argument, not merely that the call happened.
+        # ``rank_products_async`` takes the seller's ranking prompt as ``custom_prompt``
+        # and the buyer's brief as ``brief``; the prompt builder concatenates both, so
+        # swapping them changes the wording sent to the model and nothing else. An
+        # ``await_count == 1`` assertion could not see that: with the two keyword
+        # arguments exchanged in ``_rank_products_with_ai`` this file and the BDD
+        # feature were both fully green (39 passed).
+        rank.assert_awaited_once_with(
+            agent=make_agent.return_value,
+            custom_prompt="rank by relevance",
+            brief="video inventory",
+            products=[product_a],
+        )
+        assert [p.product_id for p in response.products] == ["prod-a"]
+        assert response.errors is None
 
     @pytest.mark.asyncio
-    async def test_legacy_gemini_api_key_is_used_when_ai_config_absent(self):
-        """A tenant still on the legacy gemini_api_key field keeps working."""
-        tenant = _make_tenant()
-        tenant["product_ranking_prompt"] = "rank by relevance"
-        tenant["ai_config"] = None
-        tenant["gemini_api_key"] = "legacy-key"
-        identity = _make_identity(principal_id="user-1", tenant_id="test-tenant", tenant=tenant)
-        req = _make_request()
+    async def test_malformed_ai_config_returns_unranked_products(self, monkeypatch, caplog):
+        """A broken seller config row degrades the AI feature, it does not fail the request.
 
-        mock_factory = MagicMock()
-        mock_factory.is_ai_enabled.return_value = False
+        Deliberately runs the REAL ``AIServiceFactory``. Strict
+        ``TenantAIConfig.model_validate`` raised pydantic's ``ValidationError`` inside
+        ``is_ai_enabled``, which the impl's ``(ImportError, RuntimeError, OSError)``
+        handler does not catch; ``ValidationError`` subclasses ``ValueError``, so every
+        transport normalised it into a VALIDATION_ERROR/correctable envelope naming
+        ``settings.temperature`` — a field that does not exist in the get_products
+        request schema. Mocking the factory is precisely how that escaped review, so a
+        mock here would grade nothing.
 
-        mock_uow = _mock_uow_with_products([create_test_product(product_id="prod-a")])
-        patches = _standard_patches(mock_uow)
+        The platform environment key is deleted and the factory rebuilt against that
+        environment: ``tests/conftest.py`` sets ``GEMINI_API_KEY`` for every test and
+        ``is_ai_enabled`` returns True on the platform key alone, so leaving it set
+        would take the ranked branch no matter what the tenant stored.
+        """
+        monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+        monkeypatch.delenv("PYDANTIC_AI_PROVIDER", raising=False)
 
-        with contextlib.ExitStack() as stack:
-            for p in patches:
-                stack.enter_context(p)
-            stack.enter_context(patch("src.services.ai.factory.get_factory", return_value=mock_factory))
+        from src.services.ai.factory import AIServiceFactory
 
-            from src.core.tools.products import _get_products_impl
+        keyless_factory = AIServiceFactory()
 
-            await _get_products_impl(req, identity)
+        # temperature 9 violates ModelSettings' le=2 bound — the reviewer's reproduction.
+        malformed = {"provider": "google", "api_key": "tenant-key", "settings": {"temperature": 9}}
 
-        mock_factory.is_ai_enabled.assert_called_once_with({"provider": "gemini", "api_key": "legacy-key"})
+        with ProductEnv(product_ranking_prompt="rank by relevance", ai_config=malformed) as env:
+            env.add_product(product_id="prod-a")
+            env.add_product(product_id="prod-b")
+            env.mock["ranking_factory"].return_value = keyless_factory
+
+            with caplog.at_level(logging.WARNING, logger="src.services.ai.config"):
+                response = await env.call_impl(brief="video inventory")
+
+        # Catalog order, not an exception and not a truncated list.
+        assert [p.product_id for p in response.products] == ["prod-a", "prod-b"]
+
+        # getMessage() renders the %s arguments; `record.message` is only populated
+        # once a formatter has run, so it would be missing on the raw record.
+        ignored = [r for r in caplog.records if "malformed tenant ai_config" in r.getMessage()]
+        assert len(ignored) == 1, [r.getMessage() for r in caplog.records]
+        assert ignored[0].levelno == logging.WARNING
+
+        # And the buyer is told the list is unranked rather than left to guess.
+        assert response.errors is not None and len(response.errors) == 1
+        assert response.errors[0].code == "CONFIGURATION_ERROR"
+
+
+class TestProductionShapedTenantAIConfigurations:
+    """The three tenant rows that actually occur in production, with the platform key SET.
+
+    Every other ranking test in this file either gives the tenant its own well-formed
+    ``api_key`` or deletes ``GEMINI_API_KEY`` first. Neither is the deployed shape: a real
+    operator sets one platform Google key and then sellers store whatever the Admin UI
+    wrote for them. The three rows below are what that produces, and each one is a
+    reproduction from review:
+
+    * ``{"provider": ..., "model": ...}`` with no ``api_key`` — literally what
+      ``src/admin/blueprints/settings.py`` writes when the seller leaves the key field
+      blank, while flashing "AI features will be disabled".
+    * a row that fails validation but carries a real, usable ``api_key``.
+    * a provider for which no credential exists anywhere, while the operator's Google key
+      sits in the environment.
+
+    What each must NOT do is the same in all three: no request may be built for one vendor
+    carrying another vendor's secret, and no seller who was told AI is off may have a live
+    LLM call made on the operator's credential. ``get_products`` is auth-OPTIONAL
+    discovery (``src/core/routes/api_v1.py``), so an anonymous buyer's brief is enough to
+    trigger any of these paths.
+    """
+
+    @staticmethod
+    def _ranked(product_id: str = "prod-a"):
+        """A successful ranking result, so the tests can tell "ranked" from "degraded"."""
+        from src.services.ai.agents.ranking_agent import ProductRanking, ProductRankingResult
+
+        return ProductRankingResult(
+            rankings=[ProductRanking(product_id=product_id, relevance_score=0.9, reason="matches the brief")]
+        )
+
+    @pytest.mark.asyncio
+    async def test_keyless_admin_ui_row_skips_policy_and_ranks_on_the_platforms_own_vendor(self, monkeypatch, caplog):
+        """A provider/model row with no key is not a tenant configuration.
+
+        Two failures were reproduced from this one row while the platform key was set.
+        The policy gate opened on it, so ``check_brief_compliance`` made a live LLM call
+        on the OPERATOR's credential for a seller the Admin UI had just told "AI features
+        will be disabled" — and a BLOCKED verdict there raises
+        ``AdCPPolicyViolationError``, a new rejection visible to the buyer. And the
+        ranking path resolved provider and key from independent expressions, so the row's
+        ``provider: anthropic`` was paired with the platform's ``GEMINI_API_KEY`` and the
+        operator's Google secret was addressed to api.anthropic.com.
+
+        Correct: the row resolves to no tenant configuration at all, the policy gate skips
+        exactly as it did before this feature existed, and ranking falls back to the
+        platform's OWN coherent provider+model+key — Google's model on Google's key.
+        """
+        admin_ui_row = {"provider": "anthropic", "model": "claude-sonnet-4-20250514"}  # key left blank
+
+        with _platform_ai_environment(monkeypatch) as (factory, built):
+            with ProductEnv(
+                product_ranking_prompt="rank by relevance",
+                ai_config=admin_ui_row,
+                advertising_policy={"enabled": True},
+            ) as env:
+                env.add_product(product_id="prod-a")
+                env.mock["ranking_factory"].return_value = factory
+                policy_cls = env.mock["policy_service"]
+
+                with (
+                    patch("src.services.ai.agents.ranking_agent.create_ranking_agent"),
+                    patch(
+                        "src.services.ai.agents.ranking_agent.rank_products_async",
+                        new_callable=AsyncMock,
+                        return_value=self._ranked(),
+                    ),
+                    caplog.at_level(logging.WARNING, logger="src.core.tools.products"),
+                ):
+                    response = await env.call_impl(brief="video inventory")
+
+        # Not constructed, so no brief was sent anywhere on the operator's credential.
+        policy_cls.assert_not_called()
+        # And skipped for the RIGHT reason. `assert_not_called()` alone is also satisfied
+        # by policy checks being off, which is not what this tenant configured — the row
+        # says enabled, and it is the missing tenant credential that stops the check.
+        _assert_one_products_warning(caplog, "no AI configuration")
+        assert built == [(CANONICAL_GOOGLE_PROVIDER, DEFAULT_GOOGLE_MODEL, _PLATFORM_GEMINI_SECRET)], built
+        assert [p.product_id for p in response.products] == ["prod-a"]
+        assert response.errors is None
+
+    @pytest.mark.asyncio
+    async def test_malformed_row_hands_its_key_to_nobody_and_still_ranks(self, monkeypatch, caplog):
+        """A row that fails validation carries a usable key — and it must go nowhere.
+
+        ``temperature: 9`` violates ``ModelSettings``' ``le=2``, so the row does not
+        parse; the ``api_key`` beside it is perfectly good. Two opposite mistakes are
+        available and both were reproduced: pairing the surviving fields with the platform
+        key (the seller's chosen vendor addressed with the operator's Google secret), and
+        pairing the seller's Anthropic key with the platform's Google client.
+
+        Correct: a row that does not parse resolves to nothing, so neither half of it is
+        used — not its provider, not its key — the seller gets one WARNING naming the row,
+        and ranking runs on the platform's own coherent configuration. No advisory is due
+        because the products really were ranked.
+        """
+        seller_key = "sk-ant-SELLER-OWN-KEY"
+        malformed = {"provider": "anthropic", "api_key": seller_key, "settings": {"temperature": 9}}
+
+        with _platform_ai_environment(monkeypatch) as (factory, built):
+            with ProductEnv(
+                product_ranking_prompt="rank by relevance",
+                ai_config=malformed,
+                advertising_policy={"enabled": True},
+            ) as env:
+                env.add_product(product_id="prod-a")
+                env.mock["ranking_factory"].return_value = factory
+                policy_cls = env.mock["policy_service"]
+
+                with (
+                    patch("src.services.ai.agents.ranking_agent.create_ranking_agent"),
+                    patch(
+                        "src.services.ai.agents.ranking_agent.rank_products_async",
+                        new_callable=AsyncMock,
+                        return_value=self._ranked(),
+                    ),
+                    caplog.at_level(logging.WARNING),
+                ):
+                    response = await env.call_impl(brief="video inventory")
+
+        policy_cls.assert_not_called()
+        _assert_one_products_warning(caplog, "no AI configuration")
+        assert built == [(CANONICAL_GOOGLE_PROVIDER, DEFAULT_GOOGLE_MODEL, _PLATFORM_GEMINI_SECRET)], built
+        assert seller_key not in str(built), built
+        assert [p.product_id for p in response.products] == ["prod-a"]
+        assert response.errors is None
+
+        # One warning per CONSUMER, not one per request: the policy gate and the ranking
+        # path each ask `TenantAIConfig.from_tenant` the same question, and this request
+        # takes both. Pinning 2 rather than "at least 1" is deliberate — a third copy
+        # would mean a fourth consumer appeared, or that one of them started re-resolving
+        # inside a loop.
+        ignored = [r for r in caplog.records if "malformed tenant ai_config" in r.getMessage()]
+        assert len(ignored) == 2, [r.getMessage() for r in caplog.records]
+        assert {r.levelno for r in ignored} == {logging.WARNING}
+        assert {r.name for r in ignored} == {"src.services.ai.config"}
+
+    @pytest.mark.asyncio
+    async def test_provider_without_a_matching_credential_builds_nothing_and_advises(self, monkeypatch, caplog):
+        """No credential for the resolved provider means AI is off — the Google key is not a substitute.
+
+        The deployment names Anthropic (``PYDANTIC_AI_PROVIDER`` / ``PYDANTIC_AI_MODEL``),
+        only the operator's ``GEMINI_API_KEY`` is present, and the seller's own row is the
+        keyless Admin-UI shape. The platform's key is whatever
+        ``_get_provider_api_key(PYDANTIC_AI_PROVIDER)`` finds, so there is no Anthropic
+        credential anywhere — and a Google key lying around must not stand in for one.
+        "There is a key somewhere" is precisely the reasoning that green-lit a request
+        which could only run by borrowing another vendor's secret.
+
+        Correct: nothing coherent resolves, so nothing is built at all — ``built == []``
+        is the strongest available statement that no secret crossed vendors — the catalog
+        comes back unranked, and the buyer is TOLD it is unranked instead of being handed a
+        plausible-looking list in catalog order.
+
+        SCOPE. This is the products-path reachable half. The other half of the
+        provider-blind fallback — a tenant config that names a foreign provider reaching
+        the factory WITHOUT a key — cannot occur here any more, because
+        ``TenantAIConfig.from_tenant`` now returns either a config with the tenant's own
+        key or None. It is graded at the seam it can still reach, by
+        ``tests/unit/test_ai_service_factory.py`` (``test_platform_key_is_never_lent_to_another_vendor``
+        and ``test_ai_is_disabled_when_the_platform_key_belongs_to_another_vendor``);
+        restating it here would be a second copy that grades nothing new.
+        """
+        with _platform_ai_environment(monkeypatch, provider="anthropic", model="claude-sonnet-4-20250514") as (
+            factory,
+            built,
+        ):
+            with ProductEnv(
+                product_ranking_prompt="rank by relevance",
+                ai_config={"provider": "anthropic", "model": "claude-sonnet-4-20250514"},
+                advertising_policy={"enabled": True},
+            ) as env:
+                env.add_product(product_id="prod-a")
+                env.add_product(product_id="prod-b")
+                env.mock["ranking_factory"].return_value = factory
+                policy_cls = env.mock["policy_service"]
+
+                with (
+                    patch("src.services.ai.agents.ranking_agent.create_ranking_agent") as make_agent,
+                    # Patched even though the point is that it is never reached: leaving
+                    # the real coroutine in place means a regression that re-enables AI
+                    # here reaches a live provider from a unit test instead of failing an
+                    # assertion.
+                    patch(
+                        "src.services.ai.agents.ranking_agent.rank_products_async",
+                        new_callable=AsyncMock,
+                    ) as rank,
+                    caplog.at_level(logging.WARNING, logger="src.core.tools.products"),
+                ):
+                    response = await env.call_impl(brief="video inventory")
+
+        policy_cls.assert_not_called()
+        assert built == [], built
+        make_agent.assert_not_called()
+        rank.assert_not_awaited()
+        assert [p.product_id for p in response.products] == ["prod-a", "prod-b"]
+
+        assert response.errors is not None and len(response.errors) == 1
+        advisory = response.errors[0]
+        assert advisory.code == "CONFIGURATION_ERROR"
+        assert advisory.recovery == "terminal"
+        assert advisory.severity == "warning"
+        assert advisory.field == "products[]"
+        assert "PRODUCT_RANKING_UNAVAILABLE" in advisory.message
+
+        _assert_one_products_warning(caplog, "no usable AI configuration")
+
+        # Legal on the wire, not merely constructible: a COMPLETED response carrying a
+        # non-fatal advisory.
+        from tests.helpers.pinned_schema import validate_against_pinned_schema
+
+        validate_against_pinned_schema(
+            "media-buy/get-products-response.json", response.model_dump(mode="json", exclude_none=True)
+        )
+
+
+class TestRankingFailureAdvisories:
+    """EVERY unranked return says so on errors[], and says the right thing about retrying.
+
+    The misconfiguration path had an advisory; the two runtime paths did not. A provider
+    401/429/5xx, a timeout, a malformed model response — pydantic-ai raises
+    ``ModelHTTPError`` / ``UnexpectedModelBehavior`` / ``UsageLimitExceeded`` /
+    ``UserError``, ALL of which subclass ``RuntimeError`` — was caught in
+    ``_get_products_impl``, logged, and dropped through with ``advisories`` empty, so the
+    response went out with ``errors=None``: a plausible-looking catalog-order list and no
+    way for the buyer to tell it was never ranked, on the paths most likely to happen in
+    production.
+
+    The CODE has to differ from the misconfiguration advisory's. CONFIGURATION_ERROR
+    carries recovery ``terminal`` — the pinned enumMetadata spells it "the buyer cannot
+    resolve a seller-side deployment misconfiguration and MUST NOT auto-retry" — which is
+    the wrong instruction for a rate limit or a 503.
+    """
+
+    @staticmethod
+    async def _run_with_failing_rank(exc: Exception):
+        """One product, ranking configured and enabled, ``rank_products_async`` raising.
+
+        The factory is an autospec of the real ``AIServiceFactory`` reporting AI enabled,
+        so the impl reaches the ranking call — the point of the test is what happens
+        AFTER production decides ranking should run. Awaited INSIDE the ``with``: the env
+        stops its patches on exit, and a coroutine returned out of the block would run
+        against the real database.
+        """
+        from src.services.ai.factory import AIServiceFactory
+
+        factory = create_autospec(AIServiceFactory, instance=True)
+        factory.is_ai_enabled.return_value = True
+        factory.create_model.return_value = object()
+
+        with ProductEnv(product_ranking_prompt="rank by relevance", ai_config=_TENANT_AI_CONFIG) as env:
+            env.add_product(product_id="prod-a")
+            env.add_product(product_id="prod-b")
+            env.mock["ranking_factory"].return_value = factory
+
+            with (
+                patch("src.services.ai.agents.ranking_agent.create_ranking_agent"),
+                patch(
+                    "src.services.ai.agents.ranking_agent.rank_products_async",
+                    new_callable=AsyncMock,
+                    side_effect=exc,
+                ),
+            ):
+                return await env.call_impl(brief="video inventory")
+
+    @pytest.mark.asyncio
+    async def test_failed_ranking_call_reports_one_transient_advisory(self):
+        """A provider failure returns the catalog unranked AND says so, retriably."""
+        response = await self._run_with_failing_rank(RuntimeError("429 Too Many Requests"))
+
+        assert [p.product_id for p in response.products] == ["prod-a", "prod-b"]
+        assert response.errors is not None and len(response.errors) == 1
+        advisory = response.errors[0]
+        assert advisory.code == "SERVICE_UNAVAILABLE"
+        assert advisory.recovery == "transient"
+        assert advisory.severity == "warning"
+        assert advisory.field == "products[]"
+        assert "PRODUCT_RANKING_UNAVAILABLE" in advisory.message
+
+        # Legal on the wire, not merely constructible: it rides in a COMPLETED response.
+        from tests.helpers.pinned_schema import validate_against_pinned_schema
+
+        validate_against_pinned_schema(
+            "media-buy/get-products-response.json", response.model_dump(mode="json", exclude_none=True)
+        )
+
+    @pytest.mark.asyncio
+    async def test_advisory_never_puts_the_provider_exception_text_on_the_wire(self, caplog):
+        """``get_products`` is auth-OPTIONAL discovery, so this message reaches anonymous buyers.
+
+        A provider exception's text routinely carries the request URL, the response body
+        and key fragments; the pinned enumDescription for CONFIGURATION_ERROR is explicit
+        that sellers "MUST NOT include credentials, connection strings, or stack traces —
+        the message is wire-visible to the buyer". The class NAME is what classifies; the
+        full text belongs in the seller's log.
+
+        BOTH halves of that split are graded here, because either one alone is satisfied
+        by a change that breaks the other: dropping the log entirely keeps the secret off
+        the wire, and logging at DEBUG hides from the operator the only record of why
+        ranking stopped. So the exception text must be ABSENT from the buyer's advisory
+        and PRESENT in a WARNING on ``src.core.tools.products``.
+        """
+
+        class ModelHTTPError(RuntimeError):
+            """Stands in for pydantic_ai.exceptions.ModelHTTPError (also a RuntimeError)."""
+
+        secret = "AIzaSy-PLATFORM-SECRET-do-not-echo"
+        with caplog.at_level(logging.WARNING, logger="src.core.tools.products"):
+            response = await self._run_with_failing_rank(ModelHTTPError(f"401 from https://x?key={secret}"))
+
+        message = response.errors[0].message
+        assert secret not in message, message
+        assert "401" not in message, message
+        # The class name survives, so the seller can still classify from the wire alone.
+        assert "ModelHTTPError" in message, message
+
+        _assert_one_products_warning(caplog, secret)
+
+    @pytest.mark.asyncio
+    async def test_unbuildable_model_reports_a_terminal_advisory_not_a_failed_request(self):
+        """``create_model`` refusing a config degrades ranking; it does not 500 discovery.
+
+        ``is_ai_enabled`` can report a coherent provider/model/key and ``create_model``
+        can still refuse the combination — a provider with no explicit-API-key
+        integration, where handing pydantic-ai the string form would authenticate with
+        whatever else is in the environment. ``AdCPConfigurationError`` extends
+        ``Exception``, not ``RuntimeError``, so nothing caught it: an anonymous buyer's
+        discovery call failed outright because the SELLER had misconfigured a provider.
+        Same fault as "nothing usable resolved", so the same code and the same advice.
+        """
+        from src.core.exceptions import AdCPConfigurationError
+        from src.services.ai.factory import AIServiceFactory
+
+        factory = create_autospec(AIServiceFactory, instance=True)
+        factory.is_ai_enabled.return_value = True
+        factory.create_model.side_effect = AdCPConfigurationError("provider 'gateway/x' has no explicit-key branch")
+
+        with ProductEnv(product_ranking_prompt="rank by relevance", ai_config=_TENANT_AI_CONFIG) as env:
+            env.add_product(product_id="prod-a")
+            env.mock["ranking_factory"].return_value = factory
+            response = await env.call_impl(brief="video inventory")
+
+        assert [p.product_id for p in response.products] == ["prod-a"]
+        assert response.errors is not None and len(response.errors) == 1
+        advisory = response.errors[0]
+        assert advisory.code == "CONFIGURATION_ERROR"
+        assert advisory.recovery == "terminal"
+        assert advisory.severity == "warning"
+        assert "AdCPConfigurationError" in advisory.message
+
+    def test_every_advisory_code_carries_the_recovery_the_pin_publishes(self):
+        """The wire ``recovery`` must equal the pinned ``enumMetadata`` for its code.
+
+        ``recovery`` is stated on the wire because pinned ``core/error.json`` makes the
+        code vocabulary OPEN — a client that cannot look a code up reads ``recovery``
+        instead — which only helps if what we state is what the enum says. Graded against
+        the installed SDK's own schema tree, not a literal copied into this file, so a
+        spec bump that reclassifies a code fails here instead of shipping stale advice.
+        """
+        from src.core.tools.products import _ADVISORY_RECOVERY, _unranked_products_advisory
+        from tests.helpers.pinned_schema import recovery_by_code
+
+        pinned = recovery_by_code()
+        assert set(_ADVISORY_RECOVERY) <= set(pinned), "advisory code absent from the pinned enum"
+        for code, recovery in _ADVISORY_RECOVERY.items():
+            assert recovery == pinned[code], f"{code}: emit {recovery!r}, pin says {pinned[code]!r}"
+            # And the builder actually uses the table rather than a literal of its own.
+            assert _unranked_products_advisory("t", code=code, cause="x").recovery == pinned[code]
 
 
 class TestAdapterPricingAnnotation:

--- a/tests/unit/test_naming_parameter_bug.py
+++ b/tests/unit/test_naming_parameter_bug.py
@@ -11,26 +11,48 @@ Related fixes:
 """
 
 from datetime import datetime
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from src.core.utils.naming import apply_naming_template, build_order_name_context
 
 
+@pytest.fixture(autouse=True)
+def _no_platform_ai_key(monkeypatch):
+    """Keep these tests offline.
+
+    tests/conftest.py sets GEMINI_API_KEY for every test, and is_ai_enabled() returns
+    True on the platform key alone, so any build_order_name_context() call here reached
+    the real naming agent and opened a socket to generativelanguage.googleapis.com.
+    None of these tests is about the agent - they grade parameter handling and template
+    substitution - so the platform credential is removed and generate_auto_name takes
+    its documented fallback branch.
+    """
+    for var in ("GEMINI_API_KEY", "GOOGLE_API_KEY", "PYDANTIC_AI_PROVIDER", "PYDANTIC_AI_MODEL"):
+        monkeypatch.delenv(var, raising=False)
+
+
 class TestBuildOrderNameContextParameters:
     """Tests for build_order_name_context parameter handling."""
 
     def test_positional_string_arg_causes_error(self):
-        """Passing a string as 5th positional arg causes AttributeError.
+        """Passing a string as 5th positional arg raises.
 
         The function signature is:
             build_order_name_context(request, packages, start, end, tenant_ai_config=None, tenant_gemini_key=None)
 
-        Passing a string as 5th positional arg makes it tenant_ai_config,
-        which then fails when .api_key is accessed.
+        Passing a string as 5th positional arg makes it tenant_ai_config, which is a
+        caller mistake and must be reported as one. This test documents why callers
+        MUST use keyword arguments.
 
-        This test documents why callers MUST use keyword arguments.
+        RESTORED assertion. It had been rewritten to expect "one WARNING" instead,
+        which pinned a caller bug as an acceptable degradation: the naming call then
+        ran on somebody else's AI configuration and returned a plausible name. The
+        exception TYPE moved — TenantAIConfig.coerce now raises TypeError at the parse
+        boundary, naming the parameter and the offending type, instead of the old
+        AttributeError thrown when the factory reached for `.api_key` several frames
+        deeper — but "a caller mistake raises" is the contract, and it is back.
         """
         request = MagicMock()
         request.brand = MagicMock(domain="testbrand.com")
@@ -43,8 +65,11 @@ class TestBuildOrderNameContextParameters:
         gemini_key = "AIzaSy..."  # A string API key
 
         # This fails because the string is treated as tenant_ai_config
-        with pytest.raises(AttributeError, match="api_key"):
+        with pytest.raises(TypeError) as excinfo:
             build_order_name_context(request, packages, start_time, end_time, gemini_key)  # Wrong!
+
+        assert "str" in str(excinfo.value)
+        assert "ai_config" in str(excinfo.value)
 
     def test_keyword_arg_works_correctly(self):
         """Passing gemini_key as keyword argument works correctly."""
@@ -58,17 +83,25 @@ class TestBuildOrderNameContextParameters:
         end_time = datetime(2025, 1, 31)
         gemini_key = "AIzaSy..."
 
-        # Correct usage - using keyword argument
-        context = build_order_name_context(
-            request,
-            packages,
-            start_time,
-            end_time,
-            tenant_gemini_key=gemini_key,  # Correct!
-        )
+        # Patched so the assertion below can grade WHERE the key landed without the
+        # naming agent making a real call to the provider on a fake key - this test
+        # used to open a live socket to generativelanguage.googleapis.com.
+        with patch("src.core.utils.naming.generate_auto_name") as auto_name:
+            auto_name.return_value = "Testbrand Campaign"
+            # Correct usage - using keyword argument
+            context = build_order_name_context(
+                request,
+                packages,
+                start_time,
+                end_time,
+                tenant_gemini_key=gemini_key,  # Correct!
+            )
 
         assert "brand_name" in context
         assert "date_range" in context
+        # The point of the test: the key reaches the 6th parameter, not the 5th.
+        assert auto_name.call_args.kwargs["tenant_gemini_key"] == gemini_key
+        assert auto_name.call_args.kwargs["tenant_ai_config"] is None
 
 
 class TestMediaBuyIdInContext:


### PR DESCRIPTION
A seller who configures AI in the Admin UI gets no AI product ranking. Products come back
in catalog order, the response says nothing about it, and the only trace is a `debug` log
line. The symptom a publisher reports is "the ranking prompt has no effect".

`_get_products_impl` called the AI factory with no arguments, so `is_ai_enabled()` and
`create_model()` saw only the platform-level environment key (`GEMINI_API_KEY` and
friends, via `get_platform_defaults()`). The Admin UI writes to `tenants.ai_config`. The
two never met. `ai_config` was also absent from both tenant projections
(`TenantContext`, `serialize_tenant_to_dict`), so the value could not have reached the
call even if it were passed on.

The first version of this PR passed `tenant.get("ai_config")` into the two factory calls.
Review found that this wrote the resolution rule a fourth time, converted one of the two
AI consumers in the function it edited, and left the silent-skip half of the problem
untouched. The change below is the rework.

## The fix

`TenantAIConfig` gains the two class methods that own the rule, in the module that owns
the model (`src/services/ai/config.py`):

- **`coerce(value, *, source=...)`** — the one parse of a stored AI configuration value.
  The factory's three parse sites and `naming.py` route through it.
- **`from_tenant(tenant)`** — answers "given a tenant, what is its AI configuration?"
  once. Accepts the ORM row, `TenantContext`/`LazyTenantContext`, and the plain tenant
  dict; the field names are identical across all three and only the access mechanism
  differs, which is what `_read_tenant_field` handles.

Resolution order is `ai_config` carrying a non-empty `api_key`, then the legacy
`gemini_api_key` column, then `None`. Both consumers in `_get_products_impl` — ranking
and the policy check — go through it, as do `naming.py` and both AI-availability sites in
`admin/blueprints/creatives.py`.

Usability, not truthiness, is the contract. `admin/blueprints/settings.py:558-561` writes
`{"provider": ..., "model": ...}` with no `api_key` when the seller leaves the key field
blank, and flashes "AI features will be disabled" as it does. Returning that row as a real
configuration opened the policy gate for those tenants and ran `check_brief_compliance` on
the *operator's* platform credential — a live LLM call, and a BLOCKED verdict there raises
`AdCPPolicyViolationError`, a buyer-visible rejection the seller never asked for.

Two further defects were found while reworking and are fixed at the same seam:

- **The platform-key fallback was provider-blind.** `create_model` resolved provider and
  api_key from independent expressions, so a tenant configured for `anthropic` with no key
  of its own got an `AnthropicModel` holding the platform's *Google* credential — the
  operator's Gemini key sent to `api.anthropic.com`. `get_products` is auth-optional
  discovery, so an anonymous brief reaches it. The platform provider, model and key now
  travel together: they fill in only when the resolved provider is the same vendor
  (`factory.py:130-136`).
- **The legacy key was paired with the platform's model.** With `PYDANTIC_AI_MODEL` set to
  an Anthropic model, a tenant on the legacy `gemini_api_key` column got a `GoogleModel`
  named `claude-sonnet-4-…`, and every call 404'd. `from_tenant` pins
  `DEFAULT_GOOGLE_MODEL` with the provider — the same pin `policy_check_service.py:67`
  hard-codes at its own call site.

## Findings

### 1. The policy consumer in the same function still read `gemini_api_key`

Fixed. Both consumers resolve through `TenantAIConfig.from_tenant`, the deprecated
`gemini_api_key=` kwarg is gone from the `PolicyCheckService` call, and the disabled
reason is provider-neutral.

The gate itself needed more than a substitution. `from_tenant(...) is not None` is the
policy gate; `factory.is_ai_enabled(...)` is the ranking gate. They are deliberately
different questions: ranking may fall back to a deployment-wide platform key (existing,
relied-upon behaviour — a `GEMINI_API_KEY` ranks for every tenant with a ranking prompt),
while policy screening on the operator's credential for a tenant the UI called disabled is
the defect described above.

### 2. Nothing owned tenant-to-`TenantAIConfig` resolution

Fixed as described under **The fix**. The four divergent copies the review tabulated are
now one call each. The absent-test divergence is resolved in favour of falsiness, so an
empty `ai_config` dict falls through to the legacy column instead of shadowing it;
`naming.py` was the lone `is None` site.

Not adopted: typing `TenantContext.ai_config` as `TenantAIConfig | None` and coercing at
the ORM boundary. `from_tenant` reads the tenant in whichever shape it arrives, so the
projections stay as they are and the two two-line plumbing hunks remain (they are what
carry the column into the dict `_get_products_impl` receives). Retyping the column model
is a separate change with its own migration and admin-write surface.

### 3. A malformed `ai_config` row aborted the call — but not with a 500

Fixed, and **the reviewer's diagnosis of the symptom was wrong**. `pydantic.ValidationError`
subclasses `ValueError`, and `normalize_to_adcp_error` (`src/core/exceptions.py:1360`)
maps every `ValueError` to `AdCPValidationError` at all three transport boundaries. So the
buyer did not get a 500. Reproduced against the tree:

```
$ uv run python -c "...TenantAIConfig.model_validate({'settings':{'temperature':9}})..."
raised     : ValidationError | isinstance ValueError: True
normalized : AdCPValidationError
error_code : VALIDATION_ERROR
recovery   : correctable
field      : settings.temperature
status_code: 400
```

That is worse than a 500 for the buyer, not better: a 400 with `recovery: "correctable"`
tells an autonomous agent to fix its request and resend, and names `settings.temperature`
— a field that does not exist in the `get_products` request schema (verified against the
pinned `get-products-request.json`, whose 18 top-level properties contain no `settings`).
The buyer is told to correct something it never sent and cannot reach.

`coerce` fixes this at the parse boundary rather than by widening a caught tuple, because
two failure modes arrive there and they need opposite answers:

- **Malformed stored data** (a dict or list from the JSONB column that fails the model) —
  the seller's row is broken, the buyer's request is not. Degrades to a bare
  `TenantAIConfig()` with one WARNING, and `from_tenant` then declines to return it, so it
  falls through to the legacy column and then to `None`. It is never returned as if it
  were the tenant's configuration. Returning it let the factory fill in the *platform's*
  provider and key, so a seller who deliberately chose Anthropic had the buyer's brief and
  product catalog sent to Google.
- **A caller passing the wrong Python type** (a `str`, an `int`) — `json_type.py` raises
  `TypeError` for anything that is not a dict or list, so these shapes cannot come from
  the column. They come from a caller passing the wrong argument. That raises `TypeError`
  naming the parameter and the offending type.

This is also why `tests/unit/test_naming_parameter_bug.py`'s assertion is **restored**. It
had been rewritten from `pytest.raises(AttributeError)` to expect "one WARNING", which
pinned a caller bug as an acceptable degradation — the naming call then ran on somebody
else's AI configuration and returned a plausible name. The exception type moved
(`TypeError` at the parse boundary rather than `AttributeError` several frames deeper),
but "a caller mistake raises" is the contract and it is back.

### 4. The tests did not reach the changed behaviour

Fixed, and re-verified by mutation rather than by inspection.

A new local feature, `tests/bdd/features/BR-UC-001-ai-ranking-tenant-config.feature`,
grades BR-RULE-005 across all four transports. Both scenarios remove the platform key in
their Given step (`tests/conftest.py` sets it suite-wide, and `is_ai_enabled` returns true
on that key alone), so the tenant's own configuration is the only AI configuration in
play and neither outcome is reachable without reading it. Wiring:

- `UC-001` gains an `ENV_ROUTES` row (`tests/bdd/conftest.py:3829`) over the existing
  `ProductEnv`. It had a harness all along; no row claimed the bucket, so a `@T-UC-001-*`
  scenario xfailed as "No harness wired for UC-001". `EXPECTED_WIRED_ROUTES` in
  `test_architecture_measurement_floors.py` moves 25 → 26 to match.
- The two `ProductEnv` setup methods that cannot be realized over e2e are declared in
  `EXPECTED_UNSUPPORTED_DECLARATIONS` with their reasons at the env methods, not as a
  nodeid ledger entry or an xfail tag: the platform `GEMINI_API_KEY` lives in the live
  server's own process environment (and is cached there by `get_factory`'s `lru_cache`),
  and scripted relevance scores have no live-server injection surface.

The ranking call's two free-text arguments are now graded. `rank_products_async` takes the
seller's ranking prompt as `custom_prompt` and the buyer's brief as `brief`; the prompt
builder concatenates both, so swapping them changes only the wording sent to the model and
no wire assertion can see it. Mutation-verified before the fix: with the two exchanged in
production, the BDD scenarios and the whole of `test_get_products_impl_coverage.py` stayed
green. The harness stub now checks which text arrived as which argument, and the unit test
asserts `rank.assert_awaited_once_with(...)` rather than `await_count == 1`.

`tests/integration/test_tenant_utils.py` gains the `ai_config` leg, so the two projection
hunks fail on revert.

### 5. The silent skip, and the `errors[]` advisory

Fixed. This is the buyer-visible part of the change: `GetProductsResponse.errors[]` is now
populated where it was hard-coded to `None`.

The ranking block moved out of `_get_products_impl` into `_rank_products_with_ai`, which
appends exactly one advisory on every path where ranking was configured and did not
happen. Owning the failure paths inside that function, rather than in a `try` at the call
site, is what makes "every" true: the old handler logged a warning and dropped through
with advisories untouched, so a provider 401/429/5xx returned a plausible-looking
catalog-order list with `errors=None`.

Two codes, because the two conditions need opposite advice:

- **`CONFIGURATION_ERROR`** (`recovery: terminal`) when nothing usable resolved, or when
  `create_model` refuses the seller's configuration. No retry at any backoff supplies a
  missing API key.
- **`SERVICE_UNAVAILABLE`** (`recovery: transient`) when the ranking call did not
  complete. pydantic-ai's `ModelHTTPError`, `UnexpectedModelBehavior`,
  `UsageLimitExceeded` and `UserError` all subclass `RuntimeError`, so every provider auth
  failure, 429, timeout and malformed response lands here.

`recovery` is derived from the code by `_ADVISORY_RECOVERY` rather than passed alongside
it: a call site free to pair them is a call site free to tell a buyer to retry a missing
API key. The `cause` clause never interpolates `str(exc)` — the message is wire-visible to
an anonymous buyer, and provider exception text carries request URLs, response bodies and
key fragments. The exception class name is enough to classify; the full text goes to the
seller's log.

**Where this departs from the review.** The review said "Do not use `CONFIGURATION_ERROR`:
in 3.1.1 it is `terminal` and sellers MUST flip transport failure markers, which is the
wrong shape for a response that still returns products." The wire-placement clause in the
pinned `enums/error-code.json` reads in full: "**Wire placement.** The deployment cannot
produce a success artifact, so sellers MUST flip transport-level failure markers (HTTP
5xx, MCP `isError: true`, A2A `failed`)…". Its antecedent does not hold here — the
deployment *can* produce a success artifact, and does: the catalog comes back. The
in-repo precedent is already merged and does exactly this:
`src/core/tools/media_buy_list.py:566-591` emits `CONFIGURATION_ERROR` with
`recovery: "terminal"` on `GetMediaBuysResponse.errors[]` of a completed, data-bearing
response. The review's underlying point is taken where it applies: the transient
condition, which is the one that actually happens in production, gets
`SERVICE_UNAVAILABLE`, and the two conditions are split rather than sharing one code.

A platform-specific code was considered and rejected. `core/error.json` does declare the
vocabulary open ("senders MAY emit codes outside that set"), so `PRODUCT_RANKING_UNAVAILABLE`
would be spec-legal. This repo is deliberately stricter: `verify_feature_error_codes.py`
states the policy — "the AdCP spec accepts arbitrary code strings, but our scenarios are
derived from the pinned spec and must stay on the standard vocabulary" — and
`tests/unit/test_architecture_error_code_compliance.py` enforces it by AST-scanning
`Error(code=...)` sites in `src/core/tools/`, which is where this advisory is built. No
canonical code expresses "an optional enhancement was unavailable, seller-side, on an
otherwise successful response"; `UNSUPPORTED_FEATURE` is `correctable`, which tells the
buyer to fix something only the seller can. `CONFIGURATION_ERROR` carries the correct
recovery classification, and recovery is what the spec tells receivers to act on. The
vocabulary gap is worth raising upstream; inventing a local code to paper over it is not
this PR's call to make.

**A2A reported `success=false` for every advisory-carrying response.**
`_stamp_a2a_protocol_fields` derived `success = not bool(errors)`, and
`_handle_get_products_skill` (`adcp_a2a_server.py:1673`) runs every `get_products`
response through it at line 1704. Before this
change `errors` was always `None`, so `success` was always `True`; with the advisory, a
tenant would report `success=false` on every `get_products` call. Pinned
`core/protocol-envelope.json` separates the two questions, so `_response_failed` now keys
on the `severity` marker rather than on emptiness. An entry marked `severity: "warning"`
is by the schema's own definition not a failure; anything else — including every fatal
`errors[]` this codebase emits, none of which carries the marker — still reports
`success=False`. The predicate is deliberately not keyed on the tool or the code, so
`get_media_buys`' `_omitted_row_advisory` and the `property_list_unsupported_advisories`
on `create_media_buy`/`update_media_buy` become one-keyword fixes rather than a per-tool
branch here.

The `score < 0.1` exclusion is deliberately **not** reported on `errors[]`: the pinned
schema assigns score-threshold reporting to `filter_diagnostics` and calls it
observability.

## Spec grounding for the `errors[]` advisory

Pinned version: `adcp==6.6.0`, targeting AdCP spec **3.1.1** (`pyproject.toml:10`;
`docs/adcp-spec-version.md`). All quotes verified against
`.venv/lib/python3.12/site-packages/adcp/_schemas/3.1/`.

**The channel exists on this response.** `media-buy/get-products-response.json`
declares `errors` among its 17 top-level properties, described as "Task-specific errors
and warnings (e.g., product filtering issues)", `$ref`-ing `core/error.json`. The
response has no top-level `required` array, so `errors[]` is optional and a completed
response may carry it.

**Non-fatal warnings ride the payload, never the envelope.**
`core/protocol-envelope.json`, on `properties.adcp_error`: "a fatal task failure SHOULD
populate both this envelope-level field AND the payload's `errors[]` array … Non-fatal
warnings populate ONLY `payload.errors[]` with `severity: warning` — the envelope MUST NOT
carry `adcp_error` for non-failures." The envelope's own examples carry the contrast:
`examples[2].data.payload.errors[0].severity` is `"warning"`.

**`severity` is not a declared field of `core/error.json`.** Stated plainly because it
matters: the error item declares `code`, `message`, `field`, `suggestion`, `retry_after`,
`issues`, `details`, `recovery`, `source`, `sdk_id`, with `required: ["code", "message"]`
and `additionalProperties: true`. `severity` is admitted by `additionalProperties`, named
by the envelope schema as the marker for a non-fatal payload error, and carried by that
schema's own examples in exactly this position. That is the whole basis for emitting it.

**The code vocabulary is open.** `core/error.json`, on `code`: "The error-code vocabulary
is open: `error.code` is wire-typed `string` (not a closed enum), the standard codes
published in `enums/error-code.json` are documentary, and senders MAY emit codes outside
that set… Receivers MUST decode unknown codes — treat the response as well-formed, read
`error.recovery` for the recovery classification, and fall back to `transient` when
`recovery` is absent." This is why `recovery` is stated on the wire rather than left to be
inferred from the enum.

**`enumMetadata` for the two codes used** (`enums/error-code.json`):

| Code | `recovery` | `suggestion` |
|---|---|---|
| `CONFIGURATION_ERROR` | `terminal` | surface to a human at the seller — the buyer cannot resolve a seller-side deployment misconfiguration and MUST NOT auto-retry |
| `SERVICE_UNAVAILABLE` | `transient` | retry with exponential backoff |

The `CONFIGURATION_ERROR` `enumDescription` also carries the message-content rule the
advisory follows: sellers "MUST NOT include credentials, connection strings, or stack
traces — the message is wire-visible to the buyer".

**Storyboard clause: ungraded.** No conformance phase grades this. Evidence:
`docs/test-obligations/storyboard-wireability.yaml` enumerates every storyboard step;
16 of them call `get_products`, and every graded check on those steps is
`response_schema` or `field_present` on `products[…]`. `path: errors…` appears in no step
in either obligation map, and the strings `ranking`, `relevance` and `unranked` appear
zero times across both files. The behaviour is graded here instead, by the BDD scenarios
in finding 4.

## What is deliberately not in this PR

Each of these is a real site with the same root cause, outside the boundary of this diff:

- **Three adapter call sites still read `tenant.gemini_api_key` directly** (#2223) and pass it as
  a bare string into the naming path: `src/adapters/google_ad_manager.py:645`,
  `src/adapters/mock_ad_server.py:817`, `src/adapters/gam/managers/workflow.py:167`. They
  work — `coerce` accepts the legacy path — but they ask the question themselves instead
  of calling `from_tenant`, so a tenant on `ai_config` alone gets platform naming.
- **`src/services/setup_checklist_service.py:730` and `:1116`** (#2224) both compute
  `gemini_configured = bool(tenant.gemini_api_key)`, so the setup checklist reports "AI not
  configured" for a tenant configured through `ai_config`. Same shape as the
  `creatives.py` inconsistency fixed here, in a service this diff does not otherwise touch.
- **`src/services/policy_check_service.py:63-70`** (#2225) keeps its own hand-rolled
  `TenantAIConfig(provider="gemini", model="gemini-2.0-flash", api_key=...)` construction
  behind the deprecated `gemini_api_key=` kwarg. `products.py` no longer takes that path,
  but the shim is still reachable from other callers and duplicates what `from_tenant`
  now owns. Removing it means auditing the remaining callers of the deprecated kwarg.
- **Three existing advisories do not carry `severity: "warning"`**, so they keep reporting
  `success=false` over A2A: `src/core/tools/media_buy_list.py:582` and the two attached by
  `src/services/targeting_capabilities.py:255`. This is their pre-existing behaviour, not a
  regression from this change — `_response_failed` only moves the marker for entries that
  explicitly declare themselves advisory, precisely so that "is this non-fatal?" stays a
  per-advisory ruling rather than something inferred from the code or the tool. Each needs
  one keyword and its own decision.
- **`ai_config["api_key"]` is stored in plaintext.** (#2226) `src/core/database/models.py:98,102`
  comments the column as carrying `api_key (encrypted)`; `src/admin/blueprints/settings.py`
  writes it in clear text and nothing decrypts on read. This diff neither reads nor writes
  an encryption path. Flagged in the original description and repeated here because it is
  still true: the comment and the write disagree, and one of them has to move.

## CI

The Quality Gate failure on this PR was **branch staleness, not a defect in the change**.
`check_ruff_complexity_count.py::check_baseline_not_raised` compares the local
`.ruff-complexity-baseline` against `origin/main`'s and fails when any key is higher —
"The ruff complexity baseline may only shrink." The PR head (`f78a60cc`) branched from
`1d93e372` and does not contain `f9e82da6`, which lowered the baseline:

```
$ git show refs/pull/2167/head:.ruff-complexity-baseline
{ "C901": 182, "PLR0912": 133, "PLR0915": 107 }
$ git show origin/main:.ruff-complexity-baseline
{ "C901": 177, "PLR0912": 130, "PLR0915": 102 }
$ git merge-base --is-ancestor f9e82da6 refs/pull/2167/head; echo $?
1
```

All three keys higher than main, all three failing the raise guard. Fixed by rebasing onto
`main`; the hook is clean on the rebased tree (`C901: 177 (unchanged)`, `PLR0912: 130
(unchanged)`, `PLR0915: 102 (unchanged)`).

`.duplication-baseline` `tests` drops 71 → 69: two duplicate test blocks were collapsed
while reworking, and the ratchet auto-lowers.

## Changes

| File | Change |
|---|---|
| `src/services/ai/config.py` | `TenantAIConfig.coerce` / `.from_tenant`, `_read_tenant_field`, `DEFAULT_GOOGLE_MODEL` paired with the provider |
| `src/services/ai/factory.py` | Three parse sites route through `coerce`; platform provider/model/key fill in only for the same vendor |
| `src/core/tools/products.py` | Ranking extracted to `_rank_products_with_ai`; advisory builder; both AI consumers resolve through `from_tenant` |
| `src/a2a_server/adcp_a2a_server.py` | `_response_failed` keys the `success` marker on `severity`, not on `errors[]` emptiness |
| `src/admin/blueprints/creatives.py` | `_tenant_ai_enabled` helper; the availability flag and the review impl now agree |
| `src/core/utils/naming.py` | Routes through `coerce`; drops its own `is None` absent-test |
| `src/core/tenant_context.py`, `src/core/utils/tenant_utils.py` | Carry `ai_config` in both tenant projections |

Tests: a new four-transport BDD feature for BR-RULE-005 plus its steps and binder, a new
unit module for the admin AI-review availability flag, the `ai_config` leg in
`test_tenant_utils.py`, the restored assertion in `test_naming_parameter_bug.py`, and the
two structural-guard ledgers (`EXPECTED_WIRED_ROUTES`,
`EXPECTED_UNSUPPORTED_DECLARATIONS`) updated in the same change.

## Verification

```
$ uv run pytest -q -p no:randomly tests/unit/test_get_products_impl_coverage.py \
    tests/unit/test_ai_service_factory.py tests/unit/test_naming_parameter_bug.py \
    tests/unit/test_ai_review.py tests/unit/test_admin_creative_ai_review_availability.py \
    tests/unit/test_a2a_success_field_consolidation.py \
    tests/unit/test_architecture_measurement_floors.py \
    tests/unit/test_architecture_e2e_rest_escape_hatches.py
158 passed, 7 skipped, 1 warning in 2.74s

$ uv run pytest -q -p no:randomly tests/bdd/test_uc001_ai_ranking_tenant_config.py \
    tests/integration/test_get_products_behavioral.py tests/integration/test_tenant_utils.py \
    tests/integration/test_a2a_response_compliance.py     # against PostgreSQL
69 passed, 59 warnings in 12.41s
```

Each behavioural decision above has a test that fails when the decision is reverted. The
ones worth naming, because they were silently green before: the ranking argument order
(finding 4), the both-set precedence branch of `from_tenant`, the provider-scoped platform
fallback, and the A2A `success` marker on an advisory-carrying response.
