### PR TITLE
fix: route A2A failures to the correct protocol layer (#2070)

### DIFF
--- a/.duplication-baseline
+++ b/.duplication-baseline
@@ -1,5 +1,5 @@
 {
   "src": 31,
-  "tests": 71,
+  "tests": 69,
   "scripts": 0
 }

--- a/src/a2a_server/adcp_a2a_server.py
+++ b/src/a2a_server/adcp_a2a_server.py
@@ -833,7 +833,7 @@ class AdCPRequestHandler(RequestHandler):
                     # All skills failed - mark task as failed
                     task.status.CopyFrom(TaskStatus(state=TaskState.TASK_STATE_FAILED))
 
-                    # Send protocol-level webhook notification for failure
+                    # Delivery is gated centrally in _send_protocol_webhook (inline terminal → skip).
                     error_messages = [
                         res["error_envelope"]["errors"][0]["message"] for res in results if not res["success"]
                     ]
@@ -1039,7 +1039,7 @@ class AdCPRequestHandler(RequestHandler):
             # Mark task with appropriate status
             task.status.CopyFrom(TaskStatus(state=task_state))
 
-            # Send protocol-level webhook notification if configured
+            # Delivery is gated centrally in _send_protocol_webhook (inline terminal → skip).
             await self._send_protocol_webhook(task, status=task_status_str)
 
         except A2AError:
@@ -1085,9 +1085,9 @@ class AdCPRequestHandler(RequestHandler):
                 )
             )
 
-            # Inline terminal failed Task: no webhook (webhooks.mdx:160 MUST NOT), and
-            # the accepted push config is dropped here — a terminal task returned
-            # synchronously has no future consumer for it.
+            # No webhook: an inline terminal failed Task is gated out centrally in
+            # _send_protocol_webhook. The accepted push config is dropped — a terminal
+            # task returned synchronously has no future consumer for it.
             self._task_push_configs.pop(task_id, None)
 
         self.tasks[task_id] = task

--- a/src/a2a_server/adcp_a2a_server.py
+++ b/src/a2a_server/adcp_a2a_server.py
@@ -221,23 +221,25 @@ DISCOVERY_SKILLS = frozenset(
 
 
 def _internal_error_for(operation: str, exc: Exception) -> InternalError:
-    """Canonical InternalError shape for non-skill A2A boundary failures.
+    """Canonical InternalError shape for non-Task A2A boundary failures.
 
     Skill handlers raise typed ``AdCPError`` (or untyped exceptions that the
     dispatcher normalizes), and ``_handle_explicit_skill`` → ``on_message_send``
-    surface those as a two-layer envelope on a failed Task's DataPart. Non-skill
-    paths (``on_message_send`` fallthrough, NL handlers) historically picked their
-    own prefixes (``"Message processing failed: "``, ``"Error in ..."``)
-    for semantically identical untyped failures — divergence on the buyer-
-    facing wire message for the same condition.
+    surface those as a two-layer envelope on a failed Task's DataPart —
+    including the top-level ``on_message_send`` fallthrough, which per AdCP
+    3.1.x transport rules (building/operating/transport-errors.mdx "Layer
+    Separation") RETURNS a failed Task carrying the envelope artifact rather
+    than raising this helper. JSON-RPC errors are reserved for genuine
+    transport faults (``A2AError``) and methods with no Task to carry the
+    envelope.
 
-    Use this helper at every non-skill ``InternalError(...)`` raise site that
-    is NOT a deliberate protocol-level convention (see push-notif handlers
-    below). The canonical prefix is ``"{operation} failed: {exc}"`` so
-    storyboard runners can parse the failure uniformly.
+    Use this helper only at ``InternalError(...)`` raise sites that have no
+    async Task to attach an envelope artifact to. The canonical prefix is
+    ``"{operation} failed: {exc}"`` so storyboard runners can parse the
+    failure uniformly.
 
     The four ``on_*_task_push_notification_config`` JSON-RPC protocol methods use
-    this helper too — they have no async Task to carry a DataPart, so the two-layer
+    this helper — they have no async Task to carry a DataPart, so the two-layer
     envelope rides in the error's ``data`` field (``error.data["errors"][0]["code"]``
     / ``error.data["adcp_error"]``). ``InternalError`` stays an ``A2AError`` so the
     SDK's ``JsonRpcDispatcher`` serializes it as a structured JSON-RPC error; raising
@@ -925,9 +927,10 @@ class AdCPRequestHandler(RequestHandler):
                 # ``_create_media_buy`` is an NL stub that always raises
                 # ``AdCPCapabilityNotSupportedError`` — the explicit-skill
                 # path is the spec contract for media buy creation. The
-                # outer error handler at on_message_send catches the raise
-                # and attaches a spec-compliant two-layer envelope to the
-                # failed Task artifact.
+                # outer error handler at on_message_send catches the raise,
+                # attaches a spec-compliant two-layer envelope to the failed
+                # Task artifact, and returns that failed Task (never a
+                # JSON-RPC error).
                 await self._create_media_buy(combined_text, identity)
             else:
                 # General help response
@@ -1022,12 +1025,14 @@ class AdCPRequestHandler(RequestHandler):
                 principal_id=err_principal_id,
             )
 
-            # Send protocol-level webhook notification for failure if configured
             task.status.CopyFrom(TaskStatus(state=TaskState.TASK_STATE_FAILED))
             # Attach error to task artifacts as a spec-compliant two-layer
             # envelope (same shape as failed-skill DataParts) so storyboard
             # runners can ``JSON.parse`` the artifact uniformly regardless of
-            # which failure path produced it.
+            # which failure path produced it. ``_build_error_envelope``
+            # normalizes untyped exceptions to base AdCPError (wire code
+            # SERVICE_UNAVAILABLE via ERROR_CODE_MAPPING) and passes
+            # through a typed AdCPError's own wire code.
             del task.artifacts[:]
             task.artifacts.append(
                 Artifact(
@@ -1037,10 +1042,17 @@ class AdCPRequestHandler(RequestHandler):
                 )
             )
 
+            # Send protocol-level webhook notification for failure if configured
             await self._send_protocol_webhook(task, status="failed")
 
-            # Raise A2A error instead of creating failed task
-            raise _internal_error_for("message processing", e)
+            # Per AdCP 3.1.x transport rules (spec prose:
+            # building/operating/transport-errors.mdx "Layer Separation" and the
+            # two-layer error-handling model), application/task-execution
+            # failures MUST be returned in the task response body as a failed
+            # Task carrying the envelope artifact. JSON-RPC errors are reserved
+            # for genuine transport faults (A2AError, re-raised above). So we
+            # fall through to the shared store-and-return below — never raise
+            # InternalError here.
 
         self.tasks[task_id] = task
         return task

--- a/src/a2a_server/adcp_a2a_server.py
+++ b/src/a2a_server/adcp_a2a_server.py
@@ -220,6 +220,19 @@ DISCOVERY_SKILLS = frozenset(
 )
 
 
+# Terminal A2A task states. `_send_protocol_webhook` notifies on the INITIAL synchronous
+# response only; an inline terminal response must not emit a webhook (pinned AdCP 3.1.1
+# webhooks.mdx:160 — the buyer already has the result).
+_TERMINAL_TASK_STATES = frozenset(
+    {
+        TaskState.TASK_STATE_COMPLETED,
+        TaskState.TASK_STATE_FAILED,
+        TaskState.TASK_STATE_CANCELED,
+        TaskState.TASK_STATE_REJECTED,
+    }
+)
+
+
 def _internal_error_for(operation: str, exc: Exception) -> InternalError:
     """Canonical InternalError shape for non-Task A2A boundary failures.
 
@@ -466,6 +479,14 @@ class AdCPRequestHandler(RequestHandler):
         ``notify`` selects the payload type from the status: Task for final states,
         TaskStatusUpdateEvent for intermediate ones.
         """
+        # This sender notifies on the INITIAL synchronous response only. Per pinned AdCP
+        # 3.1.1 webhooks.mdx:160, an inline terminal response MUST NOT emit a webhook — the
+        # buyer already has the result. No async completion-delivery path exists today; if
+        # one is added it MUST use a distinct entry point, because this guard would
+        # otherwise suppress its legitimate terminal completion webhook.
+        if task.status.state in _TERMINAL_TASK_STATES:
+            return
+
         try:
             # Check if task has push notification config stored
             webhook_config = self._task_push_configs.get(task.id)

--- a/src/a2a_server/adcp_a2a_server.py
+++ b/src/a2a_server/adcp_a2a_server.py
@@ -166,14 +166,14 @@ def _accept_a2a_push_config(url: str, scheme: str | None, credentials: str | Non
     tool path on either precondition.
 
     Why both surfaces must come through here rather than call the constructor
-    directly: ``on_message_send``'s body runs inside a ``try`` whose handlers are
-    ``except A2AError: raise`` / ``except Exception`` -> ``_internal_error_for``.
-    ``AdCPValidationError`` is not an ``A2AError``, so a raw constructor call
-    there would surface a buyer's correctable credential refusal as
-    ``INTERNAL_ERROR``. The translation below preserves the raised
-    ``AdCPValidationError`` verbatim (see
-    :func:`_invalid_params_from_ssrf_error`'s isinstance branch), which is what
-    keeps a credential refusal naming the credentials field instead of being
+    directly: a push-config refusal is a protocol-level precondition failure and
+    must surface as a JSON-RPC ``InvalidParamsError``. ``AdCPValidationError`` is
+    not an ``A2AError``, so a raw constructor call inside ``on_message_send``'s
+    ``try`` would fall to its typed-error branch and be returned as a task-level
+    ``VALIDATION_ERROR`` failed Task instead. The translation below re-raises the
+    refusal as ``InvalidParamsError`` (see
+    :func:`_invalid_params_from_ssrf_error`'s isinstance branch), keeping it on
+    the transport layer and naming the credentials field instead of being
     re-labelled as a URL problem.
     """
     try:
@@ -470,14 +470,14 @@ class AdCPRequestHandler(RequestHandler):
         result: dict[str, Any] | None = None,
         error: str | None = None,
     ):
-        """Send protocol-level push notification if configured.
+        """Send a protocol-level push notification for a non-terminal status, if configured.
 
-        Per AdCP A2A spec (https://docs.adcontextprotocol.org/docs/protocols/a2a-guide#push-notifications-a2a-specific):
-        - Final states (completed, failed, canceled): Send full Task object with artifacts
-        - Intermediate states (working, input-required, submitted): Send TaskStatusUpdateEvent
-
-        ``notify`` selects the payload type from the status: Task for final states,
-        TaskStatusUpdateEvent for intermediate ones.
+        This sender delivers only on the INITIAL synchronous response, which today is
+        always non-terminal here (``submitted``): an inline terminal response is guarded
+        out below (pinned AdCP 3.1.1 webhooks.mdx:160 — the buyer already has the result).
+        The terminal completion of a ``submitted`` operation is delivered later by an async
+        worker, which does not exist yet and would need its own entry point (see the guard).
+        For the non-terminal states that reach ``notify``, it sends a TaskStatusUpdateEvent.
         """
         # This sender notifies on the INITIAL synchronous response only. Per pinned AdCP
         # 3.1.1 webhooks.mdx:160, an inline terminal response MUST NOT emit a webhook — the
@@ -544,9 +544,9 @@ class AdCPRequestHandler(RequestHandler):
                 notification_type=None,
             )
 
-            # notify() picks the payload type: Task for final states,
-            # TaskStatusUpdateEvent for intermediate ones. protocol is "a2a"
-            # unconditionally -- this IS the A2A server.
+            # notify() picks the payload type by status; terminal states are guarded out
+            # above, so in practice this delivers a TaskStatusUpdateEvent for the
+            # non-terminal (submitted) case. protocol is "a2a" -- this IS the A2A server.
             sent = await push_notification_service.notify(
                 push_notification_config,
                 task=webhook_task,
@@ -830,15 +830,11 @@ class AdCPRequestHandler(RequestHandler):
                 successful_skills = [res["skill"] for res in results if res["success"]]
 
                 if failed_skills and not successful_skills:
-                    # All skills failed - mark task as failed
+                    # All skills failed - mark task as failed and return it inline.
+                    # No webhook: an inline terminal response is gated out centrally in
+                    # _send_protocol_webhook (webhooks.mdx:160), so a call here would be a
+                    # guaranteed no-op — the buyer already has the failed Task.
                     task.status.CopyFrom(TaskStatus(state=TaskState.TASK_STATE_FAILED))
-
-                    # Delivery is gated centrally in _send_protocol_webhook (inline terminal → skip).
-                    error_messages = [
-                        res["error_envelope"]["errors"][0]["message"] for res in results if not res["success"]
-                    ]
-                    await self._send_protocol_webhook(task, status="failed", error="; ".join(error_messages))
-
                     return task
                 elif successful_skills:
                     # Log successful skill invocations with rich context

--- a/src/a2a_server/adcp_a2a_server.py
+++ b/src/a2a_server/adcp_a2a_server.py
@@ -1047,9 +1047,11 @@ class AdCPRequestHandler(RequestHandler):
                 )
             )
 
-            # Send protocol-level webhook notification for failure if configured
-            await self._send_protocol_webhook(task, status="failed")
-
+            # No webhook here: this branch returns a terminal failed Task
+            # synchronously (inline response). Pinned AdCP 3.1.1
+            # webhooks.mdx:160 (MUST NOT) + a2a-guide:484 — an inline terminal
+            # response emits no push notification.
+            #
             # The exception is a typed application failure, so return its
             # failed Task. The untyped transport-crash branch returned above.
 

--- a/src/a2a_server/adcp_a2a_server.py
+++ b/src/a2a_server/adcp_a2a_server.py
@@ -1002,7 +1002,12 @@ class AdCPRequestHandler(RequestHandler):
             await self._send_protocol_webhook(task, status=task_status_str)
 
         except A2AError:
-            # Re-raise A2AError as-is (will be caught by JSON-RPC handler)
+            # Transport fault: the request could not be routed to a skill, so the
+            # buyer receives a JSON-RPC error and no Task exists to query. Drop the
+            # Task and push registration stashed before the try so neither orphans
+            # (a2a-response-format.mdx@3.1.1 "no artifact produced" row).
+            self.tasks.pop(task_id, None)
+            self._task_push_configs.pop(task_id, None)
             raise
         except Exception as e:
             # Use identity resolved at transport boundary (if available).
@@ -1021,23 +1026,15 @@ class AdCPRequestHandler(RequestHandler):
                 principal_id=err_principal_id,
             )
 
-            # Pinned AdCP 3.1.1, docs/building/operating/transport-errors.mdx
-            # "Layer Separation": an internal crash belongs to the transport
-            # channel. Do not normalize an untyped bug to SERVICE_UNAVAILABLE /
-            # transient — that tells the buyer to retry a potentially
-            # deterministic defect. The A2A SDK serializes this InternalError as
-            # JSON-RPC -32603. Its static message and absent data deliberately
-            # keep exception text and internals off the buyer wire.
-            if not isinstance(e, AdCPError):
-                self.tasks.pop(task_id, None)
-                self._task_push_configs.pop(task_id, None)
-                raise InternalError(message="Internal server error") from e
-
+            # A Task exists and structured error data is in hand, so per pinned AdCP
+            # 3.1.1 a2a-response-format.mdx "Where the Error Lives: Decision Rule" the
+            # failure is RETURNED as a failed Task carrying the adcp_error DataPart —
+            # the same path MCP (tool_error_logging), REST, and the A2A explicit-skill
+            # loop already take. ``_build_error_envelope`` routes an untyped crash
+            # through ``normalize_to_adcp_error`` to base AdCPError (wire
+            # SERVICE_UNAVAILABLE) and passes a typed AdCPError's own wire code. JSON-RPC
+            # is reserved for failures where no Task was produced (the A2AError branch).
             task.status.CopyFrom(TaskStatus(state=TaskState.TASK_STATE_FAILED))
-            # Attach error to task artifacts as a spec-compliant two-layer
-            # envelope (same shape as failed-skill DataParts).
-            # ``_build_error_envelope`` preserves the typed AdCPError's wire
-            # code and recovery metadata.
             del task.artifacts[:]
             task.artifacts.append(
                 Artifact(
@@ -1047,13 +1044,10 @@ class AdCPRequestHandler(RequestHandler):
                 )
             )
 
-            # No webhook here: this branch returns a terminal failed Task
-            # synchronously (inline response). Pinned AdCP 3.1.1
-            # webhooks.mdx:160 (MUST NOT) + a2a-guide:484 — an inline terminal
-            # response emits no push notification.
-            #
-            # The exception is a typed application failure, so return its
-            # failed Task. The untyped transport-crash branch returned above.
+            # Inline terminal failed Task: no webhook (webhooks.mdx:160 MUST NOT), and
+            # the accepted push config is dropped here — a terminal task returned
+            # synchronously has no future consumer for it.
+            self._task_push_configs.pop(task_id, None)
 
         self.tasks[task_id] = task
         return task

--- a/src/a2a_server/adcp_a2a_server.py
+++ b/src/a2a_server/adcp_a2a_server.py
@@ -223,15 +223,11 @@ DISCOVERY_SKILLS = frozenset(
 def _internal_error_for(operation: str, exc: Exception) -> InternalError:
     """Canonical InternalError shape for non-Task A2A boundary failures.
 
-    Skill handlers raise typed ``AdCPError`` (or untyped exceptions that the
-    dispatcher normalizes), and ``_handle_explicit_skill`` → ``on_message_send``
-    surface those as a two-layer envelope on a failed Task's DataPart —
-    including the top-level ``on_message_send`` fallthrough, which per AdCP
-    3.1.x transport rules (building/operating/transport-errors.mdx "Layer
-    Separation") RETURNS a failed Task carrying the envelope artifact rather
-    than raising this helper. JSON-RPC errors are reserved for genuine
-    transport faults (``A2AError``) and methods with no Task to carry the
-    envelope.
+    Skill handlers raise typed ``AdCPError`` for expected application failures,
+    and ``on_message_send`` surfaces those as a two-layer envelope on a failed
+    Task's DataPart. Untyped crashes instead become a separately sanitized
+    JSON-RPC ``InternalError`` at the outer boundary, per AdCP 3.1.1
+    ``docs/building/operating/transport-errors.mdx`` "Layer Separation".
 
     Use this helper only at ``InternalError(...)`` raise sites that have no
     async Task to attach an envelope artifact to. The canonical prefix is
@@ -269,9 +265,9 @@ class AdCPRequestHandler(RequestHandler):
         """Build a spec-compliant two-layer envelope for any exception.
 
         Single source of truth for "wrap-arbitrary-exception → wire envelope"
-        used by both the per-skill dispatcher (``_build_failed_skill_result``)
-        and the top-level ``on_message_send`` error handler. Delegates to
-        ``normalize_to_adcp_error`` for the type→AdCPError mapping
+        used by the per-skill dispatcher (``_build_failed_skill_result``) and
+        by ``on_message_send`` for typed application failures. Delegates to
+        ``normalize_to_adcp_error`` for the per-skill type→AdCPError mapping
         (``ValueError → AdCPValidationError``, ``PermissionError →
         AdCPAuthorizationError``, arbitrary ``Exception →
         AdCPError(INTERNAL_ERROR)``) so the wire output stays in
@@ -1025,14 +1021,23 @@ class AdCPRequestHandler(RequestHandler):
                 principal_id=err_principal_id,
             )
 
+            # Pinned AdCP 3.1.1, docs/building/operating/transport-errors.mdx
+            # "Layer Separation": an internal crash belongs to the transport
+            # channel. Do not normalize an untyped bug to SERVICE_UNAVAILABLE /
+            # transient — that tells the buyer to retry a potentially
+            # deterministic defect. The A2A SDK serializes this InternalError as
+            # JSON-RPC -32603. Its static message and absent data deliberately
+            # keep exception text and internals off the buyer wire.
+            if not isinstance(e, AdCPError):
+                self.tasks.pop(task_id, None)
+                self._task_push_configs.pop(task_id, None)
+                raise InternalError(message="Internal server error") from e
+
             task.status.CopyFrom(TaskStatus(state=TaskState.TASK_STATE_FAILED))
             # Attach error to task artifacts as a spec-compliant two-layer
-            # envelope (same shape as failed-skill DataParts) so storyboard
-            # runners can ``JSON.parse`` the artifact uniformly regardless of
-            # which failure path produced it. ``_build_error_envelope``
-            # normalizes untyped exceptions to base AdCPError (wire code
-            # SERVICE_UNAVAILABLE via ERROR_CODE_MAPPING) and passes
-            # through a typed AdCPError's own wire code.
+            # envelope (same shape as failed-skill DataParts).
+            # ``_build_error_envelope`` preserves the typed AdCPError's wire
+            # code and recovery metadata.
             del task.artifacts[:]
             task.artifacts.append(
                 Artifact(
@@ -1045,14 +1050,8 @@ class AdCPRequestHandler(RequestHandler):
             # Send protocol-level webhook notification for failure if configured
             await self._send_protocol_webhook(task, status="failed")
 
-            # Per AdCP 3.1.x transport rules (spec prose:
-            # building/operating/transport-errors.mdx "Layer Separation" and the
-            # two-layer error-handling model), application/task-execution
-            # failures MUST be returned in the task response body as a failed
-            # Task carrying the envelope artifact. JSON-RPC errors are reserved
-            # for genuine transport faults (A2AError, re-raised above). So we
-            # fall through to the shared store-and-return below — never raise
-            # InternalError here.
+            # The exception is a typed application failure, so return its
+            # failed Task. The untyped transport-crash branch returned above.
 
         self.tasks[task_id] = task
         return task

--- a/src/a2a_server/adcp_a2a_server.py
+++ b/src/a2a_server/adcp_a2a_server.py
@@ -295,6 +295,24 @@ class AdCPRequestHandler(RequestHandler):
             "success": False,
         }
 
+    @staticmethod
+    def _error_artifact_parts(envelope: dict[str, Any]) -> list[Part]:
+        """Parts for a failed-Task artifact: recommended TextPart + required DataPart.
+
+        Pinned AdCP 3.1.1 a2a-response-format.mdx "Required Structure": the adcp_error
+        DataPart is required and a human/LLM-readable TextPart is recommended. Single
+        source of shape shared by the top-level ``on_message_send`` failure path and the
+        per-skill dispatcher, so both failed-Task artifacts read identically. The text is
+        the envelope's own error message (``errors[0].message``), never re-derived.
+        """
+        errors = envelope.get("errors") or []
+        text = errors[0].get("message") if errors else None
+        parts: list[Part] = []
+        if text:
+            parts.append(Part(text=text))
+        parts.append(Part(data=_dict_to_value(envelope)))
+        return parts
+
     def _get_auth_token(self, context: ServerCallContext | None = None) -> str | None:
         """Extract Bearer token from ServerCallContext.
 
@@ -766,15 +784,17 @@ class AdCPRequestHandler(RequestHandler):
                     # a reference to the dict about to go on the wire, and one of
                     # them mutated it in place (the list_creatives format_id
                     # bare-string defect). Nothing rebuilds an outbound payload.
-                    text_message = None
-                    if res["success"] and isinstance(artifact_data, dict):
-                        text_message = artifact_data.get("message")
-
-                    # Build parts list per A2A spec: optional text Part + required data Part
-                    parts = []
-                    if text_message:
-                        parts.append(Part(text=text_message))
-                    parts.append(Part(data=_dict_to_value(artifact_data)))
+                    # Build parts per A2A spec: recommended text Part + required data Part.
+                    # A failed skill goes through the shared error-artifact builder so its
+                    # DataPart+TextPart shape matches the top-level on_message_send failure.
+                    if not res["success"]:
+                        parts = self._error_artifact_parts(artifact_data)
+                    else:
+                        text_message = artifact_data.get("message") if isinstance(artifact_data, dict) else None
+                        parts = []
+                        if text_message:
+                            parts.append(Part(text=text_message))
+                        parts.append(Part(data=_dict_to_value(artifact_data)))
 
                     task.artifacts.append(
                         Artifact(
@@ -1040,7 +1060,7 @@ class AdCPRequestHandler(RequestHandler):
                 Artifact(
                     artifact_id="error_1",
                     name="processing_error",
-                    parts=[Part(data=_dict_to_value(self._build_error_envelope(e)))],
+                    parts=self._error_artifact_parts(self._build_error_envelope(e)),
                 )
             )
 

--- a/src/a2a_server/adcp_a2a_server.py
+++ b/src/a2a_server/adcp_a2a_server.py
@@ -220,12 +220,16 @@ DISCOVERY_SKILLS = frozenset(
 )
 
 
-# Terminal A2A task states. `_send_protocol_webhook` notifies on the INITIAL synchronous
-# response only; an inline terminal response must not emit a webhook (pinned AdCP 3.1.1
-# webhooks.mdx:160 — the buyer already has the result).
-_TERMINAL_TASK_STATES = frozenset(
+# Inline terminal FAILURE states. `_send_protocol_webhook` skips these: a task that failed
+# on the initial synchronous response is returned inline, so a webhook would duplicate the
+# failed Task the buyer already holds (pinned AdCP 3.1.1 webhooks.mdx:160). COMPLETED is NOT
+# here on purpose — a completed task's webhook is this server's only delivery of the result to
+# a registered endpoint (there is no async completion worker), and suppressing it would remove
+# webhook delivery entirely (graded by test_webhook_registration_reaches_delivery_signed).
+# The strict-spec goal (deliver completions from an async worker AFTER a non-terminal initial
+# response, so no inline terminal ever webhooks) is a separate architecture change.
+_TERMINAL_FAILURE_STATES = frozenset(
     {
-        TaskState.TASK_STATE_COMPLETED,
         TaskState.TASK_STATE_FAILED,
         TaskState.TASK_STATE_CANCELED,
         TaskState.TASK_STATE_REJECTED,
@@ -479,12 +483,11 @@ class AdCPRequestHandler(RequestHandler):
         worker, which does not exist yet and would need its own entry point (see the guard).
         For the non-terminal states that reach ``notify``, it sends a TaskStatusUpdateEvent.
         """
-        # This sender notifies on the INITIAL synchronous response only. Per pinned AdCP
-        # 3.1.1 webhooks.mdx:160, an inline terminal response MUST NOT emit a webhook — the
-        # buyer already has the result. No async completion-delivery path exists today; if
-        # one is added it MUST use a distinct entry point, because this guard would
-        # otherwise suppress its legitimate terminal completion webhook.
-        if task.status.state in _TERMINAL_TASK_STATES:
+        # Skip a webhook for an inline terminal FAILURE: the failed Task is returned on the
+        # synchronous response, so a webhook would duplicate what the buyer already holds
+        # (pinned AdCP 3.1.1 webhooks.mdx:160). A COMPLETED task is deliberately NOT skipped —
+        # its webhook is this server's only delivery of the result to the registered endpoint.
+        if task.status.state in _TERMINAL_FAILURE_STATES:
             return
 
         try:

--- a/tests/a2a_helpers.py
+++ b/tests/a2a_helpers.py
@@ -2,10 +2,15 @@
 
 Provides make_a2a_context() to build a ServerCallContext the same way
 AdCPCallContextBuilder.build() does in production, but without needing
-a Starlette request object.
+a Starlette request object, and extract_processing_error_envelope() to
+read the two-layer AdCP error envelope off a failed Task returned by
+on_message_send's outer error handler.
 """
 
+import json
+
 from a2a.server.context import ServerCallContext
+from google.protobuf import json_format
 
 from src.core.auth_context import AUTH_CONTEXT_STATE_KEY, AuthContext
 
@@ -28,3 +33,46 @@ def make_a2a_context(
     """
     auth_ctx = AuthContext(auth_token=auth_token, headers=headers or {})
     return ServerCallContext(state={AUTH_CONTEXT_STATE_KEY: auth_ctx})
+
+
+def extract_processing_error_envelope(task) -> dict:
+    """Read the two-layer AdCP envelope from a failed Task's processing_error artifact.
+
+    ``on_message_send``'s outer error handler attaches the envelope built by
+    ``AdCPRequestHandler._build_error_envelope`` to the failed Task as a
+    single ``processing_error`` artifact with one DataPart (AdCP 3.1.x
+    transport-errors.mdx "Layer Separation": application failures ride in
+    the task body, not JSON-RPC errors).
+    """
+    assert task.artifacts, "failed Task must carry the error envelope artifact"
+    artifact = task.artifacts[0]
+    assert artifact.name == "processing_error", f"expected processing_error artifact, got {artifact.name!r}"
+    part = artifact.parts[0]
+    assert part.HasField("data"), "envelope artifact part must be a DataPart"
+    return json.loads(json_format.MessageToJson(part.data))
+
+
+def make_mock_a2a_identity():
+    """Standard mock ResolvedIdentity for A2A handler unit tests."""
+    from tests.factories import PrincipalFactory
+
+    return PrincipalFactory.make_identity(
+        principal_id="test-principal",
+        tenant_id="test-tenant",
+        tenant={"tenant_id": "test-tenant"},
+        protocol="a2a",
+    )
+
+
+def make_nl_send_message_request(text: str):
+    """Build a minimal A2A SendMessageRequest carrying NL text (no skills)."""
+    import uuid
+
+    from a2a.types import Message, Part, Role, SendMessageRequest
+
+    message = Message(
+        message_id=str(uuid.uuid4()),
+        role=Role.ROLE_USER,
+    )
+    message.parts.append(Part(text=text))
+    return SendMessageRequest(message=message)

--- a/tests/a2a_helpers.py
+++ b/tests/a2a_helpers.py
@@ -7,16 +7,14 @@ read the two-layer AdCP error envelope off a failed Task returned by
 on_message_send's outer error handler.
 """
 
-import json
-import uuid
-
 from a2a.server.context import ServerCallContext
-from a2a.types import Message, Part, Role, SendMessageRequest
-from google.protobuf import json_format
+from a2a.types import SendMessageRequest
 
+from src.a2a_server.adcp_a2a_server import AdCPRequestHandler
 from src.core.auth_context import AUTH_CONTEXT_STATE_KEY, AuthContext
 from src.core.resolved_identity import ResolvedIdentity
 from tests.factories import PrincipalFactory
+from tests.utils.a2a_helpers import create_a2a_text_message, extract_data_from_artifact
 
 
 def make_a2a_context(
@@ -39,6 +37,21 @@ def make_a2a_context(
     return ServerCallContext(state={AUTH_CONTEXT_STATE_KEY: auth_ctx})
 
 
+def make_a2a_handler(
+    auth_token: str | None = "test-token",
+    headers: dict[str, str] | None = None,
+) -> tuple[AdCPRequestHandler, ServerCallContext]:
+    """Handler + authenticated call context for driving on_message_send.
+
+    The token lives in the context state where the real ``_get_auth_token`` reads
+    it, so token extraction runs for real — the unit does not stub it. Single
+    source for the handler+context setup shared across the A2A handler unit tests.
+    """
+    handler = AdCPRequestHandler()
+    ctx = make_a2a_context(auth_token=auth_token, headers=headers or {"host": "test.example.com"})
+    return handler, ctx
+
+
 def extract_processing_error_envelope(task) -> dict:
     """Read the two-layer AdCP envelope from a failed Task's processing_error artifact.
 
@@ -47,15 +60,15 @@ def extract_processing_error_envelope(task) -> dict:
     ``processing_error`` artifact carrying the adcp_error DataPart plus a
     recommended human-readable TextPart (AdCP 3.1.1 a2a-response-format.mdx
     "Where the Error Lives": a Task-execution failure rides in the task body).
-    Scan for the DataPart — it is not necessarily ``parts[0]`` once a TextPart leads.
+    Reads the DataPart via the shared ``extract_data_from_artifact`` scanner, so
+    a leading TextPart does not shift it.
     """
     assert task.artifacts, "failed Task must carry the error envelope artifact"
     artifact = task.artifacts[0]
     assert artifact.name == "processing_error", f"expected processing_error artifact, got {artifact.name!r}"
-    for part in artifact.parts:
-        if part.HasField("data"):
-            return json.loads(json_format.MessageToJson(part.data))
-    raise AssertionError("processing_error artifact must carry a DataPart")
+    data = extract_data_from_artifact(artifact)
+    assert data, "processing_error artifact must carry a DataPart"
+    return data
 
 
 def make_mock_a2a_identity() -> ResolvedIdentity:
@@ -70,9 +83,4 @@ def make_mock_a2a_identity() -> ResolvedIdentity:
 
 def make_nl_send_message_request(text: str) -> SendMessageRequest:
     """Build a minimal A2A SendMessageRequest carrying NL text (no skills)."""
-    message = Message(
-        message_id=str(uuid.uuid4()),
-        role=Role.ROLE_USER,
-    )
-    message.parts.append(Part(text=text))
-    return SendMessageRequest(message=message)
+    return SendMessageRequest(message=create_a2a_text_message(text))

--- a/tests/a2a_helpers.py
+++ b/tests/a2a_helpers.py
@@ -40,16 +40,18 @@ def extract_processing_error_envelope(task) -> dict:
 
     ``on_message_send``'s outer error handler attaches the envelope built by
     ``AdCPRequestHandler._build_error_envelope`` to the failed Task as a
-    single ``processing_error`` artifact with one DataPart (AdCP 3.1.x
-    transport-errors.mdx "Layer Separation": application failures ride in
-    the task body, not JSON-RPC errors).
+    ``processing_error`` artifact carrying the adcp_error DataPart plus a
+    recommended human-readable TextPart (AdCP 3.1.1 a2a-response-format.mdx
+    "Where the Error Lives": a Task-execution failure rides in the task body).
+    Scan for the DataPart — it is not necessarily ``parts[0]`` once a TextPart leads.
     """
     assert task.artifacts, "failed Task must carry the error envelope artifact"
     artifact = task.artifacts[0]
     assert artifact.name == "processing_error", f"expected processing_error artifact, got {artifact.name!r}"
-    part = artifact.parts[0]
-    assert part.HasField("data"), "envelope artifact part must be a DataPart"
-    return json.loads(json_format.MessageToJson(part.data))
+    for part in artifact.parts:
+        if part.HasField("data"):
+            return json.loads(json_format.MessageToJson(part.data))
+    raise AssertionError("processing_error artifact must carry a DataPart")
 
 
 def make_mock_a2a_identity():

--- a/tests/a2a_helpers.py
+++ b/tests/a2a_helpers.py
@@ -8,11 +8,15 @@ on_message_send's outer error handler.
 """
 
 import json
+import uuid
 
 from a2a.server.context import ServerCallContext
+from a2a.types import Message, Part, Role, SendMessageRequest
 from google.protobuf import json_format
 
 from src.core.auth_context import AUTH_CONTEXT_STATE_KEY, AuthContext
+from src.core.resolved_identity import ResolvedIdentity
+from tests.factories import PrincipalFactory
 
 
 def make_a2a_context(
@@ -54,10 +58,8 @@ def extract_processing_error_envelope(task) -> dict:
     raise AssertionError("processing_error artifact must carry a DataPart")
 
 
-def make_mock_a2a_identity():
+def make_mock_a2a_identity() -> ResolvedIdentity:
     """Standard mock ResolvedIdentity for A2A handler unit tests."""
-    from tests.factories import PrincipalFactory
-
     return PrincipalFactory.make_identity(
         principal_id="test-principal",
         tenant_id="test-tenant",
@@ -66,12 +68,8 @@ def make_mock_a2a_identity():
     )
 
 
-def make_nl_send_message_request(text: str):
+def make_nl_send_message_request(text: str) -> SendMessageRequest:
     """Build a minimal A2A SendMessageRequest carrying NL text (no skills)."""
-    import uuid
-
-    from a2a.types import Message, Part, Role, SendMessageRequest
-
     message = Message(
         message_id=str(uuid.uuid4()),
         role=Role.ROLE_USER,

--- a/tests/unit/test_a2a_error_routing.py
+++ b/tests/unit/test_a2a_error_routing.py
@@ -1,11 +1,14 @@
 """A2A error routing: application failures ride in failed Tasks, not JSON-RPC.
 
-Compliance finding F7. Per AdCP 3.1.x transport rules (spec prose:
+Per AdCP 3.1.x transport rules (spec prose:
 building/operating/transport-errors.mdx "Layer Separation" and the two-layer
 error-handling model), application/task-execution failures must be RETURNED in
 the task response body as a failed Task carrying the two-layer AdCP error
 envelope artifact. JSON-RPC errors (``A2AError``) are reserved for genuine
 transport faults — malformed requests, missing auth, method-not-found.
+
+Grading: ungraded — A2A transport mechanic, unit-graded here. No conformance
+storyboard under ``dist/compliance/3.1.1/`` exercises A2A failed-Task routing.
 
 Pre-fix bug: ``on_message_send``'s outer exception handler built the correct
 failed Task with the ``processing_error`` envelope artifact, then threw it

--- a/tests/unit/test_a2a_error_routing.py
+++ b/tests/unit/test_a2a_error_routing.py
@@ -1,23 +1,25 @@
-"""A2A error routing: typed failures use Tasks; internal crashes use JSON-RPC.
+"""A2A error routing: a Task-execution failure rides in a failed Task; only a
+transport fault with no Task uses JSON-RPC.
 
-Pinned AdCP 3.1.1, ``docs/building/operating/transport-errors.mdx`` "Layer
-Separation": typed application failures belong in a failed Task carrying the
-two-layer AdCP envelope, while an untyped internal crash belongs in the
-transport channel as a sanitized JSON-RPC error.
+Pinned AdCP 3.1.1, ``a2a-response-format.mdx`` "Where the Error Lives: Decision
+Rule": when a Task exists and structured error data is in hand — a typed
+``AdCPError`` OR an untyped system crash alike — the failure is RETURNED as
+``status: failed`` carrying the two-layer AdCP envelope in a DataPart. JSON-RPC
+is reserved for failures where no Task artifact was produced (parse/auth-handshake/
+malformed request — the re-raised ``A2AError``). An untyped crash normalizes to
+base ``AdCPError`` → wire ``SERVICE_UNAVAILABLE``, the same as MCP/REST/explicit-skill.
 
 Grading: ungraded — A2A transport mechanic, unit-graded here. No conformance
 storyboard under ``dist/compliance/3.1.1/`` exercises A2A failed-Task routing.
 
-These tests pin both sides: typed ``AdCPError`` retains its Task envelope;
-unexpected ``Exception`` cannot become retryable ``SERVICE_UNAVAILABLE`` or
-expose its message on the transport error.
+These tests pin both sides: typed and untyped Task-execution failures return a
+failed Task envelope; only a genuine ``A2AError`` transport fault raises to JSON-RPC.
 """
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from a2a.types import (
-    InternalError,
     InvalidRequestError,
     SendMessageConfiguration,
     SendMessageRequest,
@@ -59,12 +61,16 @@ def _make_handler() -> tuple[AdCPRequestHandler, object]:
 
 
 @pytest.mark.asyncio
-async def test_untyped_processing_failure_raises_sanitized_internal_error():
-    """An unexpected processing crash is sanitized onto the JSON-RPC path.
+async def test_untyped_processing_failure_returns_service_unavailable_failed_task():
+    """An untyped crash returns a failed Task envelope, not a JSON-RPC error.
 
-    The crash path must also tear down BOTH per-task registries — the lifecycle
-    Task AND the accepted push config — so a transport-rejected request leaves
-    no orphaned state, and attempts no webhook.
+    Pinned AdCP 3.1.1 a2a-response-format.mdx "Where the Error Lives: Decision
+    Rule": a system error where a Task exists is RETURNED as ``status: failed``
+    carrying the adcp_error DataPart — the same path MCP/REST/explicit-skill take
+    via ``normalize_to_adcp_error`` (base AdCPError → wire SERVICE_UNAVAILABLE).
+    The inline terminal failure drops the accepted push config and emits no
+    webhook. (Scrubbing the untyped error message off the wire is a shared-seam
+    concern tracked separately, not asserted here.)
     """
     handler, ctx = _make_handler()
     params = _make_nl_request_with_push(
@@ -79,15 +85,20 @@ async def test_untyped_processing_failure_raises_sanitized_internal_error():
             "src.a2a_server.adcp_a2a_server.core_get_products_tool",
             side_effect=RuntimeError("adapter exploded: secret-canary"),
         ),
-        pytest.raises(InternalError) as exc_info,
     ):
-        await handler.on_message_send(params, context=ctx)
+        result = await handler.on_message_send(params, context=ctx)
 
-    assert exc_info.value.message == "Internal server error"
-    assert exc_info.value.data is None
-    assert "adapter exploded" not in str(exc_info.value)
-    assert not handler.tasks, "a transport-rejected request must not leave a lifecycle Task"
-    assert not handler._task_push_configs, "a transport-rejected request must not leave an orphaned push config"
+    assert isinstance(result, Task), f"expected a returned Task, got {type(result).__name__}"
+    assert result.status.state == TaskState.TASK_STATE_FAILED, (
+        f"expected TASK_STATE_FAILED, got {result.status.state!r}"
+    )
+    assert_envelope_shape(
+        extract_processing_error_envelope(result),
+        "SERVICE_UNAVAILABLE",
+        recovery="transient",
+    )
+    # Inline terminal failure: the accepted push config is dropped, no webhook fires.
+    assert not handler._task_push_configs, "terminal failure must not retain the push config"
     handler._send_protocol_webhook.assert_not_awaited()
 
 
@@ -139,7 +150,7 @@ async def test_no_webhook_on_inline_typed_failure():
 
     with (
         patch("src.core.resolved_identity.resolve_identity", return_value=_MOCK_IDENTITY),
-        patch("src.a2a_server.adcp_a2a_server._accept_a2a_push_config", return_value=MagicMock()),
+        patch("src.a2a_server.adcp_a2a_server._accept_a2a_push_config", return_value=MagicMock()) as mock_accept,
         patch(
             "src.a2a_server.adcp_a2a_server.core_get_products_tool",
             side_effect=AdCPValidationError("brief must not be empty"),
@@ -151,9 +162,11 @@ async def test_no_webhook_on_inline_typed_failure():
     assert result.status.state == TaskState.TASK_STATE_FAILED, (
         f"expected TASK_STATE_FAILED, got {result.status.state!r}"
     )
-    # An accepted push config WAS registered for this task ...
-    assert handler._task_push_configs, "push config should have been registered for the task"
-    # ... yet no webhook is emitted for the inline terminal failed Task.
+    # An accepted push config WAS registered for this task (the buyer's URL) ...
+    mock_accept.assert_called_once_with("https://buyer.example.com/webhook", None, None)
+    # ... but the inline terminal failure drops it — no orphaned URL/credentials.
+    assert not handler._task_push_configs, "terminal typed failure must not retain the push config"
+    # ... and no webhook is emitted for the inline terminal failed Task.
     handler._send_protocol_webhook.assert_not_awaited()
 
 

--- a/tests/unit/test_a2a_error_routing.py
+++ b/tests/unit/test_a2a_error_routing.py
@@ -1,0 +1,132 @@
+"""A2A error routing: application failures ride in failed Tasks, not JSON-RPC.
+
+Compliance finding F7. Per AdCP 3.1.x transport rules (spec prose:
+building/operating/transport-errors.mdx "Layer Separation" and the two-layer
+error-handling model), application/task-execution failures must be RETURNED in
+the task response body as a failed Task carrying the two-layer AdCP error
+envelope artifact. JSON-RPC errors (``A2AError``) are reserved for genuine
+transport faults — malformed requests, missing auth, method-not-found.
+
+Pre-fix bug: ``on_message_send``'s outer exception handler built the correct
+failed Task with the ``processing_error`` envelope artifact, then threw it
+away by raising ``InternalError`` (a JSON-RPC error) instead of returning the
+Task. These tests pin the returned-failed-Task contract on the wire artifact.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from a2a.types import InvalidRequestError, SendMessageRequest, Task, TaskState
+
+from src.a2a_server.adcp_a2a_server import AdCPRequestHandler
+from src.core.exceptions import AdCPValidationError
+from tests.a2a_helpers import (
+    extract_processing_error_envelope,
+    make_a2a_context,
+    make_mock_a2a_identity,
+    make_nl_send_message_request,
+)
+from tests.helpers import assert_envelope_shape
+from tests.utils.a2a_helpers import create_a2a_message_with_skill
+
+_MOCK_IDENTITY = make_mock_a2a_identity()
+_make_nl_request = make_nl_send_message_request
+
+
+def _make_handler() -> tuple[AdCPRequestHandler, object]:
+    """Handler + authenticated call context for driving on_message_send."""
+    handler = AdCPRequestHandler()
+    handler._get_auth_token = MagicMock(return_value="test-token")
+    ctx = make_a2a_context(auth_token="test-token", headers={"host": "test.example.com"})
+    return handler, ctx
+
+
+@pytest.mark.asyncio
+async def test_untyped_processing_failure_returns_failed_task_with_internal_error_envelope():
+    """An unexpected exception during message processing returns a failed Task.
+
+    The outer ``on_message_send`` handler must normalize the untyped exception
+    to base ``AdCPError`` (internal INTERNAL_ERROR → wire ``SERVICE_UNAVAILABLE``
+    via ``ERROR_CODE_MAPPING``), attach the two-layer envelope as the
+    ``processing_error`` artifact DataPart, and RETURN the failed Task — never
+    raise a JSON-RPC ``InternalError`` for an application failure.
+    """
+    handler, ctx = _make_handler()
+    params = _make_nl_request("Show me available products in the catalog")
+
+    with patch("src.core.resolved_identity.resolve_identity", return_value=_MOCK_IDENTITY):
+        with patch(
+            "src.a2a_server.adcp_a2a_server.core_get_products_tool",
+            side_effect=RuntimeError("adapter exploded"),
+        ):
+            result = await handler.on_message_send(params, context=ctx)
+
+    assert isinstance(result, Task), f"expected a returned Task, got {type(result).__name__}"
+    assert result.status.state == TaskState.TASK_STATE_FAILED, (
+        f"expected TASK_STATE_FAILED, got {result.status.state!r}"
+    )
+    envelope = extract_processing_error_envelope(result)
+    # Untyped exceptions normalize to base AdCPError (internal INTERNAL_ERROR),
+    # which maps on the wire to SERVICE_UNAVAILABLE via ERROR_CODE_MAPPING — a
+    # transient (retryable) error, so recovery is "transient".
+    assert_envelope_shape(
+        envelope,
+        "SERVICE_UNAVAILABLE",
+        recovery="transient",
+        message_substr="adapter exploded",
+    )
+    # The failed Task is also the stored lifecycle record.
+    assert handler.tasks[result.id].status.state == TaskState.TASK_STATE_FAILED
+
+
+@pytest.mark.asyncio
+async def test_typed_adcp_error_keeps_its_own_wire_code_on_failed_task():
+    """A typed AdCPError escaping to the outer handler keeps its own wire code.
+
+    The envelope must carry the AdCPError's code (here ``VALIDATION_ERROR``),
+    not a blanket ``INTERNAL_ERROR`` — ``_build_error_envelope`` passes typed
+    errors through ``normalize_to_adcp_error`` unchanged.
+    """
+    handler, ctx = _make_handler()
+    params = _make_nl_request("Show me available products in the catalog")
+
+    with patch("src.core.resolved_identity.resolve_identity", return_value=_MOCK_IDENTITY):
+        with patch(
+            "src.a2a_server.adcp_a2a_server.core_get_products_tool",
+            side_effect=AdCPValidationError("brief must not be empty"),
+        ):
+            result = await handler.on_message_send(params, context=ctx)
+
+    assert isinstance(result, Task), f"expected a returned Task, got {type(result).__name__}"
+    assert result.status.state == TaskState.TASK_STATE_FAILED, (
+        f"expected TASK_STATE_FAILED, got {result.status.state!r}"
+    )
+    assert_envelope_shape(
+        extract_processing_error_envelope(result),
+        "VALIDATION_ERROR",
+        recovery="correctable",
+        message_substr="brief must not be empty",
+    )
+
+
+@pytest.mark.asyncio
+async def test_genuine_transport_fault_still_raises_json_rpc_error():
+    """A transport-protocol fault must still surface as a JSON-RPC error.
+
+    Missing authentication for a non-discovery skill is a transport-layer
+    fault (the request cannot be routed at all), so ``on_message_send``
+    re-raises the ``A2AError`` (here ``InvalidRequestError``) onto the
+    JSON-RPC layer instead of returning a failed Task.
+    """
+    handler = AdCPRequestHandler()
+    # No auth token at all — create_media_buy is a non-discovery skill.
+    ctx = make_a2a_context(auth_token=None, headers={"host": "test.example.com"})
+    message = create_a2a_message_with_skill("create_media_buy", {"product_ids": ["prod_1"]})
+    params = SendMessageRequest(message=message)
+
+    with pytest.raises(InvalidRequestError) as exc_info:
+        await handler.on_message_send(params, context=ctx)
+
+    assert "authentication" in str(exc_info.value).lower(), (
+        f"transport fault should name the missing authentication; got: {exc_info.value}"
+    )

--- a/tests/unit/test_a2a_error_routing.py
+++ b/tests/unit/test_a2a_error_routing.py
@@ -1,25 +1,22 @@
-"""A2A error routing: application failures ride in failed Tasks, not JSON-RPC.
+"""A2A error routing: typed failures use Tasks; internal crashes use JSON-RPC.
 
-Per AdCP 3.1.x transport rules (spec prose:
-building/operating/transport-errors.mdx "Layer Separation" and the two-layer
-error-handling model), application/task-execution failures must be RETURNED in
-the task response body as a failed Task carrying the two-layer AdCP error
-envelope artifact. JSON-RPC errors (``A2AError``) are reserved for genuine
-transport faults — malformed requests, missing auth, method-not-found.
+Pinned AdCP 3.1.1, ``docs/building/operating/transport-errors.mdx`` "Layer
+Separation": typed application failures belong in a failed Task carrying the
+two-layer AdCP envelope, while an untyped internal crash belongs in the
+transport channel as a sanitized JSON-RPC error.
 
 Grading: ungraded — A2A transport mechanic, unit-graded here. No conformance
 storyboard under ``dist/compliance/3.1.1/`` exercises A2A failed-Task routing.
 
-Pre-fix bug: ``on_message_send``'s outer exception handler built the correct
-failed Task with the ``processing_error`` envelope artifact, then threw it
-away by raising ``InternalError`` (a JSON-RPC error) instead of returning the
-Task. These tests pin the returned-failed-Task contract on the wire artifact.
+These tests pin both sides: typed ``AdCPError`` retains its Task envelope;
+unexpected ``Exception`` cannot become retryable ``SERVICE_UNAVAILABLE`` or
+expose its message on the transport error.
 """
 
 from unittest.mock import MagicMock, patch
 
 import pytest
-from a2a.types import InvalidRequestError, SendMessageRequest, Task, TaskState
+from a2a.types import InternalError, InvalidRequestError, SendMessageRequest, Task, TaskState
 
 from src.a2a_server.adcp_a2a_server import AdCPRequestHandler
 from src.core.exceptions import AdCPValidationError
@@ -45,41 +42,23 @@ def _make_handler() -> tuple[AdCPRequestHandler, object]:
 
 
 @pytest.mark.asyncio
-async def test_untyped_processing_failure_returns_failed_task_with_internal_error_envelope():
-    """An unexpected exception during message processing returns a failed Task.
-
-    The outer ``on_message_send`` handler must normalize the untyped exception
-    to base ``AdCPError`` (internal INTERNAL_ERROR → wire ``SERVICE_UNAVAILABLE``
-    via ``ERROR_CODE_MAPPING``), attach the two-layer envelope as the
-    ``processing_error`` artifact DataPart, and RETURN the failed Task — never
-    raise a JSON-RPC ``InternalError`` for an application failure.
-    """
+async def test_untyped_processing_failure_raises_sanitized_internal_error():
+    """An unexpected processing crash is sanitized onto the JSON-RPC path."""
     handler, ctx = _make_handler()
     params = _make_nl_request("Show me available products in the catalog")
 
     with patch("src.core.resolved_identity.resolve_identity", return_value=_MOCK_IDENTITY):
         with patch(
             "src.a2a_server.adcp_a2a_server.core_get_products_tool",
-            side_effect=RuntimeError("adapter exploded"),
+            side_effect=RuntimeError("adapter exploded: secret-canary"),
         ):
-            result = await handler.on_message_send(params, context=ctx)
+            with pytest.raises(InternalError) as exc_info:
+                await handler.on_message_send(params, context=ctx)
 
-    assert isinstance(result, Task), f"expected a returned Task, got {type(result).__name__}"
-    assert result.status.state == TaskState.TASK_STATE_FAILED, (
-        f"expected TASK_STATE_FAILED, got {result.status.state!r}"
-    )
-    envelope = extract_processing_error_envelope(result)
-    # Untyped exceptions normalize to base AdCPError (internal INTERNAL_ERROR),
-    # which maps on the wire to SERVICE_UNAVAILABLE via ERROR_CODE_MAPPING — a
-    # transient (retryable) error, so recovery is "transient".
-    assert_envelope_shape(
-        envelope,
-        "SERVICE_UNAVAILABLE",
-        recovery="transient",
-        message_substr="adapter exploded",
-    )
-    # The failed Task is also the stored lifecycle record.
-    assert handler.tasks[result.id].status.state == TaskState.TASK_STATE_FAILED
+    assert exc_info.value.message == "Internal server error"
+    assert exc_info.value.data is None
+    assert "adapter exploded" not in str(exc_info.value)
+    assert not handler.tasks, "a transport-rejected request must not leave a lifecycle Task"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_a2a_error_routing.py
+++ b/tests/unit/test_a2a_error_routing.py
@@ -34,6 +34,7 @@ from src.core.exceptions import AdCPValidationError
 from tests.a2a_helpers import (
     extract_processing_error_envelope,
     make_a2a_context,
+    make_a2a_handler,
     make_mock_a2a_identity,
     make_nl_send_message_request,
 )
@@ -41,27 +42,15 @@ from tests.helpers import assert_envelope_shape
 from tests.utils.a2a_helpers import create_a2a_message_with_skill
 
 _MOCK_IDENTITY = make_mock_a2a_identity()
-_make_nl_request = make_nl_send_message_request
 
 
 def _make_nl_request_with_push(text: str, url: str) -> SendMessageRequest:
     """NL request carrying a protocol-level push-notification config."""
-    request = _make_nl_request(text)
+    request = make_nl_send_message_request(text)
     request.configuration.CopyFrom(
         SendMessageConfiguration(task_push_notification_config=TaskPushNotificationConfig(url=url))
     )
     return request
-
-
-def _make_handler() -> tuple[AdCPRequestHandler, object]:
-    """Handler + authenticated call context for driving on_message_send.
-
-    The token lives in the context state where the real ``_get_auth_token`` reads
-    it, so token extraction runs for real — the unit does not stub it.
-    """
-    handler = AdCPRequestHandler()
-    ctx = make_a2a_context(auth_token="test-token", headers={"host": "test.example.com"})
-    return handler, ctx
 
 
 @pytest.mark.asyncio
@@ -76,7 +65,7 @@ async def test_untyped_processing_failure_returns_service_unavailable_failed_tas
     webhook. (Scrubbing the untyped error message off the wire is a shared-seam
     concern tracked separately, not asserted here.)
     """
-    handler, ctx = _make_handler()
+    handler, ctx = make_a2a_handler()
     params = _make_nl_request_with_push(
         "Show me available products in the catalog", "https://buyer.example.com/webhook"
     )
@@ -114,8 +103,8 @@ async def test_typed_adcp_error_keeps_its_own_wire_code_on_failed_task():
     not a blanket ``INTERNAL_ERROR`` — ``_build_error_envelope`` passes typed
     errors through ``normalize_to_adcp_error`` unchanged.
     """
-    handler, ctx = _make_handler()
-    params = _make_nl_request("Show me available products in the catalog")
+    handler, ctx = make_a2a_handler()
+    params = make_nl_send_message_request("Show me available products in the catalog")
 
     with patch("src.core.resolved_identity.resolve_identity", return_value=_MOCK_IDENTITY):
         with patch(
@@ -153,7 +142,7 @@ async def test_no_webhook_on_inline_typed_failure():
     synchronously, so a webhook would be a duplicate delivery of the same
     terminal state.
     """
-    handler, ctx = _make_handler()
+    handler, ctx = make_a2a_handler()
     params = _make_nl_request_with_push(
         "Show me available products in the catalog", "https://buyer.example.com/webhook"
     )
@@ -249,7 +238,7 @@ async def test_no_webhook_on_inline_explicit_skill_failure():
     Converges with the NL-outer failure path: neither notifies on the inline terminal
     response (KM :1050 — outcome must not depend on NL vs explicit-skill request shape).
     """
-    handler, ctx = _make_handler()
+    handler, ctx = make_a2a_handler()
     message = create_a2a_message_with_skill("get_products", {"brief": "test"})
     params = _make_nl_request_with_push("unused", "https://buyer.example.com/webhook")
     params.message.CopyFrom(message)

--- a/tests/unit/test_a2a_error_routing.py
+++ b/tests/unit/test_a2a_error_routing.py
@@ -13,10 +13,18 @@ unexpected ``Exception`` cannot become retryable ``SERVICE_UNAVAILABLE`` or
 expose its message on the transport error.
 """
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from a2a.types import InternalError, InvalidRequestError, SendMessageRequest, Task, TaskState
+from a2a.types import (
+    InternalError,
+    InvalidRequestError,
+    SendMessageConfiguration,
+    SendMessageRequest,
+    Task,
+    TaskPushNotificationConfig,
+    TaskState,
+)
 
 from src.a2a_server.adcp_a2a_server import AdCPRequestHandler
 from src.core.exceptions import AdCPValidationError
@@ -31,6 +39,15 @@ from tests.utils.a2a_helpers import create_a2a_message_with_skill
 
 _MOCK_IDENTITY = make_mock_a2a_identity()
 _make_nl_request = make_nl_send_message_request
+
+
+def _make_nl_request_with_push(text: str, url: str) -> SendMessageRequest:
+    """NL request carrying a protocol-level push-notification config."""
+    request = _make_nl_request(text)
+    request.configuration.CopyFrom(
+        SendMessageConfiguration(task_push_notification_config=TaskPushNotificationConfig(url=url))
+    )
+    return request
 
 
 def _make_handler() -> tuple[AdCPRequestHandler, object]:
@@ -89,6 +106,42 @@ async def test_typed_adcp_error_keeps_its_own_wire_code_on_failed_task():
         recovery="correctable",
         message_substr="brief must not be empty",
     )
+
+
+@pytest.mark.asyncio
+async def test_no_webhook_on_inline_typed_failure():
+    """A typed failure returns a terminal failed Task inline — no push webhook.
+
+    Pinned AdCP 3.1.1 ``webhooks.mdx:160`` (MUST NOT) + ``a2a-guide:484``: an
+    inline terminal response emits no push notification, even when the caller
+    registered an accepted push config. The failed Task carries the envelope
+    synchronously, so a webhook would be a duplicate delivery of the same
+    terminal state.
+    """
+    handler, ctx = _make_handler()
+    params = _make_nl_request_with_push(
+        "Show me available products in the catalog", "https://buyer.example.com/webhook"
+    )
+    handler._send_protocol_webhook = AsyncMock()
+
+    with (
+        patch("src.core.resolved_identity.resolve_identity", return_value=_MOCK_IDENTITY),
+        patch("src.a2a_server.adcp_a2a_server._accept_a2a_push_config", return_value=MagicMock()),
+        patch(
+            "src.a2a_server.adcp_a2a_server.core_get_products_tool",
+            side_effect=AdCPValidationError("brief must not be empty"),
+        ),
+    ):
+        result = await handler.on_message_send(params, context=ctx)
+
+    assert isinstance(result, Task), f"expected a returned Task, got {type(result).__name__}"
+    assert result.status.state == TaskState.TASK_STATE_FAILED, (
+        f"expected TASK_STATE_FAILED, got {result.status.state!r}"
+    )
+    # An accepted push config WAS registered for this task ...
+    assert handler._task_push_configs, "push config should have been registered for the task"
+    # ... yet no webhook is emitted for the inline terminal failed Task.
+    handler._send_protocol_webhook.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_a2a_error_routing.py
+++ b/tests/unit/test_a2a_error_routing.py
@@ -130,6 +130,13 @@ async def test_typed_adcp_error_keeps_its_own_wire_code_on_failed_task():
         recovery="correctable",
         message_substr="brief must not be empty",
     )
+    # Failed-task artifact pairs a human-readable TextPart with the adcp_error DataPart
+    # (a2a-response-format.mdx "Required Structure": DataPart required, TextPart recommended).
+    parts = result.artifacts[0].parts
+    assert any(p.HasField("text") and "brief must not be empty" in p.text for p in parts), (
+        "failed-task artifact must carry a TextPart with the error message"
+    )
+    assert any(p.HasField("data") for p in parts), "failed-task artifact must carry the DataPart"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_a2a_error_routing.py
+++ b/tests/unit/test_a2a_error_routing.py
@@ -53,9 +53,12 @@ def _make_nl_request_with_push(text: str, url: str) -> SendMessageRequest:
 
 
 def _make_handler() -> tuple[AdCPRequestHandler, object]:
-    """Handler + authenticated call context for driving on_message_send."""
+    """Handler + authenticated call context for driving on_message_send.
+
+    The token lives in the context state where the real ``_get_auth_token`` reads
+    it, so token extraction runs for real — the unit does not stub it.
+    """
     handler = AdCPRequestHandler()
-    handler._get_auth_token = MagicMock(return_value="test-token")
     ctx = make_a2a_context(auth_token="test-token", headers={"host": "test.example.com"})
     return handler, ctx
 

--- a/tests/unit/test_a2a_error_routing.py
+++ b/tests/unit/test_a2a_error_routing.py
@@ -202,6 +202,10 @@ async def test_genuine_transport_fault_still_raises_json_rpc_error():
     assert "authentication" in str(exc_info.value).lower(), (
         f"transport fault should name the missing authentication; got: {exc_info.value}"
     )
+    # The provisional Task is registered before the auth gate raises; the A2AError branch
+    # must pop it so a transport-rejected request leaves no orphaned lifecycle Task
+    # (buyer-observable via tasks/get). Removing that pop reddens this assertion.
+    assert not handler.tasks, "A2AError transport fault must not leave an orphaned Task"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_a2a_error_routing.py
+++ b/tests/unit/test_a2a_error_routing.py
@@ -236,3 +236,34 @@ async def test_send_protocol_webhook_delivers_for_non_terminal_state():
         await handler._send_protocol_webhook(task, status="submitted")
 
     notify.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_no_webhook_on_inline_explicit_skill_failure():
+    """The explicit-skill all-failed path returns a terminal Task inline — no webhook.
+
+    Converges with the NL-outer failure path: neither notifies on the inline terminal
+    response (KM :1050 — outcome must not depend on NL vs explicit-skill request shape).
+    """
+    handler, ctx = _make_handler()
+    message = create_a2a_message_with_skill("get_products", {"brief": "test"})
+    params = _make_nl_request_with_push("unused", "https://buyer.example.com/webhook")
+    params.message.CopyFrom(message)
+    notify = AsyncMock(return_value=True)
+
+    with (
+        patch("src.core.resolved_identity.resolve_identity", return_value=_MOCK_IDENTITY),
+        patch("src.a2a_server.adcp_a2a_server._accept_a2a_push_config", return_value=MagicMock()),
+        patch(
+            "src.a2a_server.adcp_a2a_server.core_get_products_tool",
+            side_effect=RuntimeError("adapter exploded"),
+        ),
+        patch(
+            "src.a2a_server.adcp_a2a_server.get_protocol_webhook_service",
+            return_value=MagicMock(notify=notify),
+        ),
+    ):
+        result = await handler.on_message_send(params, context=ctx)
+
+    assert result.status.state == TaskState.TASK_STATE_FAILED
+    notify.assert_not_awaited()

--- a/tests/unit/test_a2a_error_routing.py
+++ b/tests/unit/test_a2a_error_routing.py
@@ -26,6 +26,7 @@ from a2a.types import (
     Task,
     TaskPushNotificationConfig,
     TaskState,
+    TaskStatus,
 )
 
 from src.a2a_server.adcp_a2a_server import AdCPRequestHandler
@@ -201,3 +202,37 @@ async def test_genuine_transport_fault_still_raises_json_rpc_error():
     assert "authentication" in str(exc_info.value).lower(), (
         f"transport fault should name the missing authentication; got: {exc_info.value}"
     )
+
+
+@pytest.mark.asyncio
+async def test_send_protocol_webhook_skips_inline_terminal_state():
+    """A terminal task is the inline response — the sender must not deliver a webhook.
+
+    Pinned AdCP 3.1.1 webhooks.mdx:160 (MUST NOT). The guard returns before the service
+    is even resolved, so an inline completed/failed/rejected/canceled task never notifies.
+    """
+    handler = AdCPRequestHandler()
+    task = Task(id="task_term", status=TaskStatus(state=TaskState.TASK_STATE_FAILED))
+    handler._task_push_configs[task.id] = MagicMock(url="https://buyer.example.com/webhook")
+
+    with patch("src.a2a_server.adcp_a2a_server.get_protocol_webhook_service") as mock_get_service:
+        await handler._send_protocol_webhook(task, status="failed")
+
+    mock_get_service.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_send_protocol_webhook_delivers_for_non_terminal_state():
+    """A non-terminal (submitted) status is a legitimate notification and is delivered."""
+    handler = AdCPRequestHandler()
+    task = Task(id="task_sub", status=TaskStatus(state=TaskState.TASK_STATE_SUBMITTED))
+    handler._task_push_configs[task.id] = MagicMock(url="https://buyer.example.com/webhook")
+    notify = AsyncMock(return_value=True)
+
+    with patch(
+        "src.a2a_server.adcp_a2a_server.get_protocol_webhook_service",
+        return_value=MagicMock(notify=notify),
+    ):
+        await handler._send_protocol_webhook(task, status="submitted")
+
+    notify.assert_awaited_once()

--- a/tests/unit/test_a2a_error_routing.py
+++ b/tests/unit/test_a2a_error_routing.py
@@ -60,22 +60,35 @@ def _make_handler() -> tuple[AdCPRequestHandler, object]:
 
 @pytest.mark.asyncio
 async def test_untyped_processing_failure_raises_sanitized_internal_error():
-    """An unexpected processing crash is sanitized onto the JSON-RPC path."""
-    handler, ctx = _make_handler()
-    params = _make_nl_request("Show me available products in the catalog")
+    """An unexpected processing crash is sanitized onto the JSON-RPC path.
 
-    with patch("src.core.resolved_identity.resolve_identity", return_value=_MOCK_IDENTITY):
-        with patch(
+    The crash path must also tear down BOTH per-task registries — the lifecycle
+    Task AND the accepted push config — so a transport-rejected request leaves
+    no orphaned state, and attempts no webhook.
+    """
+    handler, ctx = _make_handler()
+    params = _make_nl_request_with_push(
+        "Show me available products in the catalog", "https://buyer.example.com/webhook"
+    )
+    handler._send_protocol_webhook = AsyncMock()
+
+    with (
+        patch("src.core.resolved_identity.resolve_identity", return_value=_MOCK_IDENTITY),
+        patch("src.a2a_server.adcp_a2a_server._accept_a2a_push_config", return_value=MagicMock()),
+        patch(
             "src.a2a_server.adcp_a2a_server.core_get_products_tool",
             side_effect=RuntimeError("adapter exploded: secret-canary"),
-        ):
-            with pytest.raises(InternalError) as exc_info:
-                await handler.on_message_send(params, context=ctx)
+        ),
+        pytest.raises(InternalError) as exc_info,
+    ):
+        await handler.on_message_send(params, context=ctx)
 
     assert exc_info.value.message == "Internal server error"
     assert exc_info.value.data is None
     assert "adapter exploded" not in str(exc_info.value)
     assert not handler.tasks, "a transport-rejected request must not leave a lifecycle Task"
+    assert not handler._task_push_configs, "a transport-rejected request must not leave an orphaned push config"
+    handler._send_protocol_webhook.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_a2a_error_routing.py
+++ b/tests/unit/test_a2a_error_routing.py
@@ -198,20 +198,43 @@ async def test_genuine_transport_fault_still_raises_json_rpc_error():
 
 
 @pytest.mark.asyncio
-async def test_send_protocol_webhook_skips_inline_terminal_state():
-    """A terminal task is the inline response — the sender must not deliver a webhook.
+async def test_send_protocol_webhook_skips_inline_terminal_failure():
+    """An inline terminal FAILURE returns before the service is even resolved.
 
-    Pinned AdCP 3.1.1 webhooks.mdx:160 (MUST NOT). The guard returns before the service
-    is even resolved, so an inline completed/failed/rejected/canceled task never notifies.
+    Pinned AdCP 3.1.1 webhooks.mdx:160: the failed Task is returned on the synchronous
+    response, so a webhook would duplicate it. Failed/canceled/rejected are skipped;
+    completed is NOT (see test_send_protocol_webhook_delivers_for_completed_state).
     """
     handler = AdCPRequestHandler()
-    task = Task(id="task_term", status=TaskStatus(state=TaskState.TASK_STATE_FAILED))
+    task = Task(id="task_fail", status=TaskStatus(state=TaskState.TASK_STATE_FAILED))
     handler._task_push_configs[task.id] = MagicMock(url="https://buyer.example.com/webhook")
 
     with patch("src.a2a_server.adcp_a2a_server.get_protocol_webhook_service") as mock_get_service:
         await handler._send_protocol_webhook(task, status="failed")
 
     mock_get_service.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_send_protocol_webhook_delivers_for_completed_state():
+    """A completed task delivers its webhook — the server's only delivery to the endpoint.
+
+    COMPLETED is deliberately excluded from the failure-skip guard: there is no async
+    completion worker, so this inline completion webhook is how a registered endpoint
+    receives the result (graded end-to-end by test_webhook_registration_reaches_delivery_signed).
+    """
+    handler = AdCPRequestHandler()
+    task = Task(id="task_done", status=TaskStatus(state=TaskState.TASK_STATE_COMPLETED))
+    handler._task_push_configs[task.id] = MagicMock(url="https://buyer.example.com/webhook")
+    notify = AsyncMock(return_value=True)
+
+    with patch(
+        "src.a2a_server.adcp_a2a_server.get_protocol_webhook_service",
+        return_value=MagicMock(notify=notify),
+    ):
+        await handler._send_protocol_webhook(task, status="completed")
+
+    notify.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_a2a_nl_auth_redundancy.py
+++ b/tests/unit/test_a2a_nl_auth_redundancy.py
@@ -8,33 +8,20 @@ queries via resolve_identity(). Fix: reuse the identity from the handler call.
 This test verifies resolve_identity() is called at most once per NL request.
 """
 
-import uuid
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from src.a2a_server.adcp_a2a_server import AdCPRequestHandler
-from tests.a2a_helpers import make_a2a_context
-from tests.factories.principal import PrincipalFactory
-
-_MOCK_IDENTITY = PrincipalFactory.make_identity(
-    principal_id="test-principal",
-    tenant_id="test-tenant",
-    tenant={"tenant_id": "test-tenant"},
-    protocol="a2a",
+from tests.a2a_helpers import (
+    extract_processing_error_envelope,
+    make_a2a_context,
+    make_mock_a2a_identity,
+    make_nl_send_message_request,
 )
 
-
-def _make_nl_message(text: str):
-    """Build a minimal A2A SendMessageRequest with NL text (no skills)."""
-    from a2a.types import Message, Part, Role, SendMessageRequest
-
-    message = Message(
-        message_id=str(uuid.uuid4()),
-        role=Role.ROLE_USER,
-    )
-    message.parts.append(Part(text=text))
-    return SendMessageRequest(message=message)
+_MOCK_IDENTITY = make_mock_a2a_identity()
+_make_nl_message = make_nl_send_message_request
 
 
 @pytest.mark.asyncio
@@ -119,7 +106,7 @@ async def test_nl_targeting_query_calls_resolve_identity_once():
 
 
 @pytest.mark.asyncio
-async def test_nl_media_buy_raises_capability_not_supported():
+async def test_nl_media_buy_returns_failed_task_with_envelope():
     """NL media buy is not supported — invocation must surface a typed AdCPError.
 
     Pre-fix the NL stub returned ``{"success": False, "message": "use explicit"}``
@@ -127,12 +114,18 @@ async def test_nl_media_buy_raises_capability_not_supported():
     parsed the artifact as ``MCP_ERROR``. The handler now raises
     ``AdCPCapabilityNotSupportedError`` which propagates to the outer
     ``on_message_send`` error handler that attaches a spec-compliant
-    envelope to the failed Task artifact.
+    envelope to the failed Task artifact and RETURNS the failed Task
+    (per AdCP 3.1.x transport-errors.mdx "Layer Separation" — JSON-RPC
+    errors are reserved for transport faults, never application failures).
 
     Pin: identity resolution still runs once (the route dispatch happens
     before ``_create_media_buy`` raises), and the failed Task must surface
-    a wire envelope (not a fake-success dict).
+    a wire envelope (not a fake-success dict, not a raised InternalError).
     """
+    from a2a.types import TaskState
+
+    from tests.helpers import assert_envelope_shape
+
     handler = AdCPRequestHandler()
     handler._get_auth_token = MagicMock(return_value="test-token")
     ctx = make_a2a_context(auth_token="test-token", headers={"host": "test.example.com"})
@@ -140,19 +133,19 @@ async def test_nl_media_buy_raises_capability_not_supported():
     params = _make_nl_message("Create a campaign for Nike")
 
     with patch("src.core.resolved_identity.resolve_identity", return_value=_MOCK_IDENTITY) as mock_resolve:
-        # NL media buy raises AdCPCapabilityNotSupportedError; outer
-        # on_message_send catches and surfaces it as InternalError after
-        # attaching the envelope to the failed Task artifact.
-        from a2a.utils.errors import InternalError
-
-        with pytest.raises(InternalError) as exc_info:
-            await handler.on_message_send(params, context=ctx)
+        task = await handler.on_message_send(params, context=ctx)
 
     # Identity is resolved once during route dispatch before the raise.
     assert mock_resolve.call_count == 1, (
         f"resolve_identity called {mock_resolve.call_count} times for media buy NL request. Expected 1."
     )
-    # InternalError message names the original capability failure (sanity check).
-    assert "create_media_buy" in str(exc_info.value).lower() or "explicit" in str(exc_info.value).lower(), (
-        f"InternalError should reference the unsupported capability; got: {exc_info.value}"
+    assert task.status.state == TaskState.TASK_STATE_FAILED, f"Expected failed Task, got state {task.status.state!r}"
+    envelope = extract_processing_error_envelope(task)
+    # AdCPCapabilityNotSupportedError → UNSUPPORTED_FEATURE (correctable —
+    # documented intentional divergence, see AdCPCapabilityNotSupportedError).
+    assert_envelope_shape(
+        envelope,
+        "UNSUPPORTED_FEATURE",
+        recovery="correctable",
+        message_substr="create_media_buy",
     )

--- a/tests/unit/test_a2a_nl_auth_redundancy.py
+++ b/tests/unit/test_a2a_nl_auth_redundancy.py
@@ -8,20 +8,18 @@ queries via resolve_identity(). Fix: reuse the identity from the handler call.
 This test verifies resolve_identity() is called at most once per NL request.
 """
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
-from src.a2a_server.adcp_a2a_server import AdCPRequestHandler
 from tests.a2a_helpers import (
     extract_processing_error_envelope,
-    make_a2a_context,
+    make_a2a_handler,
     make_mock_a2a_identity,
     make_nl_send_message_request,
 )
 
 _MOCK_IDENTITY = make_mock_a2a_identity()
-_make_nl_message = make_nl_send_message_request
 
 
 @pytest.mark.asyncio
@@ -34,11 +32,9 @@ async def test_nl_product_query_calls_resolve_identity_once():
     """
     from src.core.schemas import GetProductsResponse
 
-    handler = AdCPRequestHandler()
-    handler._get_auth_token = MagicMock(return_value="test-token")
-    ctx = make_a2a_context(auth_token="test-token", headers={"host": "test.example.com"})
+    handler, ctx = make_a2a_handler()
 
-    params = _make_nl_message("Show me available products in the catalog")
+    params = make_nl_send_message_request("Show me available products in the catalog")
 
     with patch("src.core.resolved_identity.resolve_identity", return_value=_MOCK_IDENTITY) as mock_resolve:
         with patch("src.a2a_server.adcp_a2a_server.core_get_products_tool") as mock_products:
@@ -62,11 +58,9 @@ async def test_nl_pricing_query_calls_resolve_identity_once():
     Pricing NL path (line 674) → _handle_get_products_skill (line 1398 calls
     _create_tool_context_from_a2a) → then line 682 calls it AGAIN for logging.
     """
-    handler = AdCPRequestHandler()
-    handler._get_auth_token = MagicMock(return_value="test-token")
-    ctx = make_a2a_context(auth_token="test-token", headers={"host": "test.example.com"})
+    handler, ctx = make_a2a_handler()
 
-    params = _make_nl_message("What is the pricing for CPM ads?")
+    params = make_nl_send_message_request("What is the pricing for CPM ads?")
 
     with patch("src.core.resolved_identity.resolve_identity", return_value=_MOCK_IDENTITY) as mock_resolve:
         with patch("src.a2a_server.adcp_a2a_server.core_get_products_tool") as mock_products:
@@ -87,11 +81,9 @@ async def test_nl_targeting_query_calls_resolve_identity_once():
     Targeting NL path (line 708) → _handle_get_adcp_capabilities_skill (line 1769
     calls _create_tool_context_from_a2a) → then line 713 calls it AGAIN for logging.
     """
-    handler = AdCPRequestHandler()
-    handler._get_auth_token = MagicMock(return_value="test-token")
-    ctx = make_a2a_context(auth_token="test-token", headers={"host": "test.example.com"})
+    handler, ctx = make_a2a_handler()
 
-    params = _make_nl_message("Show me audience targeting options")
+    params = make_nl_send_message_request("Show me audience targeting options")
 
     with patch("src.core.resolved_identity.resolve_identity", return_value=_MOCK_IDENTITY) as mock_resolve:
         # Mock the core capabilities function (not the handler — to expose both calls)
@@ -127,11 +119,9 @@ async def test_nl_media_buy_returns_failed_task_with_envelope():
 
     from tests.helpers import assert_envelope_shape
 
-    handler = AdCPRequestHandler()
-    handler._get_auth_token = MagicMock(return_value="test-token")
-    ctx = make_a2a_context(auth_token="test-token", headers={"host": "test.example.com"})
+    handler, ctx = make_a2a_handler()
 
-    params = _make_nl_message("Create a campaign for Nike")
+    params = make_nl_send_message_request("Create a campaign for Nike")
 
     with patch("src.core.resolved_identity.resolve_identity", return_value=_MOCK_IDENTITY) as mock_resolve:
         task = await handler.on_message_send(params, context=ctx)

--- a/tests/unit/test_a2a_nl_auth_redundancy.py
+++ b/tests/unit/test_a2a_nl_auth_redundancy.py
@@ -115,8 +115,9 @@ async def test_nl_media_buy_returns_failed_task_with_envelope():
     ``AdCPCapabilityNotSupportedError`` which propagates to the outer
     ``on_message_send`` error handler that attaches a spec-compliant
     envelope to the failed Task artifact and RETURNS the failed Task
-    (per AdCP 3.1.x transport-errors.mdx "Layer Separation" — JSON-RPC
-    errors are reserved for transport faults, never application failures).
+    (per AdCP 3.1.1 a2a-response-format.mdx "Where the Error Lives" — a
+    Task-execution failure rides in the task body; JSON-RPC is reserved for
+    transport faults where no Task was produced).
 
     Pin: identity resolution still runs once (the route dispatch happens
     before ``_create_media_buy`` raises), and the failed Task must surface

--- a/tests/unit/test_a2a_transport_contract.py
+++ b/tests/unit/test_a2a_transport_contract.py
@@ -242,8 +242,14 @@ class TestA2AJsonRpcProtocol:
         response = client.post("/a2a", json=payload, headers=auth_headers)
         body = response.json()
         assert "error" in body, "Unknown skill should return JSON-RPC error"
+        # Pin the buyer-visible code, not just the message: an unrouted skill surfaces as
+        # method-not-found (-32601). Reclassifying the raise to InternalError would keep
+        # the message but move the code to -32603, which a buyer branches on.
+        assert body["error"]["code"] == -32601, (
+            f"unrouted skill should surface as method-not-found (-32601): {body['error']}"
+        )
         assert "nonexistent_skill" in body["error"].get("message", ""), (
-            f"MethodNotFound error should name the unknown skill: {body['error']}"
+            f"error should name the unknown skill: {body['error']}"
         )
 
     @patch(

--- a/tests/unit/test_a2a_transport_contract.py
+++ b/tests/unit/test_a2a_transport_contract.py
@@ -19,14 +19,9 @@ import pytest
 from starlette.testclient import TestClient
 
 from src.app import app
-from tests.factories.principal import PrincipalFactory
+from tests.a2a_helpers import make_mock_a2a_identity
 
-_MOCK_IDENTITY = PrincipalFactory.make_identity(
-    principal_id="test-principal",
-    tenant_id="test-tenant",
-    tenant={"tenant_id": "test-tenant"},
-    protocol="a2a",
-)
+_MOCK_IDENTITY = make_mock_a2a_identity()
 
 # ---------------------------------------------------------------------------
 # All 13 A2A skills from the dispatch map (adcp_a2a_server.py:1416-1438)

--- a/tests/unit/test_a2a_transport_contract.py
+++ b/tests/unit/test_a2a_transport_contract.py
@@ -220,12 +220,25 @@ class TestA2AJsonRpcProtocol:
         body = response.json()
         assert "error" in body, "Unknown method should return JSON-RPC error"
 
-    def test_unknown_skill_returns_error(self, client, auth_headers):
-        """Unknown skill name should return error (not crash)."""
+    @patch("src.core.resolved_identity.resolve_identity", return_value=_MOCK_IDENTITY)
+    def test_unknown_skill_returns_error(self, mock_resolve, client, auth_headers):
+        """Unknown skill name should return a JSON-RPC error (not crash).
+
+        An unroutable skill is a transport-protocol fault (MethodNotFoundError,
+        an A2AError) — per AdCP 3.1.x transport-errors.mdx "Layer Separation"
+        it belongs on the JSON-RPC error layer, unlike application failures
+        which return failed Tasks. Identity is mocked so the request reaches
+        skill dispatch; pre-fix this test passed for the wrong reason (the
+        unmocked DB crashed identity resolution first, and the old outer
+        handler converted that crash to a JSON-RPC InternalError).
+        """
         payload = _build_jsonrpc("nonexistent_skill", {})
         response = client.post("/a2a", json=payload, headers=auth_headers)
         body = response.json()
         assert "error" in body, "Unknown skill should return JSON-RPC error"
+        assert "nonexistent_skill" in body["error"].get("message", ""), (
+            f"MethodNotFound error should name the unknown skill: {body['error']}"
+        )
 
     def test_response_echoes_request_id(self, client, auth_headers):
         """JSON-RPC response must echo the request id."""

--- a/tests/unit/test_a2a_transport_contract.py
+++ b/tests/unit/test_a2a_transport_contract.py
@@ -250,20 +250,31 @@ class TestA2AJsonRpcProtocol:
         "src.a2a_server.adcp_a2a_server.AdCPRequestHandler._resolve_a2a_identity",
         side_effect=RuntimeError("database host secret-canary exploded"),
     )
-    def test_untyped_boundary_crash_is_sanitized_jsonrpc_internal_error(self, mock_resolve, client, auth_headers):
-        """An internal crash reaches the real A2A wire only as JSON-RPC -32603."""
+    def test_untyped_boundary_crash_returns_failed_task_envelope_on_wire(self, mock_resolve, client, auth_headers):
+        """An untyped crash reaches the real A2A wire as a failed-Task envelope.
+
+        Pinned AdCP 3.1.1 a2a-response-format.mdx "Where the Error Lives: Decision
+        Rule": a system error where a Task exists is returned as ``status: failed``
+        with the adcp_error DataPart (wire SERVICE_UNAVAILABLE), NOT a JSON-RPC
+        -32603 — matching the MCP/REST/explicit-skill paths. (Scrubbing the untyped
+        message off the wire is a shared-seam concern tracked separately.)
+        """
         payload = _build_jsonrpc("get_products", {"brief": "test"}, request_id="crash-test-42")
 
         response = client.post("/a2a", json=payload, headers=auth_headers)
 
-        error = _extract_jsonrpc_error(response)
         assert response.status_code == 200
         assert response.json().get("id") == "crash-test-42"
-        assert error["code"] == -32603
-        assert error["message"] == "Internal server error"
-        assert error.get("data") is None
-        assert "secret-canary" not in response.text
-        assert "SERVICE_UNAVAILABLE" not in response.text
+        result = _extract_jsonrpc_result(response)
+        task = result.get("task", result)
+        assert task["status"]["state"] in ("TASK_STATE_FAILED", "failed"), (
+            f"untyped crash must surface as a failed Task, got status: {task.get('status')}"
+        )
+        envelope = _extract_artifact_data(result)
+        code = envelope.get("adcp_error", {}).get("code") or (envelope.get("errors", [{}])[0].get("code"))
+        assert code == "SERVICE_UNAVAILABLE", (
+            f"untyped crash must carry a SERVICE_UNAVAILABLE envelope, got: {envelope}"
+        )
 
     def test_response_echoes_request_id(self, client, auth_headers):
         """JSON-RPC response must echo the request id."""

--- a/tests/unit/test_a2a_transport_contract.py
+++ b/tests/unit/test_a2a_transport_contract.py
@@ -219,18 +219,24 @@ class TestA2AJsonRpcProtocol:
         response = client.post("/a2a", json=payload, headers=auth_headers)
         body = response.json()
         assert "error" in body, "Unknown method should return JSON-RPC error"
+        assert body["error"]["code"] == -32601, (
+            f"unknown JSON-RPC method must map to the standard method-not-found code -32601: {body['error']}"
+        )
 
     @patch("src.core.resolved_identity.resolve_identity", return_value=_MOCK_IDENTITY)
     def test_unknown_skill_returns_error(self, mock_resolve, client, auth_headers):
-        """Unknown skill name should return a JSON-RPC error (not crash).
+        """Unknown skill name returns a JSON-RPC error naming the skill (not crash).
 
-        An unroutable skill is a transport-protocol fault (MethodNotFoundError,
-        an A2AError) — per AdCP 3.1.x transport-errors.mdx "Layer Separation"
-        it belongs on the JSON-RPC error layer, unlike application failures
-        which return failed Tasks. Identity is mocked so the request reaches
-        skill dispatch; pre-fix this test passed for the wrong reason (the
-        unmocked DB crashed identity resolution first, and the old outer
-        handler converted that crash to a JSON-RPC InternalError).
+        Grounding note: an unknown skill supplied as ``message/send`` *data* is
+        NOT one of the transport faults the AdCP Layer-Separation table
+        enumerates (connection-refused, malformed request, internal crash), so
+        this test does not claim spec Layer-Separation grounding for it. It pins
+        only the observable contract — an unrouted skill surfaces as a JSON-RPC
+        error whose message names the skill, rather than crashing. Identity is
+        mocked so the request reaches skill dispatch; pre-fix this test passed
+        for the wrong reason (the unmocked DB crashed identity resolution first,
+        and the old outer handler converted that crash to a JSON-RPC
+        InternalError).
         """
         payload = _build_jsonrpc("nonexistent_skill", {})
         response = client.post("/a2a", json=payload, headers=auth_headers)

--- a/tests/unit/test_a2a_transport_contract.py
+++ b/tests/unit/test_a2a_transport_contract.py
@@ -240,6 +240,25 @@ class TestA2AJsonRpcProtocol:
             f"MethodNotFound error should name the unknown skill: {body['error']}"
         )
 
+    @patch(
+        "src.a2a_server.adcp_a2a_server.AdCPRequestHandler._resolve_a2a_identity",
+        side_effect=RuntimeError("database host secret-canary exploded"),
+    )
+    def test_untyped_boundary_crash_is_sanitized_jsonrpc_internal_error(self, mock_resolve, client, auth_headers):
+        """An internal crash reaches the real A2A wire only as JSON-RPC -32603."""
+        payload = _build_jsonrpc("get_products", {"brief": "test"}, request_id="crash-test-42")
+
+        response = client.post("/a2a", json=payload, headers=auth_headers)
+
+        error = _extract_jsonrpc_error(response)
+        assert response.status_code == 200
+        assert response.json().get("id") == "crash-test-42"
+        assert error["code"] == -32603
+        assert error["message"] == "Internal server error"
+        assert error.get("data") is None
+        assert "secret-canary" not in response.text
+        assert "SERVICE_UNAVAILABLE" not in response.text
+
     def test_response_echoes_request_id(self, client, auth_headers):
         """JSON-RPC response must echo the request id."""
         payload = _build_jsonrpc("get_products", {"brief": "test"}, request_id="echo-test-42")


### PR DESCRIPTION
## Summary

Fixes #2070.

The A2A `on_message_send` boundary now applies a strict typed/untyped split:

- Expected, typed `AdCPError` application failures return a failed A2A Task carrying the standard two-layer AdCP error envelope.
- Unexpected, untyped exceptions are logged internally and surface as a sanitized JSON-RPC `-32603 Internal error`. Their exception text and internals are not sent to the buyer, and the tentative lifecycle Task/push configuration is discarded.
- Existing `A2AError` transport failures continue to pass through unchanged.
- The four task-push-notification configuration methods are unchanged because they have no Task body in which to carry an application error.

This corrects the earlier implementation, which normalized arbitrary crashes to retryable `SERVICE_UNAVAILABLE` Task failures.

## Spec grounding

Pinned AdCP 3.1.1, `docs/building/operating/transport-errors.mdx`, "Layer Separation":

- application/task failures belong in the task response body;
- internal crashes belong on the transport/protocol error path;
- raw implementation details must not be exposed to clients.

No AdCP 3.1.1 conformance storyboard directly grades this A2A routing distinction, so the behavior is pinned with focused unit and real HTTP wire tests.

## Scope

This remains a focused amendment to the #2070 A2A boundary fix extracted from closed PR #1547.

The explicit-skill dispatcher still normalizes arbitrary exceptions into task envelopes. That broader repository-wide policy change is intentionally not bundled here and remains tracked by the canonical issue #1588 (#2185 was closed as a duplicate). MCP transport behavior also remains separate because the currently pinned Python MCP v1 stack swallows `McpError` at a lower boundary; fixing that safely requires an SDK/migration decision.

## Tests

- Typed `AdCPError` → failed Task with its original wire code and recovery metadata.
- Untyped exception → sanitized JSON-RPC `-32603`, with no exception text, AdCP envelope, or retained lifecycle Task.
- Existing A2A transport errors still pass through.
- Real HTTP transport contract test verifies the serialized JSON-RPC response.

`make quality` is green: **6577 passed, 39 skipped, 32 xfailed**. Focused A2A tests: **65 passed**.